### PR TITLE
feat(agent-meta): output /unpark command after parking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   ]
 }

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -80,4 +80,13 @@ Example: `jwt-authentication.md`, `fix-login-bug.md`
 
 ## After Parking
 
-Report: "Parked to `[path]`. Use `/unpark` in a new session to resume."
+Report:
+
+```
+Parked to `[path]`.
+
+To resume in a new session:
+/unpark [path]
+```
+
+The `/unpark [path]` command should be copy-pasteable so the user can easily resume.

--- a/scripts/analyze-version-bumps.sh
+++ b/scripts/analyze-version-bumps.sh
@@ -55,7 +55,7 @@ done
 
 # Get commits that are on current branch but not on main
 get_branch_commits() {
-    git log "$DEFAULT_BRANCH..HEAD" --pretty=format:"%H %s" 2>/dev/null || echo ""
+    git log "$DEFAULT_BRANCH..HEAD" --pretty=tformat:"%H %s" 2>/dev/null || echo ""
 }
 
 # Get the full commit message (including body) for a commit hash


### PR DESCRIPTION
## Summary
- The `/park` skill now outputs the specific `/unpark [path]` command after parking
- Makes it easy to copy-paste in a new session to resume work
- **Bonus fix:** Fixed version analysis bug where single-commit PRs weren't analyzed (missing trailing newline)

## Changes
1. `feat(agent-meta)`: Output `/unpark [path]` command after parking
2. `fix(repo)`: Use `tformat:` instead of `format:` in analyze-version-bumps.sh
3. `chore(agent-meta)`: Bump version 1.0.0 → 1.1.0

## Test plan
- [ ] Run `/park` on some work and verify it outputs the `/unpark [path]` command
- [ ] Verify the path is correct and copy-pasteable
- [ ] CI should now properly detect version bump requirements for single-commit PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)