### PR TITLE
feat(tool-routing): simplify test-claude to single command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "tool-routing",
       "source": "./plugins/tool-routing",
-      "version": "1.1.1"
+      "version": "1.2.0"
     },
     {
       "name": "stay-on-target",

--- a/bin/test-claude
+++ b/bin/test-claude
@@ -1,8 +1,13 @@
 #!/bin/bash
 # test-claude - Run Claude Code with isolated test configuration
 #
-# This wrapper sets up an isolated Claude config directory with only
+# This wrapper sets up an isolated Claude config directory with all
 # local plugins installed, useful for testing plugin hooks.
+#
+# Usage:
+#   ./bin/test-claude              # Setup (if needed), install plugins, start claude
+#   ./bin/test-claude --clean      # Remove test config and start fresh
+#   ./bin/test-claude -p "prompt"  # Pass args to claude
 
 set -e
 
@@ -25,36 +30,29 @@ usage() {
 Usage: test-claude [OPTIONS] [CLAUDE_ARGS...]
 
 Run Claude Code with an isolated test configuration.
+Automatically sets up config and installs all local plugins on first run.
 
 Options:
-  --setup       Initialize/reset the test environment
-  --install     Install tool-routing plugin to test config
-  --status      Show test environment status
-  --clean       Remove test config and start fresh
-  --reset       Reset settings.json (re-copies from global config)
+  --clean       Remove test config (next run will reinitialize)
   --help        Show this help message
 
 Examples:
-  test-claude --setup              # First-time setup
-  test-claude --install            # Install tool-routing plugin
-  test-claude                      # Run claude with test config
+  test-claude                      # Setup + install + run claude
   test-claude -p "test prompt"     # Run with print mode
+  test-claude --clean              # Remove test config
 EOF
 }
 
-setup_marketplace() {
-    log "Setting up local marketplace..."
-    
+setup_config() {
+    log "Setting up test config..."
+
     # Create directories
     mkdir -p "$TEST_CONFIG/plugins/cache"
     mkdir -p "$TEST_CONFIG/plugins/marketplaces"
-    
+
     # Symlink our repo as a marketplace
-    if [ ! -L "$TEST_CONFIG/plugins/marketplaces/local-test" ]; then
-        ln -sf "$REPO_ROOT" "$TEST_CONFIG/plugins/marketplaces/local-test"
-        log "Created marketplace symlink: local-test -> $REPO_ROOT"
-    fi
-    
+    ln -sf "$REPO_ROOT" "$TEST_CONFIG/plugins/marketplaces/local-test"
+
     # Create known_marketplaces.json
     cat > "$TEST_CONFIG/plugins/known_marketplaces.json" << EOF
 {
@@ -68,19 +66,17 @@ setup_marketplace() {
   }
 }
 EOF
-    log "Created known_marketplaces.json"
-    
+
     # Create settings.json with bedrock settings from global config
-    if [ ! -f "$TEST_CONFIG/settings.json" ]; then
-        GLOBAL_SETTINGS="$HOME/.claude/settings.json"
+    GLOBAL_SETTINGS="$HOME/.claude/settings.json"
 
-        if [ -f "$GLOBAL_SETTINGS" ]; then
-            # Extract bedrock-related settings from global config
-            ENV_SETTINGS=$(jq '.env // {}' "$GLOBAL_SETTINGS")
-            AWS_AUTH=$(jq -r '.awsAuthRefresh // empty' "$GLOBAL_SETTINGS")
+    if [ -f "$GLOBAL_SETTINGS" ]; then
+        # Extract bedrock-related settings from global config
+        ENV_SETTINGS=$(jq '.env // {}' "$GLOBAL_SETTINGS")
+        AWS_AUTH=$(jq -r '.awsAuthRefresh // empty' "$GLOBAL_SETTINGS")
 
-            # Build settings with bedrock config
-            cat > "$TEST_CONFIG/settings.json" << EOF
+        # Build settings with bedrock config
+        cat > "$TEST_CONFIG/settings.json" << EOF
 {
   "env": $ENV_SETTINGS,
   $([ -n "$AWS_AUTH" ] && echo "\"awsAuthRefresh\": \"$AWS_AUTH\",")
@@ -96,10 +92,9 @@ EOF
   "hooks": {}
 }
 EOF
-            log "Created settings.json with bedrock config from global settings"
-        else
-            # Fallback to minimal settings
-            cat > "$TEST_CONFIG/settings.json" << EOF
+    else
+        # Fallback to minimal settings
+        cat > "$TEST_CONFIG/settings.json" << EOF
 {
   "permissions": {
     "allow": [
@@ -113,95 +108,37 @@ EOF
   "hooks": {}
 }
 EOF
-            log "Created minimal settings.json (no global config found)"
-        fi
     fi
-    
+
     # Create empty installed_plugins.json
-    if [ ! -f "$TEST_CONFIG/plugins/installed_plugins.json" ]; then
-        echo '{"version": 2, "plugins": {}}' > "$TEST_CONFIG/plugins/installed_plugins.json"
-        log "Created installed_plugins.json"
-    fi
-    
-    log "Setup complete!"
+    echo '{"version": 2, "plugins": {}}' > "$TEST_CONFIG/plugins/installed_plugins.json"
 }
 
-install_plugin() {
-    local plugin="${1:-tool-routing}"
-    log "Installing $plugin from local-test marketplace..."
-    
-    # Run claude plugin install with our test config
-    CLAUDE_CONFIG_DIR="$TEST_CONFIG" claude plugin install "$plugin@local-test"
-    
-    log "Plugin installed. Restart claude to load hooks."
-}
+install_all_plugins() {
+    log "Installing plugins from local-test marketplace..."
 
-show_status() {
-    log "Test environment status:"
-    echo ""
-    
-    if [ -d "$TEST_CONFIG" ]; then
-        echo "Config directory: $TEST_CONFIG"
-        echo ""
-        
-        echo "Marketplaces:"
-        if [ -f "$TEST_CONFIG/plugins/known_marketplaces.json" ]; then
-            cat "$TEST_CONFIG/plugins/known_marketplaces.json" | jq -r 'keys[]' 2>/dev/null || echo "  (error reading)"
-        else
-            echo "  (none)"
+    # Find all plugins with .claude-plugin directories
+    for plugin_dir in "$REPO_ROOT"/plugins/*/; do
+        if [ -d "$plugin_dir/.claude-plugin" ]; then
+            plugin_name=$(basename "$plugin_dir")
+            log "  Installing $plugin_name..."
+            CLAUDE_CONFIG_DIR="$TEST_CONFIG" claude plugin install "$plugin_name@local-test" 2>/dev/null || {
+                warn "  Failed to install $plugin_name (may not be in marketplace.json)"
+            }
         fi
-        echo ""
-        
-        echo "Installed plugins:"
-        if [ -f "$TEST_CONFIG/plugins/installed_plugins.json" ]; then
-            cat "$TEST_CONFIG/plugins/installed_plugins.json" | jq -r '.plugins | keys[]' 2>/dev/null || echo "  (none or error)"
-        else
-            echo "  (none)"
-        fi
-        echo ""
-        
-        echo "Hooks in settings.json:"
-        if [ -f "$TEST_CONFIG/settings.json" ]; then
-            cat "$TEST_CONFIG/settings.json" | jq '.hooks' 2>/dev/null || echo "  (error reading)"
-        fi
-    else
-        warn "Test config not initialized. Run: test-claude --setup"
-    fi
+    done
 }
 
 clean_config() {
     warn "Removing test configuration..."
     rm -rf "$TEST_CONFIG"
-    log "Clean complete. Run --setup to reinitialize."
-}
-
-reset_settings() {
-    log "Resetting settings.json..."
-    rm -f "$TEST_CONFIG/settings.json"
-    setup_marketplace
+    log "Clean complete. Next run will reinitialize."
 }
 
 # Parse arguments
 case "${1:-}" in
-    --setup)
-        setup_marketplace
-        exit 0
-        ;;
-    --install)
-        shift
-        install_plugin "$@"
-        exit 0
-        ;;
-    --status)
-        show_status
-        exit 0
-        ;;
     --clean)
         clean_config
-        exit 0
-        ;;
-    --reset)
-        reset_settings
         exit 0
         ;;
     --help|-h)
@@ -210,12 +147,13 @@ case "${1:-}" in
         ;;
 esac
 
-# Verify setup exists
+# Setup if needed
 if [ ! -d "$TEST_CONFIG" ]; then
-    error "Test config not initialized. Run: test-claude --setup"
-    exit 1
+    setup_config
+    install_all_plugins
+    log "Setup complete!"
 fi
 
 # Run claude with test config
-log "Running claude with CLAUDE_CONFIG_DIR=$TEST_CONFIG"
+log "Starting claude with test config..."
 exec env CLAUDE_CONFIG_DIR="$TEST_CONFIG" claude "$@"

--- a/plugins/tool-routing/commands/validate.md
+++ b/plugins/tool-routing/commands/validate.md
@@ -22,19 +22,17 @@ This plugin is part of the `pickled-claude-plugins` monorepo. Routes are contrib
 Use `test-claude` to validate in an isolated environment without affecting your normal Claude config:
 
 ```bash
-# From repo root
-./bin/test-claude --setup
-./bin/test-claude --install tool-routing
-./bin/test-claude --install git
-./bin/test-claude --install ci-cd-tools
-./bin/test-claude --install dev-tools
+# From repo root - sets up config, installs all plugins, starts claude
+./bin/test-claude
 
-# Run validation in isolated env
+# Or run validation commands in the isolated env
 CLAUDE_CONFIG_DIR="$PWD/tmp/test-claude-config" \
   uv run --directory plugins/tool-routing tool-routing list
 
 # Should show: "Routes (merged from 4 sources)"
 ```
+
+Use `./bin/test-claude --clean` to remove the test config and start fresh.
 
 This approach:
 - Doesn't modify your user plugin state
@@ -82,7 +80,10 @@ Test that route patterns match correctly:
 Uses isolated config with all plugins installed:
 
 ```bash
-# After running Quick Validation setup above
+# Ensure test config exists (setup + exit immediately)
+./bin/test-claude -p ""
+
+# Run tests in isolated env
 CLAUDE_CONFIG_DIR="$PWD/tmp/test-claude-config" \
   uv run --directory plugins/tool-routing tool-routing test
 ```
@@ -148,8 +149,8 @@ If `tool-routing list` shows fewer sources than expected:
 
 1. **Use test-claude for reliable results** - avoids project path issues:
    ```bash
-   ./bin/test-claude --clean && ./bin/test-claude --setup
-   ./bin/test-claude --install tool-routing
+   ./bin/test-claude --clean                  # Remove old config
+   ./bin/test-claude -p ""                    # Reinitialize (exits immediately)
    CLAUDE_CONFIG_DIR="$PWD/tmp/test-claude-config" uv run --directory plugins/tool-routing tool-routing list
    ```
 

--- a/plugins/tool-routing/docs/route-discovery.md
+++ b/plugins/tool-routing/docs/route-discovery.md
@@ -238,7 +238,28 @@ Use `gh pr view <number>` for GitHub PRs.
    claude plugin list --json | jq '.[] | select(.enabled == true) | .id'
    ```
 
-3. **Stale plugin cache** - Reinstall the plugin
+3. **Project path mismatch (local-scoped plugins)** - Local-scoped plugins use **exact path matching**. The plugin's `projectPath` must exactly equal `CLAUDE_PROJECT_ROOT` (or cwd if unset).
+
+   Check the plugin's project path:
+   ```bash
+   claude plugin list --json | jq '.[] | select(.id | contains("your-plugin")) | {id, enabled, scope, projectPath}'
+   ```
+
+   If running from a subdirectory of the scoped project:
+   ```bash
+   # Won't work - cwd is plugins/tool-routing but plugin is scoped to repo root
+   cd plugins/tool-routing
+   uv run tool-routing list
+
+   # Works - explicitly set project root
+   CLAUDE_PROJECT_ROOT="/path/to/repo" uv run tool-routing list
+
+   # Or run from repo root
+   cd /path/to/repo
+   uv run --directory plugins/tool-routing tool-routing list
+   ```
+
+4. **Stale plugin cache** - Reinstall the plugin
    ```bash
    /plugin uninstall {plugin}@{marketplace}
    /plugin install {plugin}@{marketplace}


### PR DESCRIPTION
## Summary

- Simplifies `test-claude` from 6 commands to 1
- Auto-detects and installs all plugins with `.claude-plugin/` directories
- Removes `--setup`, `--install`, `--status`, `--reset` flags (only `--clean` remains)

## Before

```bash
./bin/test-claude --setup
./bin/test-claude --install tool-routing
./bin/test-claude --install git
./bin/test-claude --install ci-cd-tools
./bin/test-claude --install dev-tools
./bin/test-claude
```

## After

```bash
./bin/test-claude  # setup + install all + run claude
```

For validation without interactive session:
```bash
./bin/test-claude -p ""  # exits immediately after setup
```

## Test plan

- [x] `./bin/test-claude --help` shows simplified usage
- [x] `./bin/test-claude --clean` removes test config
- [x] `./bin/test-claude -p ""` sets up config and exits
- [x] `CLAUDE_CONFIG_DIR=... tool-routing list` shows 5 sources
- [x] `CLAUDE_CONFIG_DIR=... tool-routing test` passes (32 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
