### PR TITLE
feat(second-brain): add vault disambiguation rules for routing

### DIFF
--- a/plugins/second-brain/commands/distill-conversation.md
+++ b/plugins/second-brain/commands/distill-conversation.md
@@ -108,25 +108,39 @@ ls -d "{vault}"/*Resources*/*/ 2>/dev/null
 ls -d "{vault}"/*Projects*/*/  2>/dev/null
 ```
 
-**2. Score each captured note against discovered destinations**
+**2. Load disambiguation rules from vault CLAUDE.md:**
+- Find `### Disambiguation:` sections
+- Extract key questions, category tables, edge case mappings
+- These override generic matching for semantically similar areas
 
-**3. Present batch summary table:**
+**3. Score each captured note:**
+
+*Apply disambiguation rules first (if loaded):*
+- Check edge case mappings (explicit rules)
+- Apply key question matches (+25% boost)
+- Apply category table matches (+15% boost)
+- Apply disambiguation mismatch penalty (-20%)
+
+*Then apply generic signals:*
+- Keyword match, related notes, PARA fit, recency
+
+**4. Present batch summary table:**
 ```
 Analyzing captured notes for routing...
 
-| Note | Suggested Destination | Confidence |
-|------|----------------------|------------|
-| "insight about caching" | Areas/AI/agentic development/ | High (82%) |
-| "redis session pattern" | Resources/software engineering/ | Medium (55%) |
-| "debugging approach" | (leave in inbox) | None |
+| Note | Suggested Destination | Confidence | Rule Applied |
+|------|----------------------|------------|--------------|
+| "insight about caching" | Areas/AI/agentic development/ | High (82%) | - |
+| "tmux-comma-parsing" | Areas/tool sharpening/ | High (95%) | edge case |
+| "debugging approach" | (leave in inbox) | None | - |
 
 Routing explanations:
 - "insight about caching" → keyword "claude" matches, related notes exist
-- "redis session pattern" → generic architecture fit
+- "tmux-comma-parsing" → vault rule: tmux config → tool sharpening
 - "debugging approach" → no strong destination match
 ```
 
-**4. Use AskUserQuestion:**
+**5. Use AskUserQuestion:**
 
 **Question:** "How should I route these?"
 
@@ -135,7 +149,7 @@ Routing explanations:
 2. Route individually (I'll ask about each)
 3. Leave all in inbox for now
 
-**5. Execute based on selection:**
+**6. Execute based on selection:**
 - "Route all": Move files with confidence > 20% to suggested destinations
 - "Route individually": Use AskUserQuestion for each note separately
 - "Leave all": Skip routing, notes stay in inbox

--- a/plugins/second-brain/commands/insight.md
+++ b/plugins/second-brain/commands/insight.md
@@ -123,14 +123,27 @@ ls -d "{vault}"/*Projects*/*/  2>/dev/null
 - Content category (architecture, debugging, tool config, etc.)
 - Source context from provenance (repo, branch)
 
-**3. Score each discovered destination:**
+**3. Load disambiguation rules from vault CLAUDE.md:**
+- Find `### Disambiguation:` sections
+- Extract key questions, category tables, edge case mappings
+- These override generic matching for semantically similar areas
+
+**4. Score each discovered destination:**
+
+*If disambiguation rules apply:*
+- Check edge case mappings first (explicit rules)
+- Apply key question matches (+25% boost)
+- Apply category table matches (+15% boost)
+- Apply disambiguation mismatch penalty (-20%)
+
+*Then apply generic signals:*
 - Keyword match in folder name (40%)
 - Related notes exist in folder (30%)
 - PARA category fit (20%)
 - Recency of folder activity (10%)
 
-**4. Calculate confidence levels:**
-- High (80-100%): Strong match + related notes
+**5. Calculate confidence levels:**
+- High (80-100%): Strong match, often with disambiguation support
 - Medium (50-79%): Partial match
 - Low (20-49%): Weak signals
 - None (<20%): Leave in inbox
@@ -144,6 +157,7 @@ Routing suggestions for "{filename}":
 1. **{Areas/path/}** (85% - High)
    → Matches keywords: "keyword1", "keyword2"
    → Related note exists: "{related-note.md}"
+   → [If disambiguation applied] Vault rule: "{edge case or key question}"
 
 2. **{Resources/path/}** (48% - Low)
    → Generic category fit
@@ -151,6 +165,8 @@ Routing suggestions for "{filename}":
 3. **Leave in Inbox** (Safe default)
    → Route later when destination is clearer
 ```
+
+When disambiguation rules influenced the result, explain which rule applied.
 
 Use AskUserQuestion with discovered options:
 - Only include destinations that actually exist (from `ls` output)

--- a/plugins/second-brain/skills/obsidian/SKILL.md
+++ b/plugins/second-brain/skills/obsidian/SKILL.md
@@ -81,8 +81,20 @@ Vaults should have a `CLAUDE.md` at root describing:
 - Routing rules
 - Naming conventions
 - References to methodology (PARA, Zettelkasten)
+- **Disambiguation rules** for semantically similar areas
 
 See `templates/vault-claude-md.md` for template.
+
+### Disambiguation Rules
+
+When a vault has areas with semantic overlap (e.g., "tool sharpening" vs "software engineering"), the vault CLAUDE.md can include `### Disambiguation:` sections that guide routing decisions.
+
+The routing algorithm checks for:
+- **Key questions** - Decision heuristics for each area
+- **Category tables** - Lists of tools/topics per area
+- **Edge case mappings** - Explicit rules for ambiguous cases
+
+See `references/routing.md` for the full disambiguation format and how to build custom rules.
 
 ## References
 
@@ -90,3 +102,4 @@ For methodology (tool-agnostic):
 - `references/para.md` - PARA organizational system
 - `references/zettelkasten.md` - Naming conventions
 - `references/note-patterns.md` - Note templates
+- `references/routing.md` - Routing algorithm with disambiguation support

--- a/plugins/second-brain/skills/obsidian/references/routing.md
+++ b/plugins/second-brain/skills/obsidian/references/routing.md
@@ -2,6 +2,8 @@
 
 Systematic algorithm for discovering vault structure and matching notes to destinations.
 
+**Key principle:** Vault-specific disambiguation rules take precedence over generic matching. Always check the vault's CLAUDE.md for routing guidance before scoring.
+
 ## Step 1: Discover Vault Structure
 
 **Never guess at paths.** Only suggest destinations that actually exist.
@@ -58,9 +60,95 @@ From frontmatter provenance:
 
 ---
 
-## Step 3: Match Destinations
+## Step 3: Load Vault Disambiguation Rules
 
-Score each discovered destination against the note:
+Read the vault's `CLAUDE.md` file and look for disambiguation sections.
+
+### Locate Disambiguation Sections
+
+Search for headers matching `### Disambiguation:` pattern:
+
+```markdown
+### Disambiguation: tool sharpening vs software engineering
+### Disambiguation: Areas vs Resources
+```
+
+### Extract Decision Criteria
+
+For each disambiguation section, extract:
+
+1. **Area definitions** - What belongs in each area
+   - Look for `#### {area-name}` subheaders
+   - Extract category tables and examples
+
+2. **Key questions** - Decision heuristics
+   - Pattern: `**Key question:** "..."`
+   - These are the primary decision criteria
+
+3. **Edge case mappings** - Explicit routing rules
+   - Look for tables with `| Scenario | Route to | Reasoning |`
+   - These override generic matching
+
+### Example Disambiguation Structure
+
+```markdown
+### Disambiguation: tool sharpening vs software engineering
+
+#### tool sharpening (MY workflow)
+Notes about tools I configure for **personal productivity**...
+| Category | Examples |
+|----------|----------|
+| Terminal/shell | tmux, ghostty, fish, zsh |
+| CLI utilities | fzf, ripgrep, jq |
+
+**Key question:** "Is this about how I set up MY machine?"
+
+#### software engineering (project ecosystem)
+Notes about tools tied to **language ecosystems**...
+| Category | Examples |
+|----------|----------|
+| Ruby ecosystem | rake, bundler, rubocop |
+| Build/CI tools | make, docker (for projects) |
+
+**Key question:** "Is this about how projects/codebases work?"
+
+#### Edge cases
+| Scenario | Route to | Reasoning |
+|----------|----------|-----------|
+| tmux config syntax | tool sharpening | MY terminal setup |
+| git aliases | tool sharpening | MY git workflow |
+| docker multi-stage builds | software engineering | Project patterns |
+```
+
+### If No Disambiguation Rules Found
+
+Proceed to Step 4 with generic matching only. The vault owner hasn't defined semantic boundaries yet.
+
+---
+
+## Step 4: Match Destinations
+
+Score each discovered destination against the note using both generic signals and vault-specific rules.
+
+### 4a: Apply Disambiguation Rules First
+
+If disambiguation rules were loaded in Step 3:
+
+1. **Check edge case mappings** - Does the note match an explicit rule?
+   - If yes: That destination gets +50% boost, others in the disambiguation get -20%
+   - Example: "tmux config" explicitly maps to "tool sharpening" → boost that destination
+
+2. **Apply key questions** - Which area's key question does the note answer?
+   - "Is this about how I set up MY machine?" → boost tool sharpening
+   - "Is this about how projects/codebases work?" → boost software engineering
+
+3. **Check category tables** - Does the note's tool/topic appear in a category list?
+   - "fzf" in tool sharpening's CLI utilities → boost tool sharpening
+   - "rubocop" in software engineering's Ruby ecosystem → boost software engineering
+
+### 4b: Generic Signal Scoring
+
+Apply baseline scoring to all destinations:
 
 | Signal | Weight | Description |
 |--------|--------|-------------|
@@ -69,24 +157,38 @@ Score each discovered destination against the note:
 | PARA category fit | 20% | Is this ongoing (Area), reference (Resource), or active (Project)? |
 | Recency | 10% | Recently modified files in folder suggest active use |
 
+### 4c: Combine Scores
+
+Final score = Generic score + Disambiguation adjustments
+
+- Edge case match: +50% to matched destination
+- Key question match: +25% to matched destination
+- Category table match: +15% to matched destination
+- Disambiguation mismatch: -20% (when another area in the disambiguation is preferred)
+
 ### Matching Examples
 
-**Note:** `202601251430 redis-session-caching.md`
-- Keywords: "redis", "session", "caching"
-- Category: Architecture decision
+**Note:** `202601281225 tmux conditional comma parsing conflict.md`
+- Keywords: "tmux", "conditional", "parsing"
+- Category: Tool configuration
 
-**Scoring:**
-- `Resources/caching/` → 60% (keyword match)
-- `Areas/gusto/` → 45% (repo context from work)
-- `Resources/software engineering/` → 35% (generic fit)
+**Without disambiguation:**
+- `Resources/programming/` → 55% (tmux is programming-adjacent)
+- `Areas/tool sharpening/` → 45% (keyword partial match)
+
+**With disambiguation rules:**
+- Edge case: "tmux config syntax → tool sharpening" matches → +50%
+- Key question: "Is this about MY machine?" → Yes → +25%
+- Final: `Areas/tool sharpening/` → 120% (capped at 95%)
+- Final: `Resources/programming/` → 35% (disambiguation mismatch: -20%)
 
 ---
 
-## Step 4: Confidence Levels
+## Step 5: Confidence Levels
 
 | Level | Score | Interpretation |
 |-------|-------|----------------|
-| **High** | 80-100% | Strong keyword match + related notes exist |
+| **High** | 80-100% | Strong match, often with disambiguation rule support |
 | **Medium** | 50-79% | Partial match or category-only fit |
 | **Low** | 20-49% | Weak signals, might fit |
 | **None** | <20% | No meaningful match - leave in inbox |
@@ -97,10 +199,11 @@ Score each discovered destination against the note:
 - Multiple destinations score equally (unclear fit)
 - Note is too generic to categorize
 - User should decide after more context emerges
+- Disambiguation rules conflict (both areas seem valid)
 
 ---
 
-## Step 5: Present with Explanations
+## Step 6: Present with Explanations
 
 Always show reasoning so users understand and can correct:
 
@@ -119,11 +222,19 @@ Routing suggestions for "202601251430 redis-session-caching.md":
    → Route later when clearer destination emerges
 ```
 
+When disambiguation rules influenced the result:
+```
+1. **Areas/tool sharpening/** (95% - High)
+   → Vault rule: "tmux config syntax" → tool sharpening
+   → Key question: "Is this about MY machine?" → YES
+```
+
 ### Presentation Rules
 
 - Show top 2-3 destinations (not all)
 - Include confidence level and percentage
 - Explain WHY each destination matched
+- Note when disambiguation rules applied
 - Always include "Leave in Inbox" option
 - Put recommended option first with "(Recommended)" suffix
 
@@ -145,14 +256,23 @@ When implementing routing in a command:
 
 2. For each note, extract signals (keywords, category, source)
 
-3. Score each destination using the weighting table
+3. Load disambiguation rules from vault CLAUDE.md:
+   - Read {vault}/CLAUDE.md
+   - Find `### Disambiguation:` sections
+   - Extract key questions, category tables, edge cases
 
-4. Present using AskUserQuestion:
+4. Score each destination:
+   - Apply disambiguation rules first (edge cases → key questions → categories)
+   - Then apply generic signal weights
+   - Combine scores with adjustments
+
+5. Present using AskUserQuestion:
    - Option 1: Highest-scoring destination (if >50%)
    - Option 2: Second-highest (if >30%)
    - Option 3: Leave in Inbox
+   - If disambiguation rule applied, note it in the explanation
 
-5. Execute move on selection:
+6. Execute move on selection:
    ```bash
    mv "{inbox}/{filename}" "{vault}/{selected-destination}/"
    ```
@@ -168,3 +288,115 @@ When implementing routing in a command:
 - **Two-level depth max** - Don't suggest `Area/Sub/Sub/Sub/`
 - **Preserve filenames** - Don't rename when moving
 - **Respect emoji prefixes** - Use exact folder names from filesystem
+
+---
+
+## Building Disambiguation Rules
+
+Vault owners can add disambiguation rules to their `CLAUDE.md` to improve routing accuracy for semantically similar areas.
+
+### When to Add Disambiguation Rules
+
+Add rules when:
+- Two areas have overlapping topics (e.g., "tool sharpening" vs "software engineering")
+- Notes frequently get misrouted to similar-sounding destinations
+- You have a clear mental model that keywords alone don't capture
+
+### Disambiguation Section Format
+
+```markdown
+### Disambiguation: {area1} vs {area2}
+
+Brief description of when this disambiguation applies.
+
+#### {area1} ({context hint})
+
+Notes about [what belongs here].
+
+| Category | Examples |
+|----------|----------|
+| {category1} | {tool1}, {tool2}, {tool3} |
+| {category2} | {tool4}, {tool5} |
+
+**Key question:** "{Question that, if answered YES, means route here}"
+
+#### {area2} ({context hint})
+
+Notes about [what belongs here].
+
+| Category | Examples |
+|----------|----------|
+| {category1} | {tool1}, {tool2} |
+
+**Key question:** "{Question that, if answered YES, means route here}"
+
+#### Edge cases
+
+| Scenario | Route to | Reasoning |
+|----------|----------|-----------|
+| {specific example} | {destination} | {why} |
+| {specific example} | {destination} | {why} |
+```
+
+### Key Question Design
+
+Good key questions are:
+- **Mutually exclusive** - Only one should answer YES for a given note
+- **Concrete** - About observable properties, not abstract qualities
+- **Simple** - Can be answered quickly by examining the note
+
+| Good | Bad |
+|------|-----|
+| "Is this about how I set up MY machine?" | "Is this technical?" |
+| "Is this about how projects/codebases work?" | "Is this important?" |
+| "Does this have a deadline?" | "Should I remember this?" |
+
+### Edge Case Table Design
+
+Use edge cases for:
+- **Ambiguous tools** - Tools that appear in multiple contexts (git, docker)
+- **Common confusions** - Topics you've seen misrouted before
+- **Exceptions** - Cases where the key question gives the wrong answer
+
+```markdown
+#### Edge cases
+
+| Scenario | Route to | Reasoning |
+|----------|----------|-----------|
+| git aliases, config | tool sharpening | MY git workflow |
+| git concepts, branching strategies | software engineering | How git works |
+| docker cleanup commands | tool sharpening | Local machine maintenance |
+| docker multi-stage builds | software engineering | Project patterns |
+```
+
+### Category Table Design
+
+Category tables help with keyword matching:
+
+```markdown
+| Category | Examples |
+|----------|----------|
+| Terminal/shell | tmux, ghostty, kitty, fish, zsh |
+| CLI utilities | fzf, ripgrep, jq, yq, fd, bat |
+```
+
+Tips:
+- List **specific tool names** - These become keywords
+- Group by **function** - Helps you think systematically
+- Include **common variations** - "vim", "neovim", "nvim"
+
+### Testing Your Rules
+
+After adding disambiguation rules:
+
+1. Review recent captures that were misrouted
+2. Run `/second-brain:route` on a test note
+3. Check if the explanation mentions your disambiguation rule
+4. Adjust key questions or edge cases if routing is still wrong
+
+### Evolving Rules Over Time
+
+- **Start minimal** - Add rules only when you see misrouting
+- **Be specific** - Vague rules don't help
+- **Update edge cases** - As you encounter new ambiguities
+- **Remove unused rules** - If areas become clearly distinct

--- a/plugins/second-brain/templates/vault-claude-md.md
+++ b/plugins/second-brain/templates/vault-claude-md.md
@@ -45,6 +45,37 @@ See `second-brain:obsidian/references/note-patterns.md` for templates:
 - Investigation notes
 - Project notes
 
+## Disambiguation Rules
+
+When routing suggests similar areas, add disambiguation rules to help the algorithm choose correctly. See `second-brain:obsidian/references/routing.md` for the full guide.
+
+### Example: Disambiguation Section
+
+```markdown
+### Disambiguation: {area1} vs {area2}
+
+#### {area1} ({context})
+Notes about [what belongs here].
+
+| Category | Examples |
+|----------|----------|
+| {category} | {tool1}, {tool2} |
+
+**Key question:** "{Question - if YES, route here}"
+
+#### {area2} ({context})
+Notes about [what belongs here].
+
+**Key question:** "{Question - if YES, route here}"
+
+#### Edge cases
+| Scenario | Route to | Reasoning |
+|----------|----------|-----------|
+| {example} | {area} | {why} |
+```
+
+Add disambiguation sections below for areas with semantic overlap in YOUR vault.
+
 ## Glossary
 
 See Glossary.md for transcription corrections (if using /second-brain:process-daily).


### PR DESCRIPTION
## Summary

- Routing algorithm now reads vault CLAUDE.md for `### Disambiguation:` sections
- Helps distinguish semantically similar areas (e.g., tool sharpening vs software engineering)
- Disambiguation rules include key questions, category tables, and edge case mappings

## Changes

- **routing.md**: Added Step 3 (load disambiguation), updated scoring with boosts/penalties
- **insight.md, route.md, distill-conversation.md**: Updated to apply disambiguation rules
- **SKILL.md**: Added disambiguation documentation
- **vault-claude-md.md**: Added template example for disambiguation sections

## How it works

When routing, Claude will:
1. Read vault CLAUDE.md for `### Disambiguation:` sections
2. Apply disambiguation rules first:
   - Edge case match: +50%
   - Key question match: +25%
   - Category table match: +15%
   - Disambiguation mismatch: -20%
3. Then apply generic signals (keyword, related notes, PARA fit, recency)
4. Present with rule explanations

## Test plan

- [ ] Test `/second-brain:route` on a tmux-related note with disambiguation rules in vault CLAUDE.md
- [ ] Verify the routing explanation mentions the vault rule that was applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)