### PR TITLE
feat(dev-tools): add working-with-colima skill

### DIFF
--- a/docs/plans/2025-12-18-working-with-colima-skill.md
+++ b/docs/plans/2025-12-18-working-with-colima-skill.md
@@ -1,0 +1,495 @@
+# Working with Colima Skill Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a skill that helps Claude assist users with Colima (Docker runtime for macOS) - lifecycle management, profile handling, Docker context integration, and troubleshooting.
+
+**Architecture:** Single SKILL.md file in `plugins/dev-tools/skills/working-with-colima/` following the existing skill patterns in this plugin. Include reference docs fetched via gitingest if needed.
+
+**Tech Stack:** Markdown skill file, Colima CLI, Docker CLI
+
+---
+
+## Task 1: Create Skill Directory Structure
+
+**Files:**
+- Create: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+
+**Step 1: Create the skill directory**
+
+```bash
+mkdir -p plugins/dev-tools/skills/working-with-colima
+```
+
+**Step 2: Verify directory exists**
+
+Run: `ls -la plugins/dev-tools/skills/working-with-colima`
+Expected: Empty directory listed
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima
+git commit -m "chore(dev-tools): create working-with-colima skill directory"
+```
+
+---
+
+## Task 2: Write SKILL.md with Frontmatter and Overview
+
+**Files:**
+- Create: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+
+**Step 1: Write initial SKILL.md with frontmatter and overview**
+
+```markdown
+---
+name: working-with-colima
+description: Use when Docker commands fail with "Cannot connect to Docker daemon", when starting/stopping container environments, or when managing multiple Docker contexts on macOS - provides Colima lifecycle management, profile handling, and troubleshooting
+---
+
+# Working with Colima
+
+## Overview
+
+Colima provides container runtimes (Docker, Containerd) on macOS with minimal setup. It runs a Linux VM and exposes Docker via contexts. Use this skill when:
+
+- Docker commands fail ("Cannot connect to Docker daemon")
+- Starting/stopping container runtime on macOS
+- Managing multiple Docker profiles/contexts
+- Troubleshooting container environment issues
+- Need SSH agent forwarding for Docker builds
+
+## When NOT to Use
+
+- Docker Compose or container orchestration (that's Docker knowledge)
+- Kubernetes cluster management (separate concern)
+- Linux environments (Colima is macOS-specific)
+```
+
+**Step 2: Verify file was created**
+
+Run: `head -20 plugins/dev-tools/skills/working-with-colima/SKILL.md`
+Expected: Shows frontmatter and overview section
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/SKILL.md
+git commit -m "feat(dev-tools): add working-with-colima skill frontmatter and overview"
+```
+
+---
+
+## Task 3: Add Quick Reference Section
+
+**Files:**
+- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+
+**Step 1: Append quick reference table**
+
+Add after the "When NOT to Use" section:
+
+```markdown
+
+## Quick Reference
+
+| Operation | Command | Notes |
+|-----------|---------|-------|
+| Start default | `colima start` | Creates `default` profile |
+| Start named profile | `colima start <profile>` | e.g., `colima start work` |
+| Start with SSH agent | `colima start <profile> -s` | Required for Docker builds needing git |
+| Start with edit | `colima start --edit` | Opens config in editor |
+| Stop | `colima stop` | Graceful stop |
+| Force stop | `colima stop --force` | Use for "Broken" status |
+| Status | `colima status` | Shows running state, socket path |
+| Status (profile) | `colima status -p <profile>` | Status for specific profile |
+| List profiles | `colima list` | Shows all profiles and status |
+| Delete profile | `colima delete <profile>` | Removes profile |
+| SSH into VM | `colima ssh` | Access underlying VM |
+| Run command in VM | `colima ssh -- <cmd>` | e.g., `colima ssh -- df -h` |
+| Edit default template | `colima template` | Affects new profiles |
+```
+
+**Step 2: Verify section was added**
+
+Run: `grep -A 20 "## Quick Reference" plugins/dev-tools/skills/working-with-colima/SKILL.md`
+Expected: Shows quick reference table
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/SKILL.md
+git commit -m "feat(dev-tools): add quick reference table to colima skill"
+```
+
+---
+
+## Task 4: Add Docker Context Integration Section
+
+**Files:**
+- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+
+**Step 1: Append Docker context section**
+
+Add after Quick Reference:
+
+```markdown
+
+## Docker Context Integration
+
+Colima creates Docker contexts for each profile:
+- Profile `default` → context `colima`
+- Profile `work` → context `colima-work`
+
+**Context switching is global** (stored in `~/.docker/config.json`):
+
+```bash
+# Switch globally (affects all terminals)
+docker context use colima-work
+
+# List available contexts
+docker context list
+```
+
+**Override per-session or per-command:**
+
+```bash
+# Per-session
+export DOCKER_CONTEXT=colima-work
+
+# Per-command
+docker --context colima-work ps
+```
+
+**Get socket path for apps that ignore contexts:**
+
+```bash
+# View socket path
+colima status -p <profile>
+
+# Get socket path programmatically
+colima status -p <profile> --json | jq -r .docker_socket
+
+# Set DOCKER_HOST for non-context-aware apps
+export DOCKER_HOST="unix://$(colima status -p work --json | jq -r .docker_socket)"
+```
+```
+
+**Step 2: Verify section was added**
+
+Run: `grep -A 5 "## Docker Context" plugins/dev-tools/skills/working-with-colima/SKILL.md`
+Expected: Shows Docker context section header and content
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/SKILL.md
+git commit -m "feat(dev-tools): add Docker context integration to colima skill"
+```
+
+---
+
+## Task 5: Add Profile Management Section
+
+**Files:**
+- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+
+**Step 1: Append profile management section**
+
+Add after Docker Context Integration:
+
+```markdown
+
+## Profile Management
+
+**Create profiles:**
+
+```bash
+# Default profile
+colima start
+
+# Named profile with resources
+colima start work --cpu 4 --memory 8 --disk 60
+```
+
+**Profile configuration locations:**
+- Config: `~/.colima/<profile>/colima.yaml`
+- Default template: `~/.colima/_templates/default.yaml`
+- Edit template: `colima template`
+
+**Delete profiles:**
+
+```bash
+colima delete <profile>
+
+# Delete including container data (v0.9.0+)
+colima delete <profile> --data
+```
+```
+
+**Step 2: Verify section was added**
+
+Run: `grep -A 5 "## Profile Management" plugins/dev-tools/skills/working-with-colima/SKILL.md`
+Expected: Shows profile management section
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/SKILL.md
+git commit -m "feat(dev-tools): add profile management to colima skill"
+```
+
+---
+
+## Task 6: Add Troubleshooting Section
+
+**Files:**
+- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+
+**Step 1: Append troubleshooting section**
+
+Add after Profile Management:
+
+```markdown
+
+## Troubleshooting
+
+### "Cannot connect to Docker daemon"
+
+1. Check if Colima is running: `colima status` (or `colima status -p <profile>`)
+2. If not running: `colima start` (or `colima start <profile>`)
+3. If running but wrong context: `docker context use colima-<profile>`
+4. For apps ignoring contexts:
+   ```bash
+   export DOCKER_HOST="unix://$(colima status -p <profile> --json | jq -r .docker_socket)"
+   ```
+
+### "Broken" status after macOS restart
+
+```bash
+colima list          # Shows "Broken" status
+colima stop --force  # Changes to "Stopped"
+colima start         # Should work now
+```
+
+### VM running slow / needs more resources
+
+```bash
+# Check current allocation
+colima list
+
+# Check usage in VM
+colima ssh -- htop
+
+# Increase resources (requires stop)
+colima stop
+colima start --cpu 4 --memory 8
+```
+
+### Container getting OOM killed
+
+The VM itself may be out of memory. Increase VM memory:
+
+```bash
+colima stop && colima start --memory 8
+```
+
+### VM disk space running low
+
+```bash
+# Check disk usage in VM
+colima ssh -- df -h
+
+# Clean up Docker resources
+docker system prune -a --volumes
+
+# Reclaim space (fstrim releases unused blocks)
+colima ssh -- sudo fstrim -a
+
+# Increase disk size if needed (requires stop)
+colima stop
+colima start --edit  # Increase disk: value
+```
+
+Note: Disk size can only be increased, not decreased.
+
+### Colima can't access internet (DNS issues)
+
+```bash
+colima start --dns 8.8.8.8 --dns 1.1.1.1
+
+# Verify connectivity
+colima ssh -- ping -c4 google.com
+```
+
+### Issues after Colima upgrade
+
+```bash
+# Test with fresh profile first
+colima start debug
+
+# If that works, reset your profile
+colima delete <profile>
+colima start <profile>
+```
+```
+
+**Step 2: Verify section was added**
+
+Run: `grep -c "###" plugins/dev-tools/skills/working-with-colima/SKILL.md`
+Expected: Shows count of subsections (should be 7)
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/SKILL.md
+git commit -m "feat(dev-tools): add troubleshooting section to colima skill"
+```
+
+---
+
+## Task 7: Add Common Options Section
+
+**Files:**
+- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+
+**Step 1: Append common options section**
+
+Add after Troubleshooting:
+
+```markdown
+
+## Common Options
+
+**Resource flags (for `colima start`):**
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--cpu` | Number of CPUs | `--cpu 4` |
+| `--memory` | Memory in GB | `--memory 8` |
+| `--disk` | Disk size in GB | `--disk 60` |
+
+**VM type flags (Apple Silicon):**
+
+| Flag | Description |
+|------|-------------|
+| `--vm-type=vz` | Use Apple Virtualization.framework (faster) |
+| `--vz-rosetta` | Enable Rosetta for x86 emulation (macOS 13+) |
+
+**Other useful flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--ssh-agent` / `-s` | Forward SSH agent (for git in Docker builds) |
+| `--edit` | Open config in editor before starting |
+| `--dns` | Custom DNS server(s), can repeat |
+| `--kubernetes` | Enable Kubernetes |
+
+**Profile flag:** Most commands accept `-p <profile>`:
+
+```bash
+colima status -p work
+colima stop -p work
+colima ssh -p work
+```
+
+## References
+
+For updated Colima documentation, fetch from upstream:
+
+```bash
+uvx gitingest https://github.com/abiosoft/colima -i "*.md" -o colima-docs.txt
+```
+
+See also: [Colima FAQ](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md)
+```
+
+**Step 2: Verify complete skill file**
+
+Run: `wc -l plugins/dev-tools/skills/working-with-colima/SKILL.md`
+Expected: Approximately 180-220 lines
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/SKILL.md
+git commit -m "feat(dev-tools): add common options and references to colima skill"
+```
+
+---
+
+## Task 8: Test Skill with Subagent (RED phase)
+
+**Purpose:** Verify the skill helps agents handle Colima scenarios correctly.
+
+**Step 1: Run baseline test WITHOUT skill**
+
+Dispatch subagent with prompt:
+> "Docker commands are failing with 'Cannot connect to the Docker daemon'. The user is on macOS. How do you troubleshoot this?"
+
+Document what the agent does/doesn't know about Colima.
+
+**Step 2: Run test WITH skill loaded**
+
+Dispatch subagent with the skill content prepended, same prompt.
+
+**Step 3: Compare results**
+
+- Does agent now mention Colima?
+- Does agent know about `colima status`, `docker context`?
+- Does agent know about `--ssh-agent` for builds?
+
+**Step 4: Document findings**
+
+Note any gaps in the skill that need addressing.
+
+---
+
+## Task 9: Refine Skill Based on Testing
+
+**Files:**
+- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+
+**Step 1: Address any gaps found in testing**
+
+Update skill content based on what agents got wrong or missed.
+
+**Step 2: Re-test if significant changes**
+
+Run another subagent test to verify improvements.
+
+**Step 3: Final commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/SKILL.md
+git commit -m "refactor(dev-tools): refine colima skill based on testing"
+```
+
+---
+
+## Task 10: Final Review and Push
+
+**Step 1: Review complete skill**
+
+```bash
+cat plugins/dev-tools/skills/working-with-colima/SKILL.md
+```
+
+Verify:
+- Frontmatter is valid (name, description under 1024 chars)
+- Description starts with "Use when..."
+- All sections present and formatted correctly
+- Code examples are correct
+
+**Step 2: Validate plugin structure**
+
+```bash
+claude plugin validate plugins/dev-tools
+```
+
+**Step 3: Push to remote**
+
+```bash
+git push origin main
+```

--- a/docs/plans/2025-12-18-working-with-colima-skill.md
+++ b/docs/plans/2025-12-18-working-with-colima-skill.md
@@ -4,43 +4,57 @@
 
 **Goal:** Create a skill that helps Claude assist users with Colima (Docker runtime for macOS) - lifecycle management, profile handling, Docker context integration, and troubleshooting.
 
-**Architecture:** Single SKILL.md file in `plugins/dev-tools/skills/working-with-colima/` following the existing skill patterns in this plugin. Include reference docs fetched via gitingest if needed.
+**Architecture:** Progressive disclosure structure - small SKILL.md (~100-150 lines) as navigation map, detailed content in `references/` directory. Follows the "200-line rule" from skill best practices.
 
 **Tech Stack:** Markdown skill file, Colima CLI, Docker CLI
+
+**Skill Structure:**
+```
+plugins/dev-tools/skills/working-with-colima/
+├── SKILL.md                    # Entry point: overview, quick ref, navigation
+└── references/
+    ├── docker-contexts.md      # Docker context integration details
+    ├── profile-management.md   # Creating, switching, deleting profiles
+    ├── troubleshooting.md      # All troubleshooting scenarios
+    └── common-options.md       # Flags and configuration
+```
 
 ---
 
 ## Task 1: Create Skill Directory Structure
 
 **Files:**
-- Create: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+- Create: `plugins/dev-tools/skills/working-with-colima/`
+- Create: `plugins/dev-tools/skills/working-with-colima/references/`
 
-**Step 1: Create the skill directory**
+**Step 1: Create the skill directories**
 
 ```bash
-mkdir -p plugins/dev-tools/skills/working-with-colima
+mkdir -p plugins/dev-tools/skills/working-with-colima/references
 ```
 
-**Step 2: Verify directory exists**
+**Step 2: Verify directories exist**
 
-Run: `ls -la plugins/dev-tools/skills/working-with-colima`
-Expected: Empty directory listed
+Run: `ls -la plugins/dev-tools/skills/working-with-colima/`
+Expected: Shows `references/` subdirectory
 
 **Step 3: Commit**
 
 ```bash
 git add plugins/dev-tools/skills/working-with-colima
-git commit -m "chore(dev-tools): create working-with-colima skill directory"
+git commit -m "chore(dev-tools): create working-with-colima skill directory structure"
 ```
 
 ---
 
-## Task 2: Write SKILL.md with Frontmatter and Overview
+## Task 2: Write SKILL.md Entry Point
 
 **Files:**
 - Create: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
 
-**Step 1: Write initial SKILL.md with frontmatter and overview**
+**Step 1: Write SKILL.md with frontmatter, overview, and quick reference**
+
+The entry point should be ~100-150 lines. It's a navigation map, not a manual.
 
 ```markdown
 ---
@@ -52,352 +66,75 @@ description: Use when Docker commands fail with "Cannot connect to Docker daemon
 
 ## Overview
 
-Colima provides container runtimes (Docker, Containerd) on macOS with minimal setup. It runs a Linux VM and exposes Docker via contexts. Use this skill when:
+Colima provides container runtimes (Docker, Containerd) on macOS with minimal setup. It runs a Linux VM and exposes Docker via contexts.
 
+**Use this skill when:**
 - Docker commands fail ("Cannot connect to Docker daemon")
 - Starting/stopping container runtime on macOS
 - Managing multiple Docker profiles/contexts
 - Troubleshooting container environment issues
 - Need SSH agent forwarding for Docker builds
 
-## When NOT to Use
-
-- Docker Compose or container orchestration (that's Docker knowledge)
-- Kubernetes cluster management (separate concern)
-- Linux environments (Colima is macOS-specific)
-```
-
-**Step 2: Verify file was created**
-
-Run: `head -20 plugins/dev-tools/skills/working-with-colima/SKILL.md`
-Expected: Shows frontmatter and overview section
-
-**Step 3: Commit**
-
-```bash
-git add plugins/dev-tools/skills/working-with-colima/SKILL.md
-git commit -m "feat(dev-tools): add working-with-colima skill frontmatter and overview"
-```
-
----
-
-## Task 3: Add Quick Reference Section
-
-**Files:**
-- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
-
-**Step 1: Append quick reference table**
-
-Add after the "When NOT to Use" section:
-
-```markdown
+**Not for:** Docker Compose, Kubernetes clusters, or Linux environments.
 
 ## Quick Reference
 
-| Operation | Command | Notes |
-|-----------|---------|-------|
-| Start default | `colima start` | Creates `default` profile |
-| Start named profile | `colima start <profile>` | e.g., `colima start work` |
-| Start with SSH agent | `colima start <profile> -s` | Required for Docker builds needing git |
-| Start with edit | `colima start --edit` | Opens config in editor |
-| Stop | `colima stop` | Graceful stop |
-| Force stop | `colima stop --force` | Use for "Broken" status |
-| Status | `colima status` | Shows running state, socket path |
-| Status (profile) | `colima status -p <profile>` | Status for specific profile |
-| List profiles | `colima list` | Shows all profiles and status |
-| Delete profile | `colima delete <profile>` | Removes profile |
-| SSH into VM | `colima ssh` | Access underlying VM |
-| Run command in VM | `colima ssh -- <cmd>` | e.g., `colima ssh -- df -h` |
-| Edit default template | `colima template` | Affects new profiles |
-```
+| Operation | Command |
+|-----------|---------|
+| Start | `colima start` or `colima start <profile>` |
+| Start with SSH agent | `colima start <profile> -s` |
+| Stop | `colima stop` or `colima stop --force` |
+| Status | `colima status -p <profile>` |
+| List profiles | `colima list` |
+| SSH into VM | `colima ssh` or `colima ssh -- <cmd>` |
+| Get socket path | `colima status -p <profile> --json \| jq -r .docker_socket` |
 
-**Step 2: Verify section was added**
+## Docker Context Basics
 
-Run: `grep -A 20 "## Quick Reference" plugins/dev-tools/skills/working-with-colima/SKILL.md`
-Expected: Shows quick reference table
-
-**Step 3: Commit**
-
-```bash
-git add plugins/dev-tools/skills/working-with-colima/SKILL.md
-git commit -m "feat(dev-tools): add quick reference table to colima skill"
-```
-
----
-
-## Task 4: Add Docker Context Integration Section
-
-**Files:**
-- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
-
-**Step 1: Append Docker context section**
-
-Add after Quick Reference:
-
-```markdown
-
-## Docker Context Integration
-
-Colima creates Docker contexts for each profile:
+Colima creates Docker contexts per profile:
 - Profile `default` → context `colima`
 - Profile `work` → context `colima-work`
 
-**Context switching is global** (stored in `~/.docker/config.json`):
-
 ```bash
-# Switch globally (affects all terminals)
+# Switch context (global - affects all terminals)
 docker context use colima-work
 
-# List available contexts
-docker context list
-```
-
-**Override per-session or per-command:**
-
-```bash
-# Per-session
+# Override per-session
 export DOCKER_CONTEXT=colima-work
 
-# Per-command
+# Override per-command
 docker --context colima-work ps
 ```
 
-**Get socket path for apps that ignore contexts:**
+For details, see `references/docker-contexts.md`.
 
+## Common Issues
+
+**Docker daemon not connecting?**
+1. `colima status` - is it running?
+2. `docker context list` - right context selected?
+3. See `references/troubleshooting.md` for more
+
+**Need more VM resources?**
 ```bash
-# View socket path
-colima status -p <profile>
-
-# Get socket path programmatically
-colima status -p <profile> --json | jq -r .docker_socket
-
-# Set DOCKER_HOST for non-context-aware apps
-export DOCKER_HOST="unix://$(colima status -p work --json | jq -r .docker_socket)"
-```
+colima stop && colima start --cpu 4 --memory 8
 ```
 
-**Step 2: Verify section was added**
-
-Run: `grep -A 5 "## Docker Context" plugins/dev-tools/skills/working-with-colima/SKILL.md`
-Expected: Shows Docker context section header and content
-
-**Step 3: Commit**
-
+**"Broken" status after restart?**
 ```bash
-git add plugins/dev-tools/skills/working-with-colima/SKILL.md
-git commit -m "feat(dev-tools): add Docker context integration to colima skill"
-```
-
----
-
-## Task 5: Add Profile Management Section
-
-**Files:**
-- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
-
-**Step 1: Append profile management section**
-
-Add after Docker Context Integration:
-
-```markdown
-
-## Profile Management
-
-**Create profiles:**
-
-```bash
-# Default profile
-colima start
-
-# Named profile with resources
-colima start work --cpu 4 --memory 8 --disk 60
-```
-
-**Profile configuration locations:**
-- Config: `~/.colima/<profile>/colima.yaml`
-- Default template: `~/.colima/_templates/default.yaml`
-- Edit template: `colima template`
-
-**Delete profiles:**
-
-```bash
-colima delete <profile>
-
-# Delete including container data (v0.9.0+)
-colima delete <profile> --data
-```
-```
-
-**Step 2: Verify section was added**
-
-Run: `grep -A 5 "## Profile Management" plugins/dev-tools/skills/working-with-colima/SKILL.md`
-Expected: Shows profile management section
-
-**Step 3: Commit**
-
-```bash
-git add plugins/dev-tools/skills/working-with-colima/SKILL.md
-git commit -m "feat(dev-tools): add profile management to colima skill"
-```
-
----
-
-## Task 6: Add Troubleshooting Section
-
-**Files:**
-- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
-
-**Step 1: Append troubleshooting section**
-
-Add after Profile Management:
-
-```markdown
-
-## Troubleshooting
-
-### "Cannot connect to Docker daemon"
-
-1. Check if Colima is running: `colima status` (or `colima status -p <profile>`)
-2. If not running: `colima start` (or `colima start <profile>`)
-3. If running but wrong context: `docker context use colima-<profile>`
-4. For apps ignoring contexts:
-   ```bash
-   export DOCKER_HOST="unix://$(colima status -p <profile> --json | jq -r .docker_socket)"
-   ```
-
-### "Broken" status after macOS restart
-
-```bash
-colima list          # Shows "Broken" status
-colima stop --force  # Changes to "Stopped"
-colima start         # Should work now
-```
-
-### VM running slow / needs more resources
-
-```bash
-# Check current allocation
-colima list
-
-# Check usage in VM
-colima ssh -- htop
-
-# Increase resources (requires stop)
-colima stop
-colima start --cpu 4 --memory 8
-```
-
-### Container getting OOM killed
-
-The VM itself may be out of memory. Increase VM memory:
-
-```bash
-colima stop && colima start --memory 8
-```
-
-### VM disk space running low
-
-```bash
-# Check disk usage in VM
-colima ssh -- df -h
-
-# Clean up Docker resources
-docker system prune -a --volumes
-
-# Reclaim space (fstrim releases unused blocks)
-colima ssh -- sudo fstrim -a
-
-# Increase disk size if needed (requires stop)
-colima stop
-colima start --edit  # Increase disk: value
-```
-
-Note: Disk size can only be increased, not decreased.
-
-### Colima can't access internet (DNS issues)
-
-```bash
-colima start --dns 8.8.8.8 --dns 1.1.1.1
-
-# Verify connectivity
-colima ssh -- ping -c4 google.com
-```
-
-### Issues after Colima upgrade
-
-```bash
-# Test with fresh profile first
-colima start debug
-
-# If that works, reset your profile
-colima delete <profile>
-colima start <profile>
-```
-```
-
-**Step 2: Verify section was added**
-
-Run: `grep -c "###" plugins/dev-tools/skills/working-with-colima/SKILL.md`
-Expected: Shows count of subsections (should be 7)
-
-**Step 3: Commit**
-
-```bash
-git add plugins/dev-tools/skills/working-with-colima/SKILL.md
-git commit -m "feat(dev-tools): add troubleshooting section to colima skill"
-```
-
----
-
-## Task 7: Add Common Options Section
-
-**Files:**
-- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
-
-**Step 1: Append common options section**
-
-Add after Troubleshooting:
-
-```markdown
-
-## Common Options
-
-**Resource flags (for `colima start`):**
-
-| Flag | Description | Example |
-|------|-------------|---------|
-| `--cpu` | Number of CPUs | `--cpu 4` |
-| `--memory` | Memory in GB | `--memory 8` |
-| `--disk` | Disk size in GB | `--disk 60` |
-
-**VM type flags (Apple Silicon):**
-
-| Flag | Description |
-|------|-------------|
-| `--vm-type=vz` | Use Apple Virtualization.framework (faster) |
-| `--vz-rosetta` | Enable Rosetta for x86 emulation (macOS 13+) |
-
-**Other useful flags:**
-
-| Flag | Description |
-|------|-------------|
-| `--ssh-agent` / `-s` | Forward SSH agent (for git in Docker builds) |
-| `--edit` | Open config in editor before starting |
-| `--dns` | Custom DNS server(s), can repeat |
-| `--kubernetes` | Enable Kubernetes |
-
-**Profile flag:** Most commands accept `-p <profile>`:
-
-```bash
-colima status -p work
-colima stop -p work
-colima ssh -p work
+colima stop --force && colima start
 ```
 
 ## References
 
-For updated Colima documentation, fetch from upstream:
+- `references/docker-contexts.md` - Context switching, DOCKER_HOST, socket paths
+- `references/profile-management.md` - Creating, configuring, deleting profiles
+- `references/troubleshooting.md` - Common issues and solutions
+- `references/common-options.md` - Flags, VM types, resource configuration
 
+## External Resources
+
+For updated Colima documentation:
 ```bash
 uvx gitingest https://github.com/abiosoft/colima -i "*.md" -o colima-docs.txt
 ```
@@ -405,17 +142,606 @@ uvx gitingest https://github.com/abiosoft/colima -i "*.md" -o colima-docs.txt
 See also: [Colima FAQ](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md)
 ```
 
-**Step 2: Verify complete skill file**
+**Step 2: Verify file length and structure**
 
 Run: `wc -l plugins/dev-tools/skills/working-with-colima/SKILL.md`
-Expected: Approximately 180-220 lines
+Expected: ~80-100 lines (well under 200-line limit)
 
 **Step 3: Commit**
 
 ```bash
 git add plugins/dev-tools/skills/working-with-colima/SKILL.md
-git commit -m "feat(dev-tools): add common options and references to colima skill"
+git commit -m "feat(dev-tools): add working-with-colima skill entry point"
 ```
+
+---
+
+## Task 3: Write Docker Contexts Reference
+
+**Files:**
+- Create: `plugins/dev-tools/skills/working-with-colima/references/docker-contexts.md`
+
+**Step 1: Write docker-contexts.md**
+
+```markdown
+# Docker Context Integration
+
+## How Colima Creates Contexts
+
+Each Colima profile creates a corresponding Docker context:
+
+| Colima Profile | Docker Context |
+|----------------|----------------|
+| `default` | `colima` |
+| `work` | `colima-work` |
+| `<name>` | `colima-<name>` |
+
+Colima sets itself as the default context on startup.
+
+## Switching Contexts
+
+### Global Switch (Persistent)
+
+Stored in `~/.docker/config.json` under `currentContext`. Affects all terminals.
+
+```bash
+# List available contexts
+docker context list
+
+# Switch globally
+docker context use colima-work
+```
+
+### Per-Session Override
+
+```bash
+export DOCKER_CONTEXT=colima-work
+```
+
+### Per-Command Override
+
+```bash
+docker --context colima-work ps
+docker --context colima-work build -t myimage .
+```
+
+## Getting the Socket Path
+
+Some applications don't respect Docker contexts and need `DOCKER_HOST` set explicitly.
+
+```bash
+# View full status including socket
+colima status -p <profile>
+
+# Extract just the socket path
+colima status -p <profile> --json | jq -r .docker_socket
+
+# Set DOCKER_HOST for non-context-aware apps
+export DOCKER_HOST="unix://$(colima status -p work --json | jq -r .docker_socket)"
+```
+
+## Socket Locations
+
+- Default profile: `~/.colima/default/docker.sock`
+- Named profile: `~/.colima/<profile>/docker.sock`
+
+## Running Multiple Profiles Simultaneously
+
+You can run multiple Colima profiles at once, each with its own Docker context:
+
+```bash
+colima start default
+colima start work --cpu 4 --memory 8
+
+# Now both contexts exist
+docker context list
+# NAME          DESCRIPTION  DOCKER ENDPOINT
+# colima        colima       unix:///.../.colima/default/docker.sock
+# colima-work   colima       unix:///.../.colima/work/docker.sock
+```
+
+Switch between them as needed, or use per-command `--context` flags.
+```
+
+**Step 2: Verify file was created**
+
+Run: `head -20 plugins/dev-tools/skills/working-with-colima/references/docker-contexts.md`
+Expected: Shows title and first section
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/references/docker-contexts.md
+git commit -m "feat(dev-tools): add docker contexts reference for colima skill"
+```
+
+---
+
+## Task 4: Write Profile Management Reference
+
+**Files:**
+- Create: `plugins/dev-tools/skills/working-with-colima/references/profile-management.md`
+
+**Step 1: Write profile-management.md**
+
+```markdown
+# Profile Management
+
+## Creating Profiles
+
+### Default Profile
+
+```bash
+colima start
+```
+
+Creates a profile named `default` with default resources (2 CPU, 2GB RAM, 100GB disk).
+
+### Named Profiles
+
+```bash
+# Basic named profile
+colima start work
+
+# With custom resources
+colima start work --cpu 4 --memory 8 --disk 60
+
+# With SSH agent forwarding (for git in Docker builds)
+colima start work -s
+# or
+colima start work --ssh-agent
+```
+
+### Using Config Files
+
+```bash
+# Edit config before starting
+colima start work --edit
+
+# Edit default template (affects new profiles)
+colima template
+```
+
+## Profile Configuration Locations
+
+| File | Purpose |
+|------|---------|
+| `~/.colima/<profile>/colima.yaml` | Config for specific profile |
+| `~/.colima/_templates/default.yaml` | Default template for new profiles |
+
+## Listing Profiles
+
+```bash
+colima list
+```
+
+Output shows:
+```
+PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK     RUNTIME    ADDRESS
+default    Running    aarch64    2       2GiB      60GiB    docker
+work       Running    aarch64    4       8GiB      60GiB    docker
+```
+
+## Checking Profile Status
+
+```bash
+# Current/default profile
+colima status
+
+# Specific profile
+colima status -p work
+
+# JSON output (for scripting)
+colima status -p work --json
+```
+
+## Stopping Profiles
+
+```bash
+# Graceful stop
+colima stop
+colima stop -p work
+
+# Force stop (use for "Broken" status)
+colima stop --force
+colima stop -p work --force
+```
+
+## Deleting Profiles
+
+```bash
+# Delete profile (keeps container data)
+colima delete work
+
+# Delete profile AND container data (v0.9.0+)
+colima delete work --data
+```
+
+## Modifying Running Profiles
+
+Resource changes require stopping first:
+
+```bash
+colima stop -p work
+colima start work --cpu 4 --memory 8
+```
+
+Or edit the config file:
+
+```bash
+colima stop -p work
+colima start work --edit  # Modify values, save, exits editor to start
+```
+```
+
+**Step 2: Verify file was created**
+
+Run: `wc -l plugins/dev-tools/skills/working-with-colima/references/profile-management.md`
+Expected: ~90-110 lines
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/references/profile-management.md
+git commit -m "feat(dev-tools): add profile management reference for colima skill"
+```
+
+---
+
+## Task 5: Write Troubleshooting Reference
+
+**Files:**
+- Create: `plugins/dev-tools/skills/working-with-colima/references/troubleshooting.md`
+
+**Step 1: Write troubleshooting.md**
+
+```markdown
+# Troubleshooting
+
+## "Cannot connect to Docker daemon"
+
+**Symptoms:**
+- `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`
+- `Is the docker daemon running?`
+
+**Diagnosis:**
+
+```bash
+# 1. Is Colima running?
+colima status
+colima status -p <profile>
+
+# 2. Which Docker context is active?
+docker context list
+```
+
+**Solutions:**
+
+1. **Colima not running:** Start it
+   ```bash
+   colima start
+   # or for a specific profile
+   colima start <profile>
+   ```
+
+2. **Wrong context selected:**
+   ```bash
+   docker context use colima
+   # or for named profile
+   docker context use colima-<profile>
+   ```
+
+3. **App ignores Docker contexts:** Set DOCKER_HOST explicitly
+   ```bash
+   export DOCKER_HOST="unix://$(colima status -p <profile> --json | jq -r .docker_socket)"
+   ```
+
+## "Broken" Status After macOS Restart
+
+**Symptom:** `colima list` shows "Broken" status
+
+```bash
+colima list
+# PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK
+# default    Broken     aarch64    2       2GiB      60GiB
+```
+
+**Solution:**
+
+```bash
+colima stop --force
+colima start
+```
+
+## VM Running Slow / Needs More Resources
+
+**Diagnosis:**
+
+```bash
+# Check current allocation
+colima list
+
+# Check actual usage in VM
+colima ssh -- htop
+# or
+colima ssh -- top
+```
+
+**Solution:**
+
+```bash
+colima stop
+colima start --cpu 4 --memory 8
+```
+
+Or edit config for persistent change:
+```bash
+colima stop
+colima start --edit  # Change cpu/memory values
+```
+
+## Container Getting OOM Killed
+
+**Symptom:** Container exits unexpectedly, `docker logs` shows nothing useful
+
+**Cause:** VM itself may be out of memory
+
+**Solution:**
+
+```bash
+colima stop
+colima start --memory 8  # or higher
+```
+
+## VM Disk Space Running Low
+
+**Diagnosis:**
+
+```bash
+colima ssh -- df -h
+```
+
+**Solutions:**
+
+1. **Clean Docker resources:**
+   ```bash
+   docker system prune -a --volumes
+   ```
+
+2. **Reclaim space in VM:**
+   ```bash
+   colima ssh -- sudo fstrim -a
+   ```
+
+3. **Increase disk size (requires stop):**
+   ```bash
+   colima stop
+   colima start --edit  # Increase disk: value
+   ```
+
+Note: Disk size can only be increased, not decreased.
+
+## Colima Can't Access Internet (DNS Issues)
+
+**Symptom:** Builds fail to download packages, can't pull images
+
+**Diagnosis:**
+
+```bash
+colima ssh -- ping -c4 google.com
+```
+
+**Solution:**
+
+```bash
+colima stop
+colima start --dns 8.8.8.8 --dns 1.1.1.1
+```
+
+## Issues After Colima Upgrade
+
+**Recommended approach:** Test with a fresh profile first
+
+```bash
+# Create a test profile
+colima start debug
+
+# If that works, the issue is your existing profile
+colima delete <profile>
+colima start <profile>
+```
+
+## Docker Build Fails - Can't Access Private Git Repos
+
+**Symptom:** `git clone` in Dockerfile fails with authentication errors
+
+**Cause:** SSH agent not forwarded to Colima VM
+
+**Solution:**
+
+```bash
+colima stop
+colima start -s
+# or
+colima start --ssh-agent
+```
+
+Then use `--ssh` flag in Docker build:
+```bash
+docker build --ssh default .
+```
+```
+
+**Step 2: Verify file was created**
+
+Run: `wc -l plugins/dev-tools/skills/working-with-colima/references/troubleshooting.md`
+Expected: ~140-160 lines
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/references/troubleshooting.md
+git commit -m "feat(dev-tools): add troubleshooting reference for colima skill"
+```
+
+---
+
+## Task 6: Write Common Options Reference
+
+**Files:**
+- Create: `plugins/dev-tools/skills/working-with-colima/references/common-options.md`
+
+**Step 1: Write common-options.md**
+
+```markdown
+# Common Options
+
+## Resource Flags
+
+Used with `colima start`:
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--cpu` | Number of CPUs | `--cpu 4` |
+| `--memory` | Memory in GB | `--memory 8` |
+| `--disk` | Disk size in GB | `--disk 60` |
+
+**Example:**
+```bash
+colima start work --cpu 4 --memory 8 --disk 60
+```
+
+**Note:** Changes require stopping first. Disk can only be increased.
+
+## VM Type Flags (Apple Silicon)
+
+| Flag | Description |
+|------|-------------|
+| `--vm-type=vz` | Apple Virtualization.framework (faster, recommended) |
+| `--vz-rosetta` | Enable Rosetta for x86 emulation |
+
+**Example (Apple Silicon with Rosetta):**
+```bash
+colima start --vm-type=vz --vz-rosetta
+```
+
+Requires macOS 13+ (Ventura) on Apple Silicon.
+
+## SSH Agent Forwarding
+
+| Flag | Description |
+|------|-------------|
+| `--ssh-agent` or `-s` | Forward SSH agent to VM |
+
+**When needed:** Docker builds that clone private git repos.
+
+```bash
+colima start work -s
+```
+
+## Configuration Flags
+
+| Flag | Description |
+|------|-------------|
+| `--edit` | Open config in editor before starting |
+| `--dns` | Custom DNS server (can repeat) |
+| `--runtime` | Container runtime: `docker`, `containerd`, `incus` |
+| `--kubernetes` | Enable Kubernetes |
+
+**Examples:**
+```bash
+# Edit config
+colima start --edit
+
+# Custom DNS
+colima start --dns 8.8.8.8 --dns 1.1.1.1
+
+# With Kubernetes
+colima start --kubernetes
+```
+
+## Profile Flag
+
+Most commands accept `-p <profile>` to target a specific profile:
+
+```bash
+colima status -p work
+colima stop -p work
+colima ssh -p work
+colima delete -p work
+```
+
+## Default VM Specs
+
+If not specified, Colima creates VMs with:
+- 2 CPUs
+- 2 GB memory
+- 100 GB disk
+
+## Config File Format
+
+Located at `~/.colima/<profile>/colima.yaml`:
+
+```yaml
+cpu: 4
+memory: 8
+disk: 60
+arch: host
+runtime: docker
+vmType: vz
+rosetta: true
+mountType: virtiofs
+```
+
+Edit with `colima start --edit` or `colima template` for defaults.
+```
+
+**Step 2: Verify file was created**
+
+Run: `wc -l plugins/dev-tools/skills/working-with-colima/references/common-options.md`
+Expected: ~90-100 lines
+
+**Step 3: Commit**
+
+```bash
+git add plugins/dev-tools/skills/working-with-colima/references/common-options.md
+git commit -m "feat(dev-tools): add common options reference for colima skill"
+```
+
+---
+
+## Task 7: Verify Complete Skill Structure
+
+**Step 1: Check all files exist**
+
+```bash
+find plugins/dev-tools/skills/working-with-colima -type f -name "*.md"
+```
+
+Expected:
+```
+plugins/dev-tools/skills/working-with-colima/SKILL.md
+plugins/dev-tools/skills/working-with-colima/references/docker-contexts.md
+plugins/dev-tools/skills/working-with-colima/references/profile-management.md
+plugins/dev-tools/skills/working-with-colima/references/troubleshooting.md
+plugins/dev-tools/skills/working-with-colima/references/common-options.md
+```
+
+**Step 2: Verify SKILL.md is under 200 lines**
+
+```bash
+wc -l plugins/dev-tools/skills/working-with-colima/SKILL.md
+```
+
+Expected: Under 150 lines
+
+**Step 3: Verify total skill size is reasonable**
+
+```bash
+wc -l plugins/dev-tools/skills/working-with-colima/**/*.md
+```
+
+Expected: ~500-600 total lines across all files
 
 ---
 
@@ -432,13 +758,13 @@ Document what the agent does/doesn't know about Colima.
 
 **Step 2: Run test WITH skill loaded**
 
-Dispatch subagent with the skill content prepended, same prompt.
+Dispatch subagent with the SKILL.md content prepended, same prompt.
 
 **Step 3: Compare results**
 
 - Does agent now mention Colima?
 - Does agent know about `colima status`, `docker context`?
-- Does agent know about `--ssh-agent` for builds?
+- Does agent reference the troubleshooting guide?
 
 **Step 4: Document findings**
 
@@ -449,7 +775,7 @@ Note any gaps in the skill that need addressing.
 ## Task 9: Refine Skill Based on Testing
 
 **Files:**
-- Modify: `plugins/dev-tools/skills/working-with-colima/SKILL.md`
+- Modify: Any files that need updates based on testing
 
 **Step 1: Address any gaps found in testing**
 
@@ -459,10 +785,10 @@ Update skill content based on what agents got wrong or missed.
 
 Run another subagent test to verify improvements.
 
-**Step 3: Final commit**
+**Step 3: Commit refinements**
 
 ```bash
-git add plugins/dev-tools/skills/working-with-colima/SKILL.md
+git add plugins/dev-tools/skills/working-with-colima/
 git commit -m "refactor(dev-tools): refine colima skill based on testing"
 ```
 
@@ -479,8 +805,8 @@ cat plugins/dev-tools/skills/working-with-colima/SKILL.md
 Verify:
 - Frontmatter is valid (name, description under 1024 chars)
 - Description starts with "Use when..."
-- All sections present and formatted correctly
-- Code examples are correct
+- References are correctly linked
+- Code examples are accurate
 
 **Step 2: Validate plugin structure**
 
@@ -491,5 +817,24 @@ claude plugin validate plugins/dev-tools
 **Step 3: Push to remote**
 
 ```bash
-git push origin main
+git push origin feature/working-with-colima
+```
+
+**Step 4: Create PR (optional)**
+
+```bash
+gh pr create --title "feat(dev-tools): add working-with-colima skill" \
+  --body "Adds skill for working with Colima container runtime on macOS.
+
+## Summary
+- Progressive disclosure structure (SKILL.md + references/)
+- Quick reference for common commands
+- Docker context integration guidance
+- Troubleshooting for common issues
+- Profile management documentation
+
+## Test plan
+- [ ] Verify skill activates on Docker daemon connection errors
+- [ ] Verify references load correctly
+- [ ] Test with real Colima scenarios"
 ```

--- a/plugins/dev-tools/skills/working-with-colima/README.md
+++ b/plugins/dev-tools/skills/working-with-colima/README.md
@@ -1,0 +1,52 @@
+# Working with Colima Skill
+
+A Claude Code skill for working with [Colima](https://github.com/abiosoft/colima), a container runtime for macOS.
+
+## When This Skill Activates
+
+- Docker commands fail with "Cannot connect to Docker daemon"
+- Starting/stopping container environments on macOS
+- Managing multiple Docker profiles/contexts
+- Troubleshooting container environment issues
+- SSH agent forwarding for Docker builds
+
+## Structure
+
+```
+working-with-colima/
+├── SKILL.md                     # Entry point (~80 lines)
+├── README.md                    # This file
+├── docs/
+│   └── test-cases.md            # RED/GREEN test validation
+└── references/
+    ├── docker-contexts.md       # Context switching, DOCKER_HOST
+    ├── profile-management.md    # Creating, configuring profiles
+    ├── troubleshooting.md       # Common issues and solutions
+    ├── common-options.md        # CLI flags, VM configuration
+    └── colima-upstream/         # Official Colima docs
+        ├── README.md
+        ├── FAQ.md
+        └── INSTALL.md
+```
+
+## Design
+
+Uses **progressive disclosure**:
+- `SKILL.md` is a compact navigation map with quick reference
+- Detailed content lives in `references/` for when deeper knowledge is needed
+- Upstream docs included locally for comprehensive reference
+
+## Testing
+
+See `docs/test-cases.md` for RED/GREEN validation scenarios used during development.
+
+Key finding: Without this skill, agents default to Docker Desktop troubleshooting. With this skill, agents correctly use Colima-specific diagnostics (`colima status`, Docker contexts, correct socket paths).
+
+## Updating Upstream Docs
+
+To refresh the upstream Colima documentation:
+
+```bash
+uvx gitingest https://github.com/abiosoft/colima -i "*.md" -o /tmp/colima-docs.txt
+# Then manually update files in references/colima-upstream/
+```

--- a/plugins/dev-tools/skills/working-with-colima/SKILL.md
+++ b/plugins/dev-tools/skills/working-with-colima/SKILL.md
@@ -73,11 +73,10 @@ colima stop --force && colima start
 - `references/troubleshooting.md` - Common issues and solutions
 - `references/common-options.md` - Flags, VM types, resource configuration
 
-## External Resources
+## Upstream Documentation
 
-For updated Colima documentation:
-```bash
-uvx gitingest https://github.com/abiosoft/colima -i "*.md" -o colima-docs.txt
-```
+Local copies of official Colima docs (from [github.com/abiosoft/colima](https://github.com/abiosoft/colima)):
 
-See also: [Colima FAQ](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md)
+- `references/colima-upstream/README.md` - Official README with features and usage
+- `references/colima-upstream/FAQ.md` - Official FAQ and troubleshooting
+- `references/colima-upstream/INSTALL.md` - Installation options

--- a/plugins/dev-tools/skills/working-with-colima/SKILL.md
+++ b/plugins/dev-tools/skills/working-with-colima/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: working-with-colima
+description: Use when Docker commands fail with "Cannot connect to Docker daemon", when starting/stopping container environments, or when managing multiple Docker contexts on macOS - provides Colima lifecycle management, profile handling, and troubleshooting
+---
+
+# Working with Colima
+
+## Overview
+
+Colima provides container runtimes (Docker, Containerd) on macOS with minimal setup. It runs a Linux VM and exposes Docker via contexts.
+
+**Use this skill when:**
+- Docker commands fail ("Cannot connect to Docker daemon")
+- Starting/stopping container runtime on macOS
+- Managing multiple Docker profiles/contexts
+- Troubleshooting container environment issues
+- Need SSH agent forwarding for Docker builds
+
+**Not for:** Docker Compose, Kubernetes clusters, or Linux environments.
+
+## Quick Reference
+
+| Operation | Command |
+|-----------|---------|
+| Start | `colima start` or `colima start <profile>` |
+| Start with SSH agent | `colima start <profile> -s` |
+| Stop | `colima stop` or `colima stop --force` |
+| Status | `colima status -p <profile>` |
+| List profiles | `colima list` |
+| SSH into VM | `colima ssh` or `colima ssh -- <cmd>` |
+| Get socket path | `colima status -p <profile> --json \| jq -r .docker_socket` |
+
+## Docker Context Basics
+
+Colima creates Docker contexts per profile:
+- Profile `default` → context `colima`
+- Profile `work` → context `colima-work`
+
+```bash
+# Switch context (global - affects all terminals)
+docker context use colima-work
+
+# Override per-session
+export DOCKER_CONTEXT=colima-work
+
+# Override per-command
+docker --context colima-work ps
+```
+
+For details, see `references/docker-contexts.md`.
+
+## Common Issues
+
+**Docker daemon not connecting?**
+1. `colima status` - is it running?
+2. `docker context list` - right context selected?
+3. See `references/troubleshooting.md` for more
+
+**Need more VM resources?**
+```bash
+colima stop && colima start --cpu 4 --memory 8
+```
+
+**"Broken" status after restart?**
+```bash
+colima stop --force && colima start
+```
+
+## References
+
+- `references/docker-contexts.md` - Context switching, DOCKER_HOST, socket paths
+- `references/profile-management.md` - Creating, configuring, deleting profiles
+- `references/troubleshooting.md` - Common issues and solutions
+- `references/common-options.md` - Flags, VM types, resource configuration
+
+## External Resources
+
+For updated Colima documentation:
+```bash
+uvx gitingest https://github.com/abiosoft/colima -i "*.md" -o colima-docs.txt
+```
+
+See also: [Colima FAQ](https://github.com/abiosoft/colima/blob/main/docs/FAQ.md)

--- a/plugins/dev-tools/skills/working-with-colima/docs/finding-test-sessions.md
+++ b/plugins/dev-tools/skills/working-with-colima/docs/finding-test-sessions.md
@@ -1,0 +1,89 @@
+# Finding Claude Sessions for Test Cases
+
+How to find past Claude Code sessions that might contain good test scenarios for this skill.
+
+## Search Strategies
+
+### 1. Search Session History by Keywords
+
+```bash
+# Find sessions mentioning Colima
+grep -r "colima" ~/.claude/projects/*/sessions/*.json 2>/dev/null | head -20
+
+# Find sessions with Docker daemon errors
+grep -r "Cannot connect to the Docker daemon" ~/.claude/projects/*/sessions/*.json 2>/dev/null
+
+# Find sessions mentioning docker.sock
+grep -r "docker.sock" ~/.claude/projects/*/sessions/*.json 2>/dev/null
+
+# Find sessions with Docker context issues
+grep -r "docker context" ~/.claude/projects/*/sessions/*.json 2>/dev/null
+```
+
+### 2. Search by Error Messages
+
+Common error patterns that indicate Colima-related issues:
+
+```bash
+# Connection refused errors
+grep -r "connection refused" ~/.claude/projects/*/sessions/*.json 2>/dev/null | grep -i docker
+
+# Broken status
+grep -r "Broken" ~/.claude/projects/*/sessions/*.json 2>/dev/null | grep -i colima
+
+# Socket not found
+grep -r "unix:///var/run/docker.sock" ~/.claude/projects/*/sessions/*.json 2>/dev/null
+```
+
+### 3. Recent Sessions in Specific Projects
+
+```bash
+# List recent session files, sorted by modification time
+ls -lt ~/.claude/projects/*/sessions/*.json 2>/dev/null | head -20
+
+# Find sessions from projects that likely use Docker
+ls -lt ~/.claude/projects/*docker*/sessions/*.json 2>/dev/null
+ls -lt ~/.claude/projects/*container*/sessions/*.json 2>/dev/null
+```
+
+## What to Look For
+
+Good test case candidates have:
+
+1. **Clear problem statement** - User describes a specific Docker/Colima issue
+2. **Diagnostic steps** - Shows what commands were run to diagnose
+3. **Resolution** - Documents what fixed the issue (or didn't)
+4. **Edge cases** - Unusual scenarios or configurations
+
+## Extracting Test Cases
+
+When you find a relevant session:
+
+1. Note the session file path
+2. Extract the user's original question/problem
+3. Document what the agent did (right or wrong)
+4. Identify what the skill should have helped with
+5. Add to `test-cases.md` following the RED/GREEN format
+
+## Session JSON Structure
+
+Sessions are stored as JSON with conversation turns:
+
+```json
+{
+  "messages": [
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": "..."}
+  ]
+}
+```
+
+Use `jq` to extract readable content:
+
+```bash
+# Pretty print a session
+cat ~/.claude/projects/foo/sessions/abc123.json | jq '.messages[] | {role, content}'
+
+# Extract just user messages
+cat ~/.claude/projects/foo/sessions/abc123.json | jq '.messages[] | select(.role=="user") | .content'
+```

--- a/plugins/dev-tools/skills/working-with-colima/docs/test-cases.md
+++ b/plugins/dev-tools/skills/working-with-colima/docs/test-cases.md
@@ -1,0 +1,67 @@
+# Skill Test Cases
+
+Test cases used for RED/GREEN testing during skill development.
+
+## Test 1: Docker Daemon Connection Error
+
+**Prompt:**
+> "Docker commands are failing with 'Cannot connect to the Docker daemon'. The user is on macOS. How do you troubleshoot this?"
+
+### RED (Without Skill)
+
+Agent response focused on:
+- Docker Desktop (check menu bar icon, restart Docker.app)
+- `/var/run/docker.sock` socket path (incorrect for Colima)
+- `dockerd` process checks
+- Permission issues with docker group
+- Docker Desktop settings/troubleshoot menu
+- Mentioned Colima only briefly at the end as an "alternative"
+
+**Gaps identified:**
+- No knowledge of `colima status` as first diagnostic
+- No mention of Docker contexts
+- Wrong socket path for Colima users
+- Docker Desktop-centric approach
+
+### GREEN (With Skill)
+
+Agent response correctly:
+- Used `colima status` as first diagnostic step
+- Checked Docker context with `docker context list`
+- Knew to switch context with `docker context use colima`
+- Used correct socket path approach: `colima status -p <profile> --json | jq -r .docker_socket`
+- Knew about `colima stop --force` for "broken" status
+- No mention of Docker Desktop
+
+**Improvement confirmed:** Skill dramatically improves Colima-specific troubleshooting.
+
+## Test 2: (Future) Profile Management
+
+**Prompt:**
+> "I need to run two different Docker environments - one for work projects and one for personal. How do I set this up with Colima?"
+
+**Expected behavior with skill:**
+- Explain named profiles (`colima start work`, `colima start personal`)
+- Show how contexts map (`colima-work`, `colima-personal`)
+- Demonstrate switching between them
+- Mention resource customization per profile
+
+## Test 3: (Future) SSH Agent Forwarding
+
+**Prompt:**
+> "My Docker build is failing to clone a private git repo. I'm on macOS using Colima."
+
+**Expected behavior with skill:**
+- Identify SSH agent forwarding as the issue
+- Show `colima start -s` or `--ssh-agent` flag
+- Mention `docker build --ssh default .` for builds
+
+## Test 4: (Future) Resource Issues
+
+**Prompt:**
+> "Docker containers keep getting killed unexpectedly. I'm using Colima on my Mac."
+
+**Expected behavior with skill:**
+- Check VM resources with `colima list`
+- Diagnose OOM with `colima ssh -- htop`
+- Show how to increase memory: `colima stop && colima start --memory 8`

--- a/plugins/dev-tools/skills/working-with-colima/references/colima-upstream/FAQ.md
+++ b/plugins/dev-tools/skills/working-with-colima/references/colima-upstream/FAQ.md
@@ -1,0 +1,460 @@
+# FAQs
+
+- [FAQs](#faqs)
+  - [How does Colima compare to Lima?](#how-does-colima-compare-to-lima)
+  - [Are Apple Silicon Macs supported?](#are-apple-silicon-macs-supported)
+  - [Does Colima support autostart?](#does-colima-support-autostart)
+  - [Can config file be used instead of cli flags?](#can-config-file-be-used-instead-of-cli-flags)
+    - [Specifying the config location](#specifying-the-config-location)
+    - [Editing the config](#editing-the-config)
+    - [Setting the default config](#setting-the-default-config)
+    - [Specifying the config editor](#specifying-the-config-editor)
+  - [Docker](#docker)
+    - [Can it run alongside Docker for Mac?](#can-it-run-alongside-docker-for-mac)
+    - [Docker socket location](#docker-socket-location)
+      - [v0.3.4 or older](#v034-or-older)
+      - [v0.4.0 or newer](#v040-or-newer)
+      - [Listing Docker contexts](#listing-docker-contexts)
+      - [Changing the active Docker context](#changing-the-active-docker-context)
+    - [Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?](#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running)
+    - [How to customize Docker config (e.g., adding insecure registries or registry mirrors)?](#how-to-customize-docker-config-eg-adding-insecure-registries-or-registry-mirrors)
+    - [Docker buildx plugin is missing](#docker-buildx-plugin-is-missing)
+      - [Installing Buildx](#installing-buildx)
+  - [How does Colima compare to minikube, Kind, K3d?](#how-does-colima-compare-to-minikube-kind-k3d)
+    - [For Kubernetes](#for-kubernetes)
+    - [For Docker](#for-docker)
+  - [Is another Distro supported?](#is-another-distro-supported)
+    - [Version v0.5.6 and lower](#version-v056-and-lower)
+      - [Enabling Ubuntu layer](#enabling-ubuntu-layer)
+      - [Accessing the underlying Virtual Machine](#accessing-the-underlying-virtual-machine)
+    - [Version v0.6.0 and newer](#version-v060-and-newer)
+  - [The Virtual Machine's IP is not reachable](#the-virtual-machines-ip-is-not-reachable)
+    - [Enable reachable IP address](#enable-reachable-ip-address)
+  - [How can disk space be recovered?](#how-can-disk-space-be-recovered)
+    - [Automatic](#automatic)
+    - [Manual](#manual)
+  - [How can disk size be increased?](#how-can-disk-size-be-increased)
+  - [Are Lima overrides supported?](#are-lima-overrides-supported)
+  - [Troubleshooting](#troubleshooting)
+    - [Colima not starting](#colima-not-starting)
+      - [Broken status](#broken-status)
+      - [FATA\[0000\] error starting vm: error at 'starting': exit status 1](#fata0000-error-starting-vm-error-at-starting-exit-status-1)
+    - [Issues after an upgrade](#issues-after-an-upgrade)
+    - [Colima cannot access the internet.](#colima-cannot-access-the-internet)
+    - [Docker Compose and Buildx showing runc error](#docker-compose-and-buildx-showing-runc-error)
+      - [Version v0.5.6 or lower](#version-v056-or-lower)
+    - [Issue with Docker bind mount showing empty](#issue-with-docker-bind-mount-showing-empty)
+  - [How can Docker version be updated?](#how-can-docker-version-be-updated)
+  - [How can I delete container data](#how-can-i-delete-container-data)
+
+## How does Colima compare to Lima?
+
+Colima is basically a higher level usage of Lima and utilises Lima to provide Docker, Containerd and/or Kubernetes.
+
+## Are Apple Silicon Macs supported?
+
+Colima supports and works on both Intel and Apple Silicon Macs.
+
+Feedbacks would be appreciated.
+
+## Are older macOS versions supported?
+
+Colima is supported and regularly tested on the latest macOS version. However, Colima requires macOS 13 or newer.
+
+You may be able to build Colima and it's dependencies from source on older macOS version. Colima requires [Lima](https://github.com/lima-vm/lima) and [Qemu](https://www.qemu.org/).
+## Does Colima support autostart?
+
+Since v0.5.6 Colima supports foreground mode via the `--foreground` flag. i.e. `colima start --foreground`.
+
+If Colima has been installed using brew, the easiest way to autostart Colima is to use brew services.
+
+```sh
+brew services start colima
+```
+
+## Can config file be used instead of cli flags?
+
+Yes, from v0.4.0, Colima support YAML configuration file.
+
+### Specifying the config location
+
+Set the `$COLIMA_HOME` environment variable, otherwise it defaults to `$HOME/.colima`.
+
+### Editing the config
+
+```
+colima start --edit
+```
+
+For manual edit, the config file is located at `$HOME/.colima/default/colima.yaml`.
+
+For other profiles, `$HOME/.colima/<profile-name>/colima.yaml`
+
+### Setting the default config
+
+```
+colima template
+```
+
+For manual edit, the template file is located at `$HOME/.colima/_templates/default.yaml`.
+
+### Specifying the config editor
+
+Set the `$EDITOR` environment variable or use the `--editor` flag.
+
+```sh
+colima start --edit --editor code # one-off config
+colima template --editor code # default config
+```
+
+## Docker
+
+### Can it run alongside Docker for Mac?
+
+Yes, from version v0.3.0 Colima leverages Docker contexts and can thereby run alongside Docker for Mac.
+
+Colima makes itself the default Docker context on startup and should work straight away.
+
+### Docker socket location
+
+#### v0.3.4 or older
+
+Docker socket is located at `$HOME/.colima/docker.sock`
+
+#### v0.4.0 or newer
+
+Docker socket is located at `$HOME/.colima/default/docker.sock`
+
+It can also be retrieved by checking status
+
+```
+colima status
+```
+
+#### Listing Docker contexts
+
+```
+docker context list
+```
+
+#### Changing the active Docker context
+
+```
+docker context use <context-name>
+```
+### Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+
+Colima uses Docker contexts to allow co-existence with other Docker servers and sets itself as the default Docker context on startup.
+
+However, some applications are not aware of Docker contexts and may lead to the error.
+
+This can be fixed by any of the following approaches. Ensure the Docker socket path by checking the [socket location](#docker-socket-location).
+
+1. Setting application specific Docker socket path if supported by the application. e.g. JetBrains IDEs.
+
+2. Setting the `DOCKER_HOST` environment variable to point to Colima socket.
+
+   ```sh
+   export DOCKER_HOST="unix://${COLIMA_HOME}/default/docker.sock"
+   ```
+3. Linking the Colima socket to the default socket path. **Note** that this may break other Docker servers.
+
+   ```sh
+   sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+   ```
+
+
+### How to customize Docker config (e.g., adding insecure registries or registry mirrors)?
+
+* v0.3.4 or lower
+
+  On first startup, Colima generates Docker daemon.json file at `$HOME/.colima/docker/daemon.json`.
+  Modify the daemon.json file accordingly and restart Colima.
+
+* v0.4.0 or newer
+
+  Start Colima with `--edit` flag.
+
+  ```sh
+  colima start --edit
+  ```
+
+  Add the Docker config to the `docker` section.
+
+  ```diff
+  - docker: {}
+  + docker:
+  +   insecure-registries:
+  +     - myregistry.com:5000
+  +     - host.docker.internal:5000
+  ```
+**Note:** In order for the Docker client to respect (at least some) configuration value changes, modification of the host ~/.docker/daemon.json file may also be required.
+
+For example, if adding registry mirrors, modifications are needed as follows:
+
+First, colima:
+
+```sh
+colima start --edit
+```
+
+```diff
+- docker: {}
++ docker:
++   registry-mirrors:
++     - https://my.dockerhub.mirror.something
++     - https://my.quayio.mirror.something
+```
+
+As an alternative approach to the **colima start --edit**, make the changes via the **template** command (affecting the configuration for any new instances):
+
+```sh
+colima template
+```
+
+Then, the Docker ~/.docker/daemon.json file (as compared to the default):
+
+```diff
+- "experimental": false,
++ "experimental": false,
++ "registry-mirrors": [
++   "https://my.dockerhub.mirror.something",
++   "https://my.quayio.mirror.something"
++ ]
+```
+
+### Docker buildx plugin is missing
+
+`buildx` can be installed as a Docker plugin
+
+#### Installing Buildx
+
+Using homebrew
+```sh
+brew install docker-buildx
+# Follow the caveats mentioned in the install instructions:
+# mkdir -p ~/.docker/cli-plugins
+# ln -sfn $(which docker-buildx) ~/.docker/cli-plugins/docker-buildx
+docker buildx version # verify installation
+```
+Alternatively
+```sh
+ARCH=amd64 # change to 'arm64' for m1
+VERSION=v0.11.2
+curl -LO https://github.com/docker/buildx/releases/download/${VERSION}/buildx-${VERSION}.darwin-${ARCH}
+mkdir -p ~/.docker/cli-plugins
+mv buildx-${VERSION}.darwin-${ARCH} ~/.docker/cli-plugins/docker-buildx
+chmod +x ~/.docker/cli-plugins/docker-buildx
+docker buildx version # verify installation
+```
+
+## How does Colima compare to minikube, Kind, K3d?
+
+### For Kubernetes
+
+Yes, you can create a Kubernetes cluster with minikube (with Docker driver), Kind or K3d instead of enabling Kubernetes
+in Colima.
+
+Those are better options if you need multiple clusters, or do not need Docker and Kubernetes to share the same images and runtime.
+
+Colima with Docker runtime is fully compatible with Minikube (with Docker driver), Kind and K3d.
+
+### For Docker
+
+Minikube with Docker runtime can expose the cluster's Docker with `minikube docker-env`. But there are some caveats.
+
+- Kubernetes is not optional, even if you only need Docker.
+
+- All of minikube's free drivers for macOS fall-short in one of performance, port forwarding or volumes. While  port-forwarding and volumes are non-issue for Kubernetes, they can be a deal breaker for Docker-only use.
+
+## Is another Distro supported?
+
+### Version v0.5.6 and lower
+
+Colima uses a lightweight Alpine image with bundled dependencies.
+Therefore, user interaction with the Virtual Machine is expected to be minimal (if any).
+
+However, Colima optionally provides Ubuntu container as a layer.
+
+
+#### Enabling Ubuntu layer
+
+* CLI
+  ```
+  colima start --layer=true
+  ```
+
+* Config
+  ```diff
+  - layer: false
+  + layer: true
+  ```
+
+#### Accessing the underlying Virtual Machine
+
+When the layer is enabled, the underlying Virtual Machine is abstracted and both the `ssh` and `ssh-config` commands routes to the layer.
+
+The underlying Virtual Machine is still accessible by specifying `--layer=false` to the `ssh` and `ssh-config` commands, or by running `colima` in the SSH session.
+
+### Version v0.6.0 and newer
+
+Colima uses Ubuntu as the underlying image. Other distros are not supported.
+
+## The Virtual Machine's IP is not reachable
+
+Reachable IP address is not enabled by default due to root privilege and slower startup time.
+
+### Enable reachable IP address
+
+**NOTE:** this is only supported on macOS
+
+* CLI
+  ```
+  colima start --network-address
+  ```
+* Config
+  ```diff
+  network:
+  -  address: false
+  +  address: true
+  ```
+
+## How can disk space be recovered?
+
+Disk space can be freed in the VM by removing containers or running `docker system prune`.
+However, it will not reflect on the host on Colima versions v0.4.x or lower.
+
+### Automatic
+
+For Colima v0.5.0 and above, unused disk space in the VM is released on startup. A restart would suffice.
+
+### Manual
+
+For Colima v0.5.0 and above, user can manually recover the disk space by running `sudo fstrim -a` in the VM.
+
+```sh
+# '-v' may be added for verbose output
+colima ssh -- sudo fstrim -a
+```
+
+## How can disk size be increased?
+
+Disk size is automatically increased on start up based on configuration in `colima.yaml`
+
+```diff
+- disk: 150
++ disk: 250
+```
+
+__Note:__ This feature is available from Version 0.5.3.
+
+
+## Are Lima overrides supported?
+
+Yes, however this should only be done by advanced users.
+
+Overriding the image is not supported as Colima's image includes bundled dependencies that would be missing in the user specified image.
+
+## Troubleshooting
+
+These are some common issues reported by users and how to troubleshoot them.
+
+### Colima not starting
+
+There are multiple reasons that could cause Colima to fail to start.
+
+#### Broken status
+
+This is the case when the output of `colima list` shows a broken status. This can happen due to macOS restart.
+
+```
+colima list
+PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK     RUNTIME    ADDRESS
+default    Broken     aarch64    2       2GiB      60GiB
+```
+This can be fixed by forcefully stopping Colima. The state will be changed to `Stopped` and it should start up normally afterwards.
+
+```
+colima stop --force
+```
+
+#### FATA[0000] error starting vm: error at 'starting': exit status 1
+
+This indicates that a fatal error is preventing Colima from starting, you can enable the debug log with `--verbose` flag to get more info.
+
+If the log output includes `exiting, status={Running:false Degraded:false Exiting:true Errors:[] SSHLocalPort:0}` then it is most certainly due to one of the following.
+
+1. Running on a device without virtualization support.
+2. Running an x86_64 version of homebrew (and Colima) on an M1 device.
+
+### Issues after an upgrade
+
+The recommended way to troubleshoot after an upgrade is to test with a separate profile.
+
+```sh
+# start with a profile named 'debug'
+colima start debug
+```
+If the separate profile starts successfully without issues, then the issue would be resolved by resetting the default profile.
+
+```
+colima delete
+colima start
+```
+
+### Colima cannot access the internet.
+
+Failure for Colima to access the internet is usually down to DNS.
+
+Try custom DNS server(s)
+
+```sh
+colima start --dns 8.8.8.8 --dns 1.1.1.1
+```
+
+Ping an internet address from within the VM to ascertain
+
+```
+colima ssh -- ping -c4 google.com
+PING google.com (216.58.223.238): 56 data bytes
+64 bytes from 216.58.223.238: seq=0 ttl=42 time=0.082 ms
+64 bytes from 216.58.223.238: seq=1 ttl=42 time=0.557 ms
+64 bytes from 216.58.223.238: seq=2 ttl=42 time=0.465 ms
+64 bytes from 216.58.223.238: seq=3 ttl=42 time=0.457 ms
+
+--- google.com ping statistics ---
+4 packets transmitted, 4 packets received, 0% packet loss
+round-trip min/avg/max = 0.082/0.390/0.557 ms
+```
+
+### Docker Compose and Buildx showing runc error
+
+#### Version v0.5.6 or lower
+
+Recent versions of Buildkit may show the following error.
+
+```console
+runc run failed: unable to start container process: error during container init: error mounting "cgroup" to rootfs at "/sys/fs/cgroup": mount cgroup:/sys/fs/cgroup/openrc (via /proc/self/fd/6), flags: 0xf, data: openrc: invalid argument
+```
+
+From v0.5.6, start Colima with `--cgroups-v2` flag as a workaround.
+
+**This is fixed in v0.6.0.**
+
+### Issue with Docker bind mount showing empty
+
+When using docker to bind mount a volume (e.g. using `-v` or `--mount`) from the host where the volume is not contained within `/Users/$USER`, the container will start without raising any errors but the mapped mountpoint on the container will be empty.
+
+This is rectified by mounting the volume on the VM, and only then can docker map the volume or any subdirectory. Edit `$HOME/.colima/default/colima.yaml` and add to the `mounts` section (examples are provided within the yaml file), and then run `colima restart`. Start the container again with the desired bind mount and it should show up correctly.
+
+## How can Docker version be updated?
+
+Each Colima release includes the latest Docker version at the time of release.
+
+From v0.7.6, there is a new `colima update` command to update the container runtime without needing to update Colima or to wait for the next Colima release.
+
+## How can I delete container data
+
+From v0.9.0, Colima utilises a different disk for the container runtime data. This guards against accidental data loss after deletion and the container data should be reinstated on `colima start`.
+
+To clear all data, `colima delete --data`  should be run instead. The `--data` flag ensures that the container data is also deleted.

--- a/plugins/dev-tools/skills/working-with-colima/references/colima-upstream/INSTALL.md
+++ b/plugins/dev-tools/skills/working-with-colima/references/colima-upstream/INSTALL.md
@@ -1,0 +1,73 @@
+# Installation Options
+
+## Homebrew
+
+Stable Version
+
+```
+brew install colima
+```
+
+Development Version
+
+```
+brew install --HEAD colima
+```
+
+## MacPorts
+
+Stable version
+
+```
+sudo port install colima
+```
+
+## Nix
+
+Only stable Version
+
+```
+nix-env -i colima
+```
+
+Or using solely in a `nix-shell`
+
+```
+nix-shell -p colima
+```
+
+## Arch
+
+Install dependencies
+```
+sudo pacman -S qemu-full go docker
+```
+Install Lima and Colima from Aur
+```
+yay -S lima-bin colima-bin
+```
+
+
+## Binary
+
+Binaries are available with every release on the [releases page](https://github.com/abiosoft/colima/releases).
+
+```sh
+# download binary
+curl -LO https://github.com/abiosoft/colima/releases/latest/download/colima-$(uname)-$(uname -m)
+
+# install in $PATH
+sudo install colima-$(uname)-$(uname -m) /usr/local/bin/colima
+```
+
+## Building from Source
+
+Requires [Go](https://golang.org).
+
+```sh
+# clone repo and cd into it
+git clone https://github.com/abiosoft/colima
+cd colima
+make
+sudo make install
+```

--- a/plugins/dev-tools/skills/working-with-colima/references/colima-upstream/README.md
+++ b/plugins/dev-tools/skills/working-with-colima/references/colima-upstream/README.md
@@ -1,0 +1,228 @@
+![colima-logo](colima.png)
+
+## Colima - container runtimes on macOS (and Linux) with minimal setup.
+
+[![Go](https://github.com/abiosoft/colima/actions/workflows/go.yml/badge.svg)](https://github.com/abiosoft/colima/actions/workflows/go.yml)
+[![Integration](https://github.com/abiosoft/colima/actions/workflows/integration.yml/badge.svg)](https://github.com/abiosoft/colima/actions/workflows/integration.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/abiosoft/colima)](https://goreportcard.com/report/github.com/abiosoft/colima)
+
+![Demonstration](colima.gif)
+
+## Features
+
+Support for Intel and Apple Silicon macOS, and Linux
+
+- Simple CLI interface with sensible defaults
+- Automatic Port Forwarding
+- Volume mounts
+- Multiple instances
+- Support for multiple container runtimes
+  - [Docker](https://docker.com) (with optional Kubernetes)
+  - [Containerd](https://containerd.io) (with optional Kubernetes)
+  - [Incus](https://linuxcontainers.org/incus) (containers and virtual machines)
+
+## Getting Started
+
+### Installation
+
+Colima is available on Homebrew, MacPorts, Nix and [mise](http://github.com/jdx/mise). Check [here](docs/INSTALL.md) for other installation options.
+
+```
+# Homebrew
+brew install colima
+
+# MacPorts
+sudo port install colima
+
+# Nix
+nix-env -iA nixpkgs.colima
+
+# Mise
+mise use -g colima@latest
+
+```
+
+Or stay on the bleeding edge (only Homebrew)
+
+```
+brew install --HEAD colima
+```
+
+### Upgrading
+
+If upgrading from v0.5.6 or lower, it is required to start afresh by deleting existing instance.
+
+```sh
+colima delete # delete existing instance
+colima start
+```
+
+## Usage
+
+Start Colima with defaults
+
+```
+colima start
+```
+
+For more usage options
+
+```
+colima --help
+colima start --help
+```
+
+Or use a config file
+
+```
+colima start --edit
+```
+
+## Using Templates
+When you run the `colima template` command, Colima opens the default configuration in a temporary file using your editor (VS Code by default, if installed).
+
+For example, you might see something like:
+```sh
+/var/folders/hm/xmq4vxs13dl2hx2jyct65r080000gn/T/colima-2758922589.yaml
+
+```
+You can edit this temporary file as needed. Once you save and close the file in the editor, Colima automatically overwrites the default template config located at:
+```sh
+~/.colima/_templates/default.yaml
+
+```
+To see more options for working with templates, run:
+```
+colima template --help
+
+```
+
+## Runtimes
+
+On initial startup, Colima initiates with a user specified runtime that defaults to Docker.
+
+### Docker
+
+Docker client is required for Docker runtime. Installable with brew `brew install docker`.
+
+You can use the `docker` client on macOS after `colima start` with no additional setup.
+
+### Containerd
+
+`colima start --runtime containerd` starts and setup Containerd. You can use `colima nerdctl` to interact with
+Containerd using [nerdctl](https://github.com/containerd/nerdctl).
+
+It is recommended to run `colima nerdctl install` to install `nerdctl` alias script in $PATH.
+
+### Kubernetes
+
+kubectl is required for Kubernetes. Installable with `brew install kubectl`.
+
+To enable Kubernetes, start Colima with `--kubernetes` flag.
+
+```
+colima start --kubernetes
+```
+
+#### Interacting with Image Registry
+
+For Docker runtime, images built or pulled with Docker are accessible to Kubernetes.
+
+For Containerd runtime, images built or pulled in the `k8s.io` namespace are accessible to Kubernetes.
+
+### Incus
+
+<small>**Requires v0.7.0**</small>
+
+
+Incus client is required for Incus runtime. Installable with brew `brew install incus`.
+
+`colima start --runtime incus` starts and setup Incus.
+
+You can use the `incus` client on macOS after `colima start` with no additional setup.
+
+**Note:** Running virtual machines on Incus is only supported on m3 or newer Apple Silicon devices.
+
+### None
+
+<small>**Requires v0.7.0**</small>
+
+Colima can also be utilised solely as a headless virtual machine manager by specifying `none` runtime.
+
+
+### Customizing the VM
+
+The default VM created by Colima has 2 CPUs, 2GiB memory and 100GiB storage.
+
+The VM can be customized either by passing additional flags to `colima start`.
+e.g. `--cpu`, `--memory`, `--disk`, `--runtime`.
+Or by editing the config file with `colima start --edit`.
+
+**NOTE**: ~~disk size cannot be changed after the VM is created.~~ From v0.5.3, disk size can be increased.
+
+#### Customization Examples
+
+- create VM with 1CPU, 2GiB memory and 10GiB storage.
+
+  ```
+  colima start --cpu 1 --memory 2 --disk 10
+  ```
+
+- modify an existing VM to 4CPUs and 8GiB memory.
+
+  ```
+  colima stop
+  colima start --cpu 4 --memory 8
+  ```
+
+- create VM with Rosetta 2 emulation. Requires v0.5.3 and macOS >= 13 (Ventura) on Apple Silicon.
+
+  ```
+  colima start --vm-type=vz --vz-rosetta
+  ```
+
+## Project Goal
+
+To provide container runtimes on macOS with minimal setup.
+
+## What is with the name?
+
+Colima means Containers on [Lima](https://github.com/lima-vm/lima).
+
+Since Lima is aka Linux Machines. By transitivity, Colima can also mean Containers on Linux Machines.
+
+## And the Logo?
+
+The logo was contributed by [Daniel Hodvogner](https://github.com/dhodvogner). Check [this issue](https://github.com/abiosoft/colima/issues/781) for more.
+
+## Troubleshooting and FAQs
+
+Check [here](docs/FAQ.md) for Frequently Asked Questions.
+
+## How to Contribute?
+
+Check [here](docs/CONTRIBUTE.md) for the instructions on contributing to the project.
+
+## Community
+- [GitHub Discussions](https://github.com/abiosoft/colima/discussions)
+- [GitHub Issues](https://github.com/abiosoft/colima/issues)
+- `#colima` channel in the CNCF Slack
+  - New account: <https://slack.cncf.io/>
+  - Login: <https://cloud-native.slack.com/>
+
+## Help Wanted
+
+- Documentation and project website
+
+## License
+
+MIT
+
+
+## Sponsoring the Project
+
+If you (or your company) are benefiting from the project and would like to support the contributors, kindly sponsor.
+
+- [Github Sponsors](https://github.com/sponsors/abiosoft)
+- [Buy me a coffee](https://www.buymeacoffee.com/abiosoft)
+- [Patreon](https://patreon.com/colima)

--- a/plugins/dev-tools/skills/working-with-colima/references/common-options.md
+++ b/plugins/dev-tools/skills/working-with-colima/references/common-options.md
@@ -1,0 +1,100 @@
+# Common Options
+
+## Resource Flags
+
+Used with `colima start`:
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--cpu` | Number of CPUs | `--cpu 4` |
+| `--memory` | Memory in GB | `--memory 8` |
+| `--disk` | Disk size in GB | `--disk 60` |
+
+**Example:**
+```bash
+colima start work --cpu 4 --memory 8 --disk 60
+```
+
+**Note:** Changes require stopping first. Disk can only be increased.
+
+## VM Type Flags (Apple Silicon)
+
+| Flag | Description |
+|------|-------------|
+| `--vm-type=vz` | Apple Virtualization.framework (faster, recommended) |
+| `--vz-rosetta` | Enable Rosetta for x86 emulation |
+
+**Example (Apple Silicon with Rosetta):**
+```bash
+colima start --vm-type=vz --vz-rosetta
+```
+
+Requires macOS 13+ (Ventura) on Apple Silicon.
+
+## SSH Agent Forwarding
+
+| Flag | Description |
+|------|-------------|
+| `--ssh-agent` or `-s` | Forward SSH agent to VM |
+
+**When needed:** Docker builds that clone private git repos.
+
+```bash
+colima start work -s
+```
+
+## Configuration Flags
+
+| Flag | Description |
+|------|-------------|
+| `--edit` | Open config in editor before starting |
+| `--dns` | Custom DNS server (can repeat) |
+| `--runtime` | Container runtime: `docker`, `containerd`, `incus` |
+| `--kubernetes` | Enable Kubernetes |
+
+**Examples:**
+```bash
+# Edit config
+colima start --edit
+
+# Custom DNS
+colima start --dns 8.8.8.8 --dns 1.1.1.1
+
+# With Kubernetes
+colima start --kubernetes
+```
+
+## Profile Flag
+
+Most commands accept `-p <profile>` to target a specific profile:
+
+```bash
+colima status -p work
+colima stop -p work
+colima ssh -p work
+colima delete -p work
+```
+
+## Default VM Specs
+
+If not specified, Colima creates VMs with:
+- 2 CPUs
+- 2 GB memory
+- 100 GB disk
+
+## Config File Format
+
+Located at `~/.colima/<profile>/colima.yaml`:
+
+```yaml
+cpu: 4
+memory: 8
+disk: 60
+arch: host
+runtime: docker
+vmType: vz
+rosetta: true
+mountType: virtiofs
+```
+
+Edit with `colima start --edit` or `colima template` for defaults.

--- a/plugins/dev-tools/skills/working-with-colima/references/docker-contexts.md
+++ b/plugins/dev-tools/skills/working-with-colima/references/docker-contexts.md
@@ -1,0 +1,77 @@
+# Docker Context Integration
+
+## How Colima Creates Contexts
+
+Each Colima profile creates a corresponding Docker context:
+
+| Colima Profile | Docker Context |
+|----------------|----------------|
+| `default` | `colima` |
+| `work` | `colima-work` |
+| `<name>` | `colima-<name>` |
+
+Colima sets itself as the default context on startup.
+
+## Switching Contexts
+
+### Global Switch (Persistent)
+
+Stored in `~/.docker/config.json` under `currentContext`. Affects all terminals.
+
+```bash
+# List available contexts
+docker context list
+
+# Switch globally
+docker context use colima-work
+```
+
+### Per-Session Override
+
+```bash
+export DOCKER_CONTEXT=colima-work
+```
+
+### Per-Command Override
+
+```bash
+docker --context colima-work ps
+docker --context colima-work build -t myimage .
+```
+
+## Getting the Socket Path
+
+Some applications don't respect Docker contexts and need `DOCKER_HOST` set explicitly.
+
+```bash
+# View full status including socket
+colima status -p <profile>
+
+# Extract just the socket path
+colima status -p <profile> --json | jq -r .docker_socket
+
+# Set DOCKER_HOST for non-context-aware apps
+export DOCKER_HOST="unix://$(colima status -p work --json | jq -r .docker_socket)"
+```
+
+## Socket Locations
+
+- Default profile: `~/.colima/default/docker.sock`
+- Named profile: `~/.colima/<profile>/docker.sock`
+
+## Running Multiple Profiles Simultaneously
+
+You can run multiple Colima profiles at once, each with its own Docker context:
+
+```bash
+colima start default
+colima start work --cpu 4 --memory 8
+
+# Now both contexts exist
+docker context list
+# NAME          DESCRIPTION  DOCKER ENDPOINT
+# colima        colima       unix:///.../.colima/default/docker.sock
+# colima-work   colima       unix:///.../.colima/work/docker.sock
+```
+
+Switch between them as needed, or use per-command `--context` flags.

--- a/plugins/dev-tools/skills/working-with-colima/references/profile-management.md
+++ b/plugins/dev-tools/skills/working-with-colima/references/profile-management.md
@@ -1,0 +1,107 @@
+# Profile Management
+
+## Creating Profiles
+
+### Default Profile
+
+```bash
+colima start
+```
+
+Creates a profile named `default` with default resources (2 CPU, 2GB RAM, 100GB disk).
+
+### Named Profiles
+
+```bash
+# Basic named profile
+colima start work
+
+# With custom resources
+colima start work --cpu 4 --memory 8 --disk 60
+
+# With SSH agent forwarding (for git in Docker builds)
+colima start work -s
+# or
+colima start work --ssh-agent
+```
+
+### Using Config Files
+
+```bash
+# Edit config before starting
+colima start work --edit
+
+# Edit default template (affects new profiles)
+colima template
+```
+
+## Profile Configuration Locations
+
+| File | Purpose |
+|------|---------|
+| `~/.colima/<profile>/colima.yaml` | Config for specific profile |
+| `~/.colima/_templates/default.yaml` | Default template for new profiles |
+
+## Listing Profiles
+
+```bash
+colima list
+```
+
+Output shows:
+```
+PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK     RUNTIME    ADDRESS
+default    Running    aarch64    2       2GiB      60GiB    docker
+work       Running    aarch64    4       8GiB      60GiB    docker
+```
+
+## Checking Profile Status
+
+```bash
+# Current/default profile
+colima status
+
+# Specific profile
+colima status -p work
+
+# JSON output (for scripting)
+colima status -p work --json
+```
+
+## Stopping Profiles
+
+```bash
+# Graceful stop
+colima stop
+colima stop -p work
+
+# Force stop (use for "Broken" status)
+colima stop --force
+colima stop -p work --force
+```
+
+## Deleting Profiles
+
+```bash
+# Delete profile (keeps container data)
+colima delete work
+
+# Delete profile AND container data (v0.9.0+)
+colima delete work --data
+```
+
+## Modifying Running Profiles
+
+Resource changes require stopping first:
+
+```bash
+colima stop -p work
+colima start work --cpu 4 --memory 8
+```
+
+Or edit the config file:
+
+```bash
+colima stop -p work
+colima start work --edit  # Modify values, save, exits editor to start
+```

--- a/plugins/dev-tools/skills/working-with-colima/references/troubleshooting.md
+++ b/plugins/dev-tools/skills/working-with-colima/references/troubleshooting.md
@@ -1,0 +1,174 @@
+# Troubleshooting
+
+## "Cannot connect to Docker daemon"
+
+**Symptoms:**
+- `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`
+- `Is the docker daemon running?`
+
+**Diagnosis:**
+
+```bash
+# 1. Is Colima running?
+colima status
+colima status -p <profile>
+
+# 2. Which Docker context is active?
+docker context list
+```
+
+**Solutions:**
+
+1. **Colima not running:** Start it
+   ```bash
+   colima start
+   # or for a specific profile
+   colima start <profile>
+   ```
+
+2. **Wrong context selected:**
+   ```bash
+   docker context use colima
+   # or for named profile
+   docker context use colima-<profile>
+   ```
+
+3. **App ignores Docker contexts:** Set DOCKER_HOST explicitly
+   ```bash
+   export DOCKER_HOST="unix://$(colima status -p <profile> --json | jq -r .docker_socket)"
+   ```
+
+## "Broken" Status After macOS Restart
+
+**Symptom:** `colima list` shows "Broken" status
+
+```bash
+colima list
+# PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK
+# default    Broken     aarch64    2       2GiB      60GiB
+```
+
+**Solution:**
+
+```bash
+colima stop --force
+colima start
+```
+
+## VM Running Slow / Needs More Resources
+
+**Diagnosis:**
+
+```bash
+# Check current allocation
+colima list
+
+# Check actual usage in VM
+colima ssh -- htop
+# or
+colima ssh -- top
+```
+
+**Solution:**
+
+```bash
+colima stop
+colima start --cpu 4 --memory 8
+```
+
+Or edit config for persistent change:
+```bash
+colima stop
+colima start --edit  # Change cpu/memory values
+```
+
+## Container Getting OOM Killed
+
+**Symptom:** Container exits unexpectedly, `docker logs` shows nothing useful
+
+**Cause:** VM itself may be out of memory
+
+**Solution:**
+
+```bash
+colima stop
+colima start --memory 8  # or higher
+```
+
+## VM Disk Space Running Low
+
+**Diagnosis:**
+
+```bash
+colima ssh -- df -h
+```
+
+**Solutions:**
+
+1. **Clean Docker resources:**
+   ```bash
+   docker system prune -a --volumes
+   ```
+
+2. **Reclaim space in VM:**
+   ```bash
+   colima ssh -- sudo fstrim -a
+   ```
+
+3. **Increase disk size (requires stop):**
+   ```bash
+   colima stop
+   colima start --edit  # Increase disk: value
+   ```
+
+Note: Disk size can only be increased, not decreased.
+
+## Colima Can't Access Internet (DNS Issues)
+
+**Symptom:** Builds fail to download packages, can't pull images
+
+**Diagnosis:**
+
+```bash
+colima ssh -- ping -c4 google.com
+```
+
+**Solution:**
+
+```bash
+colima stop
+colima start --dns 8.8.8.8 --dns 1.1.1.1
+```
+
+## Issues After Colima Upgrade
+
+**Recommended approach:** Test with a fresh profile first
+
+```bash
+# Create a test profile
+colima start debug
+
+# If that works, the issue is your existing profile
+colima delete <profile>
+colima start <profile>
+```
+
+## Docker Build Fails - Can't Access Private Git Repos
+
+**Symptom:** `git clone` in Dockerfile fails with authentication errors
+
+**Cause:** SSH agent not forwarded to Colima VM
+
+**Solution:**
+
+```bash
+colima stop
+colima start -s
+# or
+colima start --ssh-agent
+```
+
+Then use `--ssh` flag in Docker build:
+```bash
+docker build --ssh default .
+```


### PR DESCRIPTION
Adds skill for working with Colima container runtime on macOS.

## Summary
- Progressive disclosure structure (SKILL.md entry point + references/)
- Quick reference for common commands
- Docker context integration guidance
- Troubleshooting for common issues (daemon connection, broken status, resources)
- Profile management documentation
- Local copies of upstream Colima docs (README, FAQ, INSTALL)

## Test plan
- [x] Verified skill structure (5 files, ~80 line entry point)
- [x] Tested with subagent - correctly identifies Colima-specific troubleshooting
- [ ] Verify skill activates on Docker daemon connection errors
- [ ] Test with real Colima scenarios