### PR TITLE
fix(tool-routing): discover routes from installed plugin structure

### DIFF
--- a/plugins/tool-routing/src/tool_routing/cli.py
+++ b/plugins/tool-routing/src/tool_routing/cli.py
@@ -42,7 +42,13 @@ def get_all_routes() -> tuple[dict[str, "Route"], list[str]]:
     )
 
     plugin_root = get_plugin_root()
-    plugins_dir = Path(os.environ.get("CLAUDE_PLUGINS_DIR", ""))
+    # CLAUDE_PLUGINS_DIR can be set explicitly, or derived from CLAUDE_PLUGIN_ROOT
+    plugins_dir_env = os.environ.get("CLAUDE_PLUGINS_DIR", "")
+    if plugins_dir_env:
+        plugins_dir = Path(plugins_dir_env)
+    else:
+        # Derive from plugin root: plugin_root/../ is the plugins directory
+        plugins_dir = plugin_root.parent
     project_root = Path(os.environ.get("CLAUDE_PROJECT_ROOT", Path.cwd()))
 
     all_routes = []


### PR DESCRIPTION
## Summary

Fixes route discovery for installed plugins. Claude Code installs plugins with a version subdirectory (`plugin-name/VERSION/`), but route discovery only looked for the development layout (`plugin-name/hooks/`). This caused routes from other plugins to not be found at runtime.

## Changes

- Update `discover_plugin_routes()` to check both development and installed layouts
- Derive `CLAUDE_PLUGINS_DIR` from `CLAUDE_PLUGIN_ROOT` when not explicitly set
- Add tests for installed plugin structure discovery

## Test plan

- [x] `uv run tool-routing test` passes (30/30 tests)
- [x] `uv run pytest tests/test_config.py` passes (11/11 tests including 3 new ones)
- [x] `uv run tool-routing list` with installed plugin paths finds routes from all plugins
