### PR TITLE
feat(ci-cd-tools): use bktide snapshot as primary investigation tool

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
     {
       "name": "ci-cd-tools",
       "source": "./plugins/ci-cd-tools",
-      "version": "1.0.1"
+      "version": "1.1.0"
     },
     {
       "name": "dev-tools",

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-commits:
     name: Validate Commits & Version Bumps

--- a/plugins/ci-cd-tools/skills/working-with-buildkite-builds/references/annotation-patterns.md
+++ b/plugins/ci-cd-tools/skills/working-with-buildkite-builds/references/annotation-patterns.md
@@ -65,10 +65,17 @@ Annotation response includes:
 - `body_html`: HTML content of the annotation
 - `created_at`: Timestamp
 
-### Via bktide
+### Via bktide snapshot (Preferred)
 
 ```bash
-npx bktide annotations gusto/zenpayroll#1359675
+npx bktide@latest snapshot <buildkite-url>
+# Annotations are saved to annotations.json in the snapshot directory
+```
+
+### Via bktide annotations command
+
+```bash
+npx bktide@latest annotations gusto/zenpayroll#1359675
 ```
 
 ## Interpreting Annotations

--- a/plugins/ci-cd-tools/skills/working-with-buildkite-builds/references/troubleshooting.md
+++ b/plugins/ci-cd-tools/skills/working-with-buildkite-builds/references/troubleshooting.md
@@ -165,7 +165,7 @@ console.log(job.finished_at); // Should not be null for terminal state
 Use MCP tools instead (preferred):
 
 ```javascript
-// Instead of: npx bktide build gusto/payroll-building-blocks/123
+// Instead of: npx bktide@latest build gusto/payroll-building-blocks#123
 mcp__MCPProxy__call_tool('buildkite:get_build', {
   org_slug: 'gusto',
   pipeline_slug: 'payroll-building-blocks',
@@ -183,10 +183,17 @@ npm install -g @anthropic/bktide
 
 ### Error: "Cannot read logs with bktide"
 
-**Cause**: bktide does not have log retrieval capability
+**Cause**: The `bktide build` command does not retrieve logs
 
 **Solution**:
-Use MCP tools for logs:
+Use `bktide snapshot` (preferred) - it captures logs automatically:
+
+```bash
+npx bktide@latest snapshot <buildkite-url>
+# Logs are saved to ./tmp/bktide/snapshots/<org>/<pipeline>/<build>/steps/*/log.txt
+```
+
+Or use MCP tools as fallback:
 
 ```javascript
 mcp__MCPProxy__call_tool('buildkite:get_logs', {
@@ -335,26 +342,28 @@ const failedRspecJobs = build.jobs.filter(
 ```
 Unable to investigate build failure?
 │
-├─ Can't get build details
-│  ├─ Check URL format → [url-parsing.md]
-│  ├─ Check org/pipeline slugs → lowercase, hyphenated
+├─ Start here: npx bktide@latest snapshot <url>
+│  └─ Handles URL parsing, metadata, and logs automatically
+│
+├─ Snapshot not working?
+│  ├─ Check BK_TOKEN environment variable
+│  ├─ Try MCP tools as fallback
 │  └─ Check auth → BUILDKITE_API_TOKEN configured
 │
-├─ Can't get job logs
-│  ├─ Using bktide? → Use MCP tools instead [tool-capabilities.md]
-│  ├─ Getting "job not found"? → Using step ID instead of job UUID [url-parsing.md]
-│  ├─ Empty logs? → Check job state (started_at, finished_at)
-│  └─ Still failing? → Report to human partner (may be auth/permission)
+├─ Need logs for specific job?
+│  ├─ Snapshot captures failed/broken steps by default
+│  ├─ Use --all flag to capture all steps
+│  └─ Or use MCP get_logs with job UUID (not step ID!)
 │
 ├─ Confused about job states
 │  ├─ Many "broken" jobs? → Normal, means skipped [buildkite-states.md]
 │  ├─ "soft_failed"? → Failed but non-blocking
-│  └─ Can't find failed job? → Filter with job_state: "failed"
+│  └─ Check manifest.json for exit codes
 │
 └─ Tool not working
+   ├─ bktide error? → Use MCP tools as fallback
    ├─ MCP tool error? → Check auth, verify slugs
-   ├─ bktide error? → Use MCP tools instead
-   └─ Script error? → Use MCP tools directly
+   └─ Report to human partner if all tools fail
 ```
 
 ## See Also

--- a/plugins/ci-cd-tools/skills/working-with-buildkite-builds/scripts/find-commit-builds.js
+++ b/plugins/ci-cd-tools/skills/working-with-buildkite-builds/scripts/find-commit-builds.js
@@ -52,7 +52,7 @@ for (let i = 2; i < args.length; i++) {
 
 function getPipelines() {
   try {
-    const cmd = `npx bktide pipelines --format json ${org}`;
+    const cmd = `npx bktide@latest pipelines --format json ${org}`;
     const output = execSync(cmd, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -65,7 +65,7 @@ function getPipelines() {
 
 function getBuildsForPipeline(pipeline, commit, branch) {
   try {
-    let cmd = `npx bktide builds --format json ${org}/${pipeline}`;
+    let cmd = `npx bktide@latest builds --format json ${org}/${pipeline}`;
     if (commit) {
       // Note: bktide might not support commit filtering directly,
       // so we'll fetch recent builds and filter

--- a/plugins/ci-cd-tools/skills/working-with-buildkite-builds/scripts/get-build-logs.js
+++ b/plugins/ci-cd-tools/skills/working-with-buildkite-builds/scripts/get-build-logs.js
@@ -37,7 +37,7 @@ function usage() {
 function getBuildDetails(org, pipeline, build) {
   try {
     const output = execSync(
-      `npx bktide build ${org}/${pipeline}/${build} --format json`,
+      `npx bktide@latest build ${org}/${pipeline}#${build} --format json`,
       { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }
     );
     return JSON.parse(output);

--- a/plugins/ci-cd-tools/skills/working-with-buildkite-builds/scripts/wait-for-build.js
+++ b/plugins/ci-cd-tools/skills/working-with-buildkite-builds/scripts/wait-for-build.js
@@ -68,7 +68,7 @@ function log(message) {
 
 function getBuildStatus() {
   try {
-    const cmd = `npx bktide build --format json gusto/${pipeline}#${buildNumber}`;
+    const cmd = `npx bktide@latest build --format json ${org}/${pipeline}#${buildNumber}`;
     const output = execSync(cmd, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

- Update working-with-buildkite-builds skill to use `npx bktide@latest snapshot` as the primary tool for investigating build failures
- Simplify investigation workflow from multiple MCP tool calls to a single command
- Update all bktide references to use `@latest` for fresh installs
- Fix hardcoded org bug in wait-for-build.js script

## Changes

**Tool hierarchy reorganization:**
- `bktide snapshot` is now the primary approach (parses URLs, captures metadata, annotations, and logs)
- MCP tools are now fallback for when bktide isn't available or for specific operations (wait_for_build, unblock_job)

**Workflow simplification:**
```bash
# Before: Multiple tool calls to parse URL, get build, find job UUID, get logs
# After:
npx bktide@latest snapshot <buildkite-url>
cat ./tmp/bktide/snapshots/<org>/<pipeline>/<build>/steps/<step-id>/log.txt
```

**Files updated:**
- `SKILL.md` - Main skill documentation
- `references/tool-capabilities.md` - Capability matrix and tool guidance
- `references/annotation-patterns.md` - Added snapshot method
- `references/troubleshooting.md` - Updated decision tree
- `scripts/*.js` - Updated to use `@latest`, fixed bugs

## Test plan

- [ ] Run `npx bktide@latest snapshot <url>` on a failed build
- [ ] Verify logs are captured in snapshot directory
- [ ] Verify skill guidance is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
