### PR TITLE
feat(second-brain): link captured notes to daily note

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/commands/distill-conversation.md
+++ b/plugins/second-brain/commands/distill-conversation.md
@@ -6,6 +6,7 @@ allowed-tools:
   - Read(~/.claude/vaults/**/.obsidian/*.json)
   - Read(~/.claude/vaults/**/*.md)
   - Write(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/*.md)
   - Bash(ls:*)
   - Bash(date:*)
   - Bash(git rev-parse:*)
@@ -33,6 +34,7 @@ Load skill references:
 - `references/zettelkasten.md` for naming
 - `references/note-patterns.md` for Insight Note template
 - `references/routing.md` for destination matching
+- `references/daily-linking.md` for linking to daily note
 
 ## Step 2: Review the Conversation
 
@@ -160,6 +162,30 @@ mv "{inbox}/{filename}" "{vault}/{destination}/"
 ```
 
 **Important:** Only suggest destinations that exist (from `ls` output). Never suggest paths that weren't discovered.
+
+## Step 7: Batch Link to Daily Note
+
+Follow `references/daily-linking.md` to connect all captured notes to today's daily note.
+
+**1. Find today's daily note:**
+```bash
+cat "{vault}/.obsidian/daily-notes.json" 2>/dev/null
+date +"%Y-%m-%d"
+```
+
+**2. If daily note exists, batch-add links to `## Links` section:**
+```markdown
+- [[{filename1 without .md}]] - {description1}
+- [[{filename2 without .md}]] - {description2}
+- [[{filename3 without .md}]] - {description3}
+```
+
+**3. Confirm:**
+```
+✓ Linked {N} notes to daily note: Fleeting/{date}.md
+```
+
+If daily note doesn't exist, skip silently - notes are already captured.
 
 ## Constraints
 

--- a/plugins/second-brain/commands/insight.md
+++ b/plugins/second-brain/commands/insight.md
@@ -7,6 +7,7 @@ allowed-tools:
   - Read(~/.claude/vaults/**/.obsidian/*.json)
   - Read(~/.claude/vaults/**/*.md)
   - Write(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/*.md)
   - Bash(ls:*)
   - Bash(date:*)
   - Bash(git rev-parse:*)
@@ -36,6 +37,7 @@ Load skill references:
 - `references/zettelkasten.md` for naming
 - `references/note-patterns.md` for Insight Note template
 - `references/routing.md` for destination matching
+- `references/daily-linking.md` for linking to daily note
 
 ## Step 2: Identify the Insight
 
@@ -179,6 +181,29 @@ mv "{inbox}/{filename}" "{vault}/{selected-destination}/"
 ```
 
 If all destinations score <20%, recommend inbox without asking.
+
+## Step 8: Link to Daily Note
+
+Follow `references/daily-linking.md` to connect the captured note to today's daily note.
+
+**1. Find today's daily note:**
+```bash
+# Get daily notes folder from config
+cat "{vault}/.obsidian/daily-notes.json" 2>/dev/null
+date +"%Y-%m-%d"
+```
+
+**2. If daily note exists, add link to `## Links` section:**
+```markdown
+- [[{filename without .md}]] - {brief description of the insight}
+```
+
+**3. Confirm linking:**
+```
+✓ Linked to daily note: Fleeting/{date}.md
+```
+
+If daily note doesn't exist, skip silently - the note is already captured.
 
 ## Constraints
 

--- a/plugins/second-brain/skills/obsidian/SKILL.md
+++ b/plugins/second-brain/skills/obsidian/SKILL.md
@@ -103,3 +103,4 @@ For methodology (tool-agnostic):
 - `references/zettelkasten.md` - Naming conventions
 - `references/note-patterns.md` - Note templates
 - `references/routing.md` - Routing algorithm with disambiguation support
+- `references/daily-linking.md` - Linking captured notes to daily note

--- a/plugins/second-brain/skills/obsidian/references/daily-linking.md
+++ b/plugins/second-brain/skills/obsidian/references/daily-linking.md
@@ -1,0 +1,185 @@
+# Daily Note Linking Reference
+
+When capturing notes via `/insight` or `/distill-conversation`, link them back to today's daily note so there's a record of "what was captured today."
+
+## When to Link
+
+Link to daily note when:
+- A new note is captured via `/insight` or `/distill-conversation`
+- The daily note exists and has a `## Links` section (or can have one added)
+
+Do NOT link when:
+- Processing daily notes (`/process-daily`) - that's a different workflow
+- The note was already extracted from the daily note (would be circular)
+
+---
+
+## Step 1: Find Today's Daily Note
+
+Get daily note configuration from vault's `.obsidian/daily-notes.json`:
+
+```bash
+# Read daily notes folder from config
+cat "{vault}/.obsidian/daily-notes.json" 2>/dev/null
+```
+
+Parse the `folder` field. If config doesn't exist, check `~/.claude/second-brain.md` for `Daily notes:` setting.
+
+Construct today's path:
+```bash
+date +"%Y-%m-%d"
+# Result: {vault}/{folder}/{YYYY-MM-DD}.md
+```
+
+If the daily note doesn't exist, skip linking (don't create it).
+
+---
+
+## Step 2: Check for Links Section
+
+Read the daily note and look for `## Links` section.
+
+**If `## Links` exists:** Append to it.
+
+**If `## Links` doesn't exist but daily note does:** Add the section in the appropriate location (after `## Action Items` if present, otherwise near the top).
+
+---
+
+## Step 3: Format the Link Entry
+
+Use Obsidian wiki-link syntax with description:
+
+```markdown
+- [[{filename}]] - {brief description}
+```
+
+Where:
+- `{filename}` is the Zettelkasten filename without `.md` extension
+- `{brief description}` is a 3-8 word summary of what the note captures
+
+### Examples
+
+```markdown
+- [[202602051430 redis-session-caching]] - Redis vs Memcached for session storage
+- [[202602051445 golf-green-prompting-metaphor]] - Prompting as miniature golf geography
+- [[202602051500 pr-review-blast-radius]] - Review large PRs by blast radius, not lines
+```
+
+### Description Guidelines
+
+Good descriptions:
+- State the insight topic, not just keywords
+- Help future-you understand what this is about
+- Are scannable in a list
+
+| Good | Bad |
+|------|-----|
+| "Redis vs Memcached for session storage" | "Redis" |
+| "Prompting as miniature golf geography" | "prompting metaphor" |
+| "Review large PRs by blast radius" | "PR review thoughts" |
+
+---
+
+## Step 4: Append to Daily Note
+
+Insert the new link at the end of the `## Links` section:
+
+```bash
+# Pseudo-approach using Edit tool:
+# 1. Find the line with "## Links"
+# 2. Find the next ## header or EOF
+# 3. Insert new link line before that boundary
+```
+
+**Implementation:**
+
+If `## Links` section exists with content:
+```markdown
+## Links
+
+- [[202602051400 existing-note]] - existing description
+- [[202602051430 new-note]] - new description  ← append here
+```
+
+If `## Links` section exists but empty:
+```markdown
+## Links
+
+- [[202602051430 new-note]] - new description  ← add first entry
+```
+
+If adding `## Links` section (after `## Action Items`):
+```markdown
+## Action Items
+
+- [ ] Some task
+
+## Links
+
+- [[202602051430 new-note]] - new description  ← new section
+
+## Notes
+```
+
+---
+
+## Step 5: Confirm Linking
+
+After appending, confirm:
+
+```
+✓ Linked to daily note: Fleeting/{date}.md
+```
+
+If daily note doesn't exist or linking fails:
+```
+(Daily note not found - skipping link)
+```
+
+Don't fail the capture workflow if linking fails - the note is already saved.
+
+---
+
+## Implementation Pattern
+
+When integrating into a command:
+
+```markdown
+## After Capture: Link to Daily Note
+
+Follow `references/daily-linking.md` algorithm:
+
+1. Find today's daily note path from config
+2. If daily note exists, read it
+3. Locate or create `## Links` section
+4. Append wiki-link with description
+5. Confirm or note skipped
+
+This step is best-effort - don't fail capture if linking fails.
+```
+
+---
+
+## Batch Linking
+
+When capturing multiple notes (e.g., `/distill-conversation`), link them all in a single batch:
+
+```markdown
+## Links
+
+- [[202602051430 insight-one]] - first insight description
+- [[202602051432 insight-two]] - second insight description
+- [[202602051434 insight-three]] - third insight description
+```
+
+This avoids multiple edits to the daily note.
+
+---
+
+## Constraints
+
+- **Best-effort** - Don't fail capture if linking fails
+- **No duplicates** - Check if link already exists before adding
+- **Wiki-link format** - Use `[[filename]]` not `[text](path)`
+- **Descriptive text** - Always include meaningful description
+- **Preserve order** - Append to end of Links section (chronological)


### PR DESCRIPTION
## Summary

- Adds daily note linking to `/second-brain:insight` and `/second-brain:distill-conversation`
- When notes are captured, they're now linked back to today's daily note in the `## Links` section
- Creates a reference for "what did I capture today?"

## Changes

- **New**: `references/daily-linking.md` - shared algorithm for linking to daily notes
- **Updated**: `insight.md` - adds Step 8 for daily note linking after capture/routing
- **Updated**: `distill-conversation.md` - adds Step 7 for batch linking multiple captures
- **Updated**: Both commands now have `Edit` permission for appending to daily notes
- **Version**: Bumped second-brain from 1.2.0 → 1.3.0

## How it works

After capturing a note to inbox (and optionally routing it):
1. Find today's daily note from vault config
2. Append wiki-link + description to `## Links` section
3. Confirm or skip silently if daily note doesn't exist

Example daily note after capture:
```markdown
## Links

- [[202602051430 redis-session-caching]] - Redis vs Memcached for session storage
- [[202602051445 golf-green-prompting-metaphor]] - Prompting as miniature golf geography
```

## Test plan

- [ ] Run `/second-brain:insight` and verify link appears in daily note
- [ ] Run `/second-brain:distill-conversation` with multiple insights and verify batch linking
- [ ] Test when daily note doesn't exist (should skip silently)
- [ ] Test when `## Links` section doesn't exist (should create it)

🤖 Generated with [Claude Code](https://claude.ai/code)
