### PR TITLE
fix(ci-cd-tools): clarify when to use bktide snapshot --all vs default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
     {
       "name": "ci-cd-tools",
       "source": "./plugins/ci-cd-tools",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "dev-tools",

--- a/plugins/ci-cd-tools/skills/working-with-buildkite-builds/SKILL.md
+++ b/plugins/ci-cd-tools/skills/working-with-buildkite-builds/SKILL.md
@@ -37,14 +37,10 @@ The `snapshot` command is the **preferred** approach for investigating builds. I
 - Provides actionable next-step commands
 
 ```bash
-# Default: captures failed/broken steps only (recommended for most cases)
-# Use for investigating failures - you only need logs from steps that failed
 npx bktide@latest snapshot https://buildkite.com/org/pipeline/builds/123
-
-# --all: captures all steps including passing ones
-# Use when: verifying output of passing steps, debugging non-failure issues, or auditing what ran
-npx bktide@latest snapshot --all https://buildkite.com/org/pipeline/builds/123
 ```
+
+Run `bktide snapshot --help` for all options, or `bktide prime` for detailed LLM-friendly usage guidance.
 
 **Output structure:**
 ```

--- a/plugins/ci-cd-tools/skills/working-with-buildkite-builds/SKILL.md
+++ b/plugins/ci-cd-tools/skills/working-with-buildkite-builds/SKILL.md
@@ -37,10 +37,12 @@ The `snapshot` command is the **preferred** approach for investigating builds. I
 - Provides actionable next-step commands
 
 ```bash
-# Basic usage - captures failed/broken steps
+# Default: captures failed/broken steps only (recommended for most cases)
+# Use for investigating failures - you only need logs from steps that failed
 npx bktide@latest snapshot https://buildkite.com/org/pipeline/builds/123
 
-# Capture all steps including passing ones
+# --all: captures all steps including passing ones
+# Use when: verifying output of passing steps, debugging non-failure issues, or auditing what ran
 npx bktide@latest snapshot --all https://buildkite.com/org/pipeline/builds/123
 ```
 


### PR DESCRIPTION
## Summary
- Add guidance explaining default behavior (failed steps only) is recommended for investigating failures
- Clarify `--all` flag is for: verifying passing step output, debugging non-failure issues, or auditing

## Context
Bean: gt-2flq - The skill showed both options without explaining when to use each, leading to unnecessary downloads when investigating failures.

🤖 Generated with [Claude Code](https://claude.ai/code)