### PR TITLE
fix(repo): use origin/main in CI and apply missed version bumps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,7 +24,7 @@
     {
       "name": "dev-tools",
       "source": "./plugins/dev-tools",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "mcpproxy",
@@ -34,12 +34,12 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     {
       "name": "tool-routing",
       "source": "./plugins/tool-routing",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "stay-on-target",


### PR DESCRIPTION
## Summary

- Fixes version bump detection in GitHub Actions CI where local `main` branch doesn't exist
- The `analyze-version-bumps.sh` script now prefers `origin/main` when available
- Applies missed version bumps for plugins affected by this bug

## Problem

GitHub Actions checkout with `fetch-depth: 0` fetches all commits but doesn't create a local `main` branch - only `origin/main` exists. The script was using `git log main..HEAD` which silently failed (stderr redirected, fallback to empty), returning no commits, causing CI to pass when it should have detected pending version bumps.

This allowed several PRs to be merged without proper version bumps.

## Solution

Added `resolve_branch_ref()` function that:
1. Tries `origin/$branch` first (works in CI)
2. Falls back to local `$branch` (works in local dev)
3. Maintains compatibility with existing behavior

## Missed Version Bumps Applied

| Plugin | Previous | New | Reason |
|--------|----------|-----|--------|
| tool-routing | 1.0.0 | 1.1.0 | manifest-driven discovery feature (PR #23) |
| dev-tools | 1.0.0 | 1.1.0 | hk skill, colima merge |
| second-brain | 1.1.0 | 1.2.0 | vault disambiguation |

## Test plan

- [ ] CI should pass on this PR
- [ ] After merge, verify `claude plugin update` sees new versions

🤖 Generated with [Claude Code](https://claude.ai/code)