### PR TITLE
feat(second-brain): add note routing system with confidence scoring

### DIFF
--- a/docs/plans/2025-01-22-auto-versioning-design.md
+++ b/docs/plans/2025-01-22-auto-versioning-design.md
@@ -1,0 +1,160 @@
+# Auto-Versioning Design
+
+Automatic version bumping for plugins using git hooks and conventional commits.
+
+## Problem
+
+1. **New plugins don't get registered** - Adding a plugin directory doesn't add it to `marketplace.json`
+2. **Changes don't bump versions** - The marketplace only sees updates when versions change
+
+## Solution
+
+Two git hooks via [hk](https://github.com/jdx/hk):
+
+| Hook | Purpose |
+|------|---------|
+| `pre-commit` | Block if new plugins aren't in `marketplace.json` |
+| `commit-msg` | Validate conventional commit format, bump versions, amend commit |
+
+## Conventional Commit Mapping
+
+| Prefix | Bump |
+|--------|------|
+| `feat:` | minor |
+| `fix:`, `perf:`, `refactor:` | patch |
+| `BREAKING CHANGE:` in body or `!` | major |
+| `chore:`, `docs:`, `test:`, `ci:`, `style:`, `build:` | none |
+
+## Multi-Plugin Commits
+
+When a commit touches multiple plugins:
+
+- **No scope** (`feat: add discovery`) → bump ALL changed plugins
+- **With scope** (`feat(tool-routing): add discovery`) → bump ONLY the scoped plugin
+
+This lets you make focused bumps when needed while defaulting to bumping everything that changed.
+
+## Files
+
+```
+hk.pkl                                    # hk configuration
+scripts/hooks/
+├── check-marketplace-registry.sh         # pre-commit guard
+└── version-bump.py                       # commit-msg validation + bumping
+```
+
+### hk.pkl
+
+```pkl
+amends "package://pkg.hk.jdx.dev/hk@1/Config.pkl"
+
+linters {
+  ["check-registry"] {
+    check = "scripts/hooks/check-marketplace-registry.sh"
+  }
+  ["version-bump"] {
+    check = "uv run scripts/hooks/version-bump.py {{commit_msg_file}}"
+  }
+}
+
+hooks {
+  ["pre-commit"] {
+    steps = ["check-registry"]
+  }
+  ["commit-msg"] {
+    steps = ["version-bump"]
+  }
+}
+```
+
+### check-marketplace-registry.sh
+
+**Logic:**
+1. Find all directories matching `plugins/*/` containing `.claude-plugin/plugin.json`
+2. Parse `.claude-plugin/marketplace.json` to get registered plugin names
+3. If any plugin dirs aren't registered, exit 1 with message
+
+**Output on failure:**
+```
+ERROR: Unregistered plugins detected
+
+The following plugins are not in .claude-plugin/marketplace.json:
+  - my-new-plugin
+
+Add them to marketplace.json before committing:
+  "my-new-plugin": { "source": "./plugins/my-new-plugin" }
+```
+
+### version-bump.py
+
+**Logic:**
+1. Parse commit message from file passed as argument
+2. Validate conventional commit format (exit 1 if invalid)
+3. Determine bump type from commit type
+4. If bump type is "none" (chore, docs, etc.), exit 0 early
+5. Get staged files via `git diff --cached --name-only`
+6. Extract unique plugin names from `plugins/{name}/...` paths
+7. If scope matches a plugin name, filter to only that plugin
+8. For each affected plugin:
+   - Read `.claude-plugin/plugin.json`
+   - Increment version according to bump type
+   - Write updated file
+   - Stage with `git add`
+9. Amend commit with `git commit --amend --no-edit`
+
+**Commit message validation pattern:**
+```
+^(feat|fix|perf|refactor|chore|docs|test|ci|style|build)(\(.+\))?!?: .+
+```
+
+**Output on invalid message:**
+```
+ERROR: Commit message doesn't follow conventional commit format
+
+Expected: <type>(<scope>): <description>
+Got: "updated stuff"
+
+Valid types: feat, fix, perf, refactor, chore, docs, test, ci, style, build
+Examples:
+  feat: add new route type
+  fix(tool-routing): handle missing config
+  chore: update dependencies
+```
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No plugins changed | Skip versioning, just validate format |
+| Invalid version in plugin.json | Error with clear message |
+| Scope doesn't match any plugin | Warning, bump all changed plugins anyway |
+| Amend fails | Warning (don't fail commit), user can amend manually |
+
+## Setup
+
+1. Install hk: `mise use -g hk` or `brew install jdx/tap/hk`
+2. Run `hk install` in repo root
+
+## CLAUDE.md Update
+
+Add to CLAUDE.md:
+
+```markdown
+## Versioning
+
+This repo uses conventional commits with automatic version bumping.
+
+**Commit format:** `<type>(<scope>): <description>`
+
+| Type | Version Bump |
+|------|--------------|
+| `feat` | minor |
+| `fix`, `perf`, `refactor` | patch |
+| `chore`, `docs`, `test`, `ci` | none |
+
+Add `BREAKING CHANGE:` in body or `!` after type for major bump.
+
+**Multi-plugin commits:** All changed plugins are bumped unless you specify a scope matching a plugin name.
+
+**New plugins:** Must be added to `.claude-plugin/marketplace.json` before committing.
+```

--- a/plugins/second-brain/commands/distill-conversation.md
+++ b/plugins/second-brain/commands/distill-conversation.md
@@ -15,7 +15,11 @@ If missing:
 Second brain not configured. Run /second-brain:setup first.
 ```
 
-Load skill references for note patterns and naming.
+Load skill references:
+- `second-brain:obsidian` for tool mechanics
+- `references/zettelkasten.md` for naming
+- `references/note-patterns.md` for Insight Note template
+- `references/routing.md` for destination matching
 
 ## Step 2: Review the Conversation
 
@@ -82,24 +86,53 @@ All captured to inbox.
 
 ## Step 6: Batch Routing
 
-Analyze captured notes:
+Load `references/routing.md` and analyze all captured notes together.
 
+**1. Discover vault structure once:**
+```bash
+ls -d "{vault}"/*Areas*/*/     2>/dev/null
+ls -d "{vault}"/*Resources*/*/ 2>/dev/null
+ls -d "{vault}"/*Projects*/*/  2>/dev/null
+```
+
+**2. Score each captured note against discovered destinations**
+
+**3. Present batch summary table:**
 ```
 Analyzing captured notes for routing...
 
-1. "{insight1}" → looks like it belongs in {suggested path}
-2. "{insight2}" → looks like it belongs in {suggested path}
-3. "{insight3}" → no clear match, recommend leaving in inbox
+| Note | Suggested Destination | Confidence |
+|------|----------------------|------------|
+| "insight about caching" | Areas/AI/agentic development/ | High (82%) |
+| "redis session pattern" | Resources/software engineering/ | Medium (55%) |
+| "debugging approach" | (leave in inbox) | None |
+
+Routing explanations:
+- "insight about caching" → keyword "claude" matches, related notes exist
+- "redis session pattern" → generic architecture fit
+- "debugging approach" → no strong destination match
 ```
 
-Use AskUserQuestion:
+**4. Use AskUserQuestion:**
 
 **Question:** "How should I route these?"
 
 **Options:**
-1. Route all as suggested
+1. Route all as suggested (Recommended)
 2. Route individually (I'll ask about each)
 3. Leave all in inbox for now
+
+**5. Execute based on selection:**
+- "Route all": Move files with confidence > 20% to suggested destinations
+- "Route individually": Use AskUserQuestion for each note separately
+- "Leave all": Skip routing, notes stay in inbox
+
+```bash
+# For each routed note:
+mv "{inbox}/{filename}" "{vault}/{destination}/"
+```
+
+**Important:** Only suggest destinations that exist (from `ls` output). Never suggest paths that weren't discovered.
 
 ## Constraints
 

--- a/plugins/second-brain/commands/insight.md
+++ b/plugins/second-brain/commands/insight.md
@@ -22,6 +22,7 @@ Load skill references:
 - `second-brain:obsidian` for tool mechanics
 - `references/zettelkasten.md` for naming
 - `references/note-patterns.md` for Insight Note template
+- `references/routing.md` for destination matching
 
 ## Step 2: Identify the Insight
 
@@ -86,37 +87,69 @@ Captured while {brief description of what you were working on/discussing}.
 *Captured via /second-brain:insight*
 ```
 
-## Step 6: Confirm and Analyze
+## Step 6: Confirm and Analyze for Routing
 
-After writing:
+After writing, confirm capture:
 ```
 ✓ Captured to inbox: {filename}
 
 Analyzing for routing...
 ```
 
-Search vault for related notes:
-- Grep for similar keywords
-- Check Projects, Areas, Resources folders
-- Look for existing notes on same topic
+Load `references/routing.md` and follow the algorithm:
+
+**1. Discover vault structure:**
+```bash
+ls -d "{vault}"/*Areas*/*/     2>/dev/null
+ls -d "{vault}"/*Resources*/*/ 2>/dev/null
+ls -d "{vault}"/*Projects*/*/  2>/dev/null
+```
+
+**2. Extract signals from captured note:**
+- Keywords from title and body
+- Content category (architecture, debugging, tool config, etc.)
+- Source context from provenance (repo, branch)
+
+**3. Score each discovered destination:**
+- Keyword match in folder name (40%)
+- Related notes exist in folder (30%)
+- PARA category fit (20%)
+- Recency of folder activity (10%)
+
+**4. Calculate confidence levels:**
+- High (80-100%): Strong match + related notes
+- Medium (50-79%): Partial match
+- Low (20-49%): Weak signals
+- None (<20%): Leave in inbox
 
 ## Step 7: Suggest Routing
 
-Show findings:
+Present findings with explanations:
 ```
-Found related notes:
-- {path/to/related-note.md}
-- {path/to/another-related.md}
+Routing suggestions for "{filename}":
 
-This looks like: {category - e.g., "architecture decision", "debugging pattern"}
+1. **{Areas/path/}** (85% - High)
+   → Matches keywords: "keyword1", "keyword2"
+   → Related note exists: "{related-note.md}"
+
+2. **{Resources/path/}** (48% - Low)
+   → Generic category fit
+
+3. **Leave in Inbox** (Safe default)
+   → Route later when destination is clearer
 ```
 
-Use AskUserQuestion with options:
-1. {Best matching location} (Recommended)
-2. {Second best location}
-3. Leave in inbox for now
+Use AskUserQuestion with discovered options:
+- Only include destinations that actually exist (from `ls` output)
+- Show confidence and explanation for each
+- Always include "Leave in inbox for now" option
 
-If user selects destination, move the file there.
+If user selects a destination, move the file:
+```bash
+mv "{inbox}/{filename}" "{vault}/{selected-destination}/"
+```
+
+If all destinations score <20%, recommend inbox without asking.
 
 ## Constraints
 

--- a/plugins/second-brain/commands/route.md
+++ b/plugins/second-brain/commands/route.md
@@ -1,0 +1,151 @@
+---
+description: Route notes from inbox to appropriate vault destinations
+argument-hint: [filename | "all"]
+---
+
+# Route Notes
+
+Route notes from inbox to appropriate destinations in your vault.
+
+## Step 1: Load Configuration
+
+Read `~/.claude/second-brain.md` for vault path.
+
+If missing:
+```
+Second brain not configured. Run /second-brain:setup first.
+```
+
+Load skill references:
+- `second-brain:obsidian` for tool mechanics
+- `references/routing.md` for routing algorithm
+
+## Step 2: Identify Notes to Route
+
+**If argument is a filename:**
+Look for that file in inbox. If not found, search vault.
+
+**If argument is "all":**
+List all files in inbox for batch routing.
+
+**If no argument:**
+List inbox contents and let user select:
+
+```bash
+ls "{vault}/{inbox}/"
+```
+
+```
+Notes in inbox:
+1. 202601251430 redis-session-caching.md
+2. 202601251445 claude-code-hooks.md
+3. 202601251500 debugging-approach.md
+
+Which note(s) would you like to route?
+```
+
+Use AskUserQuestion with multi-select to let user choose.
+
+## Step 3: Discover Vault Structure
+
+```bash
+ls -d "{vault}"/*Areas*/*/     2>/dev/null
+ls -d "{vault}"/*Resources*/*/ 2>/dev/null
+ls -d "{vault}"/*Projects*/*/  2>/dev/null
+```
+
+Build destination map from actual paths only.
+
+## Step 4: Analyze and Score
+
+For each selected note, follow `references/routing.md` algorithm:
+
+1. **Extract signals** from note content:
+   - Keywords from title (after Zettelkasten prefix)
+   - Key terms from body
+   - Category (architecture, debugging, tool, etc.)
+   - Source context from frontmatter
+
+2. **Score each destination:**
+   - Keyword match in folder name (40%)
+   - Related notes exist in folder (30%)
+   - PARA category fit (20%)
+   - Recency of folder activity (10%)
+
+3. **Calculate confidence:**
+   - High (80-100%): Strong match
+   - Medium (50-79%): Partial match
+   - Low (20-49%): Weak signals
+   - None (<20%): Leave in inbox
+
+## Step 5: Present Recommendations
+
+**For single note:**
+```
+Routing suggestions for "202601251430 redis-session-caching.md":
+
+1. **Areas/AI/agentic development/** (85% - High)
+   → Matches keywords: "caching", "session"
+   → Related note exists: "Redis patterns.md"
+
+2. **Resources/software engineering/** (48% - Low)
+   → Generic architecture fit
+
+3. **Leave in Inbox** (Safe default)
+```
+
+Use AskUserQuestion with options from discovered paths.
+
+**For multiple notes:**
+```
+| Note | Suggested Destination | Confidence |
+|------|----------------------|------------|
+| "redis-session-caching" | Areas/AI/agentic development/ | High (85%) |
+| "claude-code-hooks" | Areas/AI/agentic development/ | High (92%) |
+| "debugging-approach" | (leave in inbox) | None |
+```
+
+Use AskUserQuestion:
+1. Route all as suggested (Recommended)
+2. Route individually
+3. Leave all in inbox
+
+## Step 6: Execute Moves
+
+For each note being routed:
+
+```bash
+mv "{inbox}/{filename}" "{vault}/{destination}/"
+```
+
+## Step 7: Report Success
+
+```
+✓ Moved "redis-session-caching.md" → Areas/AI/agentic development/
+✓ Moved "claude-code-hooks.md" → Areas/AI/agentic development/
+○ Left "debugging-approach.md" in inbox (no clear destination)
+
+3 notes processed: 2 routed, 1 remaining in inbox
+```
+
+## Examples
+
+```bash
+# Route a specific note
+/second-brain:route redis-session-caching
+
+# Route all inbox notes
+/second-brain:route all
+
+# Interactive: list inbox and select
+/second-brain:route
+```
+
+## Constraints
+
+- **Never suggest non-existent paths** - Only use `ls` output
+- **Always include inbox option** - Safe default for uncertain cases
+- **Show reasoning** - Users should understand why
+- **Preserve filenames** - Don't rename when moving
+- **Two-level depth max** - Don't suggest deeply nested paths
+- **Respect emoji prefixes** - Use exact folder names from filesystem

--- a/plugins/second-brain/skills/obsidian/references/routing.md
+++ b/plugins/second-brain/skills/obsidian/references/routing.md
@@ -1,0 +1,170 @@
+# Note Routing Reference
+
+Systematic algorithm for discovering vault structure and matching notes to destinations.
+
+## Step 1: Discover Vault Structure
+
+**Never guess at paths.** Only suggest destinations that actually exist.
+
+```bash
+# List actual PARA folders (handle emoji prefixes)
+ls -d "{vault}"/*Projects*/*/  2>/dev/null
+ls -d "{vault}"/*Areas*/*/     2>/dev/null
+ls -d "{vault}"/*Resources*/*/ 2>/dev/null
+```
+
+Build a destination map from the output:
+
+```
+Available Destinations:
+- Areas/AI/agentic development/
+- Areas/gusto/
+- Areas/health/
+- Resources/software engineering/
+- Resources/tools/
+- Projects/home-renovation/
+```
+
+**Important:**
+- Use exact folder names from `ls` output (including emoji prefixes)
+- Only go two levels deep (Category/Subcategory/)
+- Include Inbox as always-available option
+
+---
+
+## Step 2: Extract Note Signals
+
+From the note being routed, extract:
+
+### Keywords
+- Words from title (after timestamp prefix)
+- Key terms from body content
+- Tags if present
+
+### Content Category
+- Architecture decision
+- Debugging pattern
+- Tool configuration
+- Process improvement
+- Domain knowledge
+- Meeting notes
+- Personal insight
+
+### Source Context
+From frontmatter provenance:
+- `repo:` → maps to work projects
+- `branch:` → topic hints
+- Conversation topic if captured via `/insight`
+
+---
+
+## Step 3: Match Destinations
+
+Score each discovered destination against the note:
+
+| Signal | Weight | Description |
+|--------|--------|-------------|
+| Keyword in folder name | 40% | Direct match: "claude" in title → "AI/agentic development/" |
+| Related notes in folder | 30% | Grep for similar terms in destination folder |
+| PARA category fit | 20% | Is this ongoing (Area), reference (Resource), or active (Project)? |
+| Recency | 10% | Recently modified files in folder suggest active use |
+
+### Matching Examples
+
+**Note:** `202601251430 redis-session-caching.md`
+- Keywords: "redis", "session", "caching"
+- Category: Architecture decision
+
+**Scoring:**
+- `Resources/caching/` → 60% (keyword match)
+- `Areas/gusto/` → 45% (repo context from work)
+- `Resources/software engineering/` → 35% (generic fit)
+
+---
+
+## Step 4: Confidence Levels
+
+| Level | Score | Interpretation |
+|-------|-------|----------------|
+| **High** | 80-100% | Strong keyword match + related notes exist |
+| **Medium** | 50-79% | Partial match or category-only fit |
+| **Low** | 20-49% | Weak signals, might fit |
+| **None** | <20% | No meaningful match - leave in inbox |
+
+### When to Recommend Inbox
+
+- No destination scores above 20%
+- Multiple destinations score equally (unclear fit)
+- Note is too generic to categorize
+- User should decide after more context emerges
+
+---
+
+## Step 5: Present with Explanations
+
+Always show reasoning so users understand and can correct:
+
+```
+Routing suggestions for "202601251430 redis-session-caching.md":
+
+1. **Areas/AI/agentic development/** (88% - High)
+   → Matches keywords: "claude", "code"
+   → Related note exists: "Claude Code.md"
+
+2. **Resources/software engineering/** (52% - Medium)
+   → Generic architecture reference fit
+   → No specific keyword match
+
+3. **Leave in Inbox** (Safe default)
+   → Route later when clearer destination emerges
+```
+
+### Presentation Rules
+
+- Show top 2-3 destinations (not all)
+- Include confidence level and percentage
+- Explain WHY each destination matched
+- Always include "Leave in Inbox" option
+- Put recommended option first with "(Recommended)" suffix
+
+---
+
+## Implementation Pattern
+
+When implementing routing in a command:
+
+```markdown
+## Routing Analysis
+
+1. Discover destinations:
+   ```bash
+   ls -d "{vault}"/*Areas*/*/
+   ls -d "{vault}"/*Resources*/*/
+   ls -d "{vault}"/*Projects*/*/
+   ```
+
+2. For each note, extract signals (keywords, category, source)
+
+3. Score each destination using the weighting table
+
+4. Present using AskUserQuestion:
+   - Option 1: Highest-scoring destination (if >50%)
+   - Option 2: Second-highest (if >30%)
+   - Option 3: Leave in Inbox
+
+5. Execute move on selection:
+   ```bash
+   mv "{inbox}/{filename}" "{vault}/{selected-destination}/"
+   ```
+```
+
+---
+
+## Constraints
+
+- **Never suggest non-existent paths** - Only paths from `ls` output
+- **Always include inbox option** - Safe default for uncertain cases
+- **Show reasoning** - Users should understand why
+- **Two-level depth max** - Don't suggest `Area/Sub/Sub/Sub/`
+- **Preserve filenames** - Don't rename when moving
+- **Respect emoji prefixes** - Use exact folder names from filesystem


### PR DESCRIPTION
## Summary

- Add systematic routing algorithm that discovers actual vault folders via filesystem (handles emoji prefixes like `2.🏡 Areas/`)
- Implement confidence scoring: keyword match (40%), related notes (30%), PARA fit (20%), recency (10%)
- Create new `/second-brain:route` command for routing inbox notes
- Update `/second-brain:insight` and `/second-brain:distill-conversation` to use the new routing logic

## Test plan

- [ ] Verify route discovery works: `ls -d ~/Vaults/pickled-knowledge/pickled-knowledge/*Areas*/*/`
- [ ] Test `/second-brain:insight` with a Claude Code insight - should suggest `Areas/AI/agentic development/`
- [ ] Test `/second-brain:distill-conversation` - verify batch routing table shows real folders
- [ ] Test `/second-brain:route` command with an inbox note

🤖 Generated with [Claude Code](https://claude.com/claude-code)