### PR TITLE
feat(repo): rename marketplace to pickled-claude-plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "technicalpickles-marketplace",
+  "name": "pickled-claude-plugins",
   "description": "Personal plugins marketplace for Josh Nichols",
   "owner": {
     "name": "Josh Nichols",

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -18,6 +18,25 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
+      - name: Verify marketplace name matches repo name
+        run: |
+          # Extract repo name from git remote (works regardless of checkout directory)
+          REMOTE_URL=$(git remote get-url origin)
+          REPO_NAME=$(basename "$REMOTE_URL" .git)
+          MARKETPLACE_NAME=$(jq -r '.name' .claude-plugin/marketplace.json)
+
+          echo "Repository name (from remote): $REPO_NAME"
+          echo "Marketplace name: $MARKETPLACE_NAME"
+
+          if [[ "$REPO_NAME" != "$MARKETPLACE_NAME" ]]; then
+            echo ""
+            echo "❌ Marketplace name does not match repository name!"
+            echo "   Update .claude-plugin/marketplace.json 'name' field to: $REPO_NAME"
+            exit 1
+          fi
+
+          echo "✓ Marketplace name matches repository name"
+
       - name: Validate conventional commits
         run: |
           echo "Validating conventional commit format..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude Code Plugins Monorepo
 
-This repository contains Claude Code plugins for the `technicalpickles-marketplace`.
+This repository contains Claude Code plugins for the `pickled-claude-plugins`.
 
 ## Repository Structure
 
@@ -32,8 +32,8 @@ When installed, plugins are copied to cache. Environment:
 
 **Changes to local source require reinstall to take effect:**
 ```bash
-/plugin uninstall {plugin}@technicalpickles-marketplace
-/plugin install {plugin}@technicalpickles-marketplace
+/plugin uninstall {plugin}@pickled-claude-plugins
+/plugin install {plugin}@pickled-claude-plugins
 # Restart Claude Code
 ```
 
@@ -85,9 +85,9 @@ This can happen with directory-source marketplaces.
 
 **Fix:**
 ```bash
-rm -rf ~/.claude/plugins/cache/technicalpickles-marketplace/{plugin}/
-/plugin uninstall {plugin}@technicalpickles-marketplace
-/plugin install {plugin}@technicalpickles-marketplace
+rm -rf ~/.claude/plugins/cache/pickled-claude-plugins/{plugin}/
+/plugin uninstall {plugin}@pickled-claude-plugins
+/plugin install {plugin}@pickled-claude-plugins
 ```
 
 ## Environment Variables

--- a/plugins/agent-meta/README.md
+++ b/plugins/agent-meta/README.md
@@ -51,7 +51,7 @@ Default location: `.parkinglot/` in project root (gitignored).
 ## Installation
 
 ```bash
-/plugin install agent-meta@technicalpickles-marketplace
+/plugin install agent-meta@pickled-claude-plugins
 ```
 
 ## See Also

--- a/plugins/ci-cd-tools/README.md
+++ b/plugins/ci-cd-tools/README.md
@@ -35,5 +35,5 @@ Use when creating or modifying Buildkite pipeline configurations and working wit
 ## Installation
 
 ```bash
-/plugin install ci-cd-tools@technicalpickles-marketplace
+/plugin install ci-cd-tools@pickled-claude-plugins
 ```

--- a/plugins/debugging-tools/README.md
+++ b/plugins/debugging-tools/README.md
@@ -18,5 +18,5 @@ Use when user mentions MCPProxy/MCP tools or when you need to discover or call t
 ## Installation
 
 ```bash
-/plugin install debugging-tools@technicalpickles-marketplace
+/plugin install debugging-tools@pickled-claude-plugins
 ```

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -79,5 +79,5 @@ Update your branch with upstream changes, intelligently resolving conflicts.
 ## Installation
 
 ```bash
-/plugin install git@technicalpickles-marketplace
+/plugin install git@pickled-claude-plugins
 ```

--- a/plugins/mcpproxy/README.md
+++ b/plugins/mcpproxy/README.md
@@ -24,5 +24,5 @@ Use when working with MCPProxy and MCP tools - detecting connection status, disc
 ## Installation
 
 ```bash
-/plugin install mcpproxy@technicalpickles-marketplace
+/plugin install mcpproxy@pickled-claude-plugins
 ```

--- a/plugins/second-brain/README.md
+++ b/plugins/second-brain/README.md
@@ -5,7 +5,7 @@ Knowledge management for Obsidian vaults. Capture insights from conversations, p
 ## Installation
 
 ```bash
-claude plugin add technicalpickles-marketplace/second-brain
+claude plugin add pickled-claude-plugins/second-brain
 ```
 
 ## Quick Start

--- a/plugins/session-analyzer/README.md
+++ b/plugins/session-analyzer/README.md
@@ -39,5 +39,5 @@ Find failed tool calls in Claude session logs.
 ## Installation
 
 ```bash
-/plugin install session-analyzer@technicalpickles-marketplace
+/plugin install session-analyzer@pickled-claude-plugins
 ```

--- a/plugins/stay-on-target/README.md
+++ b/plugins/stay-on-target/README.md
@@ -18,7 +18,7 @@ A Claude Code plugin that enforces intentional, focused development.
 ## Installation
 
 ```bash
-/plugin install stay-on-target@technicalpickles-marketplace
+/plugin install stay-on-target@pickled-claude-plugins
 ```
 
 ## Configuration

--- a/plugins/tool-routing/README.md
+++ b/plugins/tool-routing/README.md
@@ -7,7 +7,7 @@ Intercepts tool calls and suggests better alternatives. When Claude tries to use
 Add to your Claude Code plugins:
 
 ```bash
-claude plugin add technicalpickles-marketplace/tool-routing
+claude plugin add pickled-claude-plugins/tool-routing
 ```
 
 ## Quick Example

--- a/plugins/working-in-monorepos/README.md
+++ b/plugins/working-in-monorepos/README.md
@@ -54,5 +54,5 @@ uv run pytest tests/ -v
 ## Installation
 
 ```bash
-/plugin install working-in-monorepos@technicalpickles-marketplace
+/plugin install working-in-monorepos@pickled-claude-plugins
 ```


### PR DESCRIPTION
## Summary

- Rename marketplace from `technicalpickles-marketplace` to `pickled-claude-plugins` to match the repository name
- Add CI check to verify marketplace name matches repo name (extracted from git remote)
- Update all plugin README installation instructions and CLAUDE.md documentation

## Test plan

- [ ] CI passes on this PR (validates the new marketplace name check)
- [ ] Verify marketplace name is correctly extracted from git remote in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
