### PR TITLE
test: verify CI version check - DELETE ME

### DIFF
--- a/plugins/tool-routing/.claude-plugin/plugin.json
+++ b/plugins/tool-routing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tool-routing",
-  "description": "Route tool calls to better alternatives (e.g., gh CLI instead of WebFetch for GitHub PRs)",
+  "description": "Route tool calls to better alternatives (e.g., gh CLI instead of WebFetch for GitHub PRs). TEST - DELETE ME",
   "author": {
     "name": "Josh Nichols",
     "email": "josh@technicalpickles.com"


### PR DESCRIPTION
Testing that CI now correctly detects missing version bumps. Should fail with 'version bump required' error.