### PR TITLE
fix(repo): add PR comment permissions and version sync validation

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-commits:
     name: Validate Commits & Version Bumps

--- a/plugins/tool-routing/pyproject.toml
+++ b/plugins/tool-routing/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tool-routing"
-version = "0.1.0"
+version = "1.2.0"
 description = "Claude Code plugin for routing tool calls to better alternatives"
 requires-python = ">=3.9"
 dependencies = [

--- a/plugins/working-in-monorepos/pyproject.toml
+++ b/plugins/working-in-monorepos/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "working-in-monorepos-tests"
-version = "0.1.0"
+version = "1.0.0"
 description = "Tests for working-in-monorepos plugin"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
## Summary

- Add `pull-requests: write` permission to version-check workflow (fixes commenting on PRs)
- Add pre-commit check to ensure pyproject.toml versions match marketplace.json
- Sync existing mismatched versions

## Changes

1. **CI Permissions** (`.github/workflows/version-check.yml`)
   - Adds explicit permissions block for PR comments

2. **Version Sync Check** (`scripts/validate-plugin-versions.sh`)
   - New Check 5: Validates pyproject.toml versions match marketplace.json
   - Catches version drift in Python-based plugins

3. **Version Fixes**
   - tool-routing: 0.1.0 → 1.2.0
   - working-in-monorepos: 0.1.0 → 1.0.0

## Test plan

- [x] Pre-commit hook runs and passes
- [ ] CI workflow can now comment on PRs
- [ ] Version mismatch detected if introduced

Fixes gt-pyba

🤖 Generated with [Claude Code](https://claude.com/claude-code)