### PR TITLE
fix(ci-cd-tools,dev-tools): use markdown links instead of @ syntax in skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,12 +19,12 @@
     {
       "name": "ci-cd-tools",
       "source": "./plugins/ci-cd-tools",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "name": "dev-tools",
       "source": "./plugins/dev-tools",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "mcpproxy",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,22 @@ Version bumps happen automatically when PRs are approved.
 - `plugins/tool-routing/docs/tests/` - Test scenarios and baseline results
 - `plugins/tool-routing/docs/retrospectives/` - Investigation notes
 
+## Skill Authoring
+
+### Referencing Files in Skills
+
+In SKILL.md files, use standard markdown links to reference other files:
+
+```markdown
+# Correct - standard markdown link
+See [references/index.md](references/index.md) for complete list.
+
+# Wrong - @ imports only work in CLAUDE.md, not SKILL.md
+See `@references/index.md` for complete list.
+```
+
+The `@path/to/file` import syntax is a CLAUDE.md-specific feature. In SKILL.md files, Claude reads linked files on demand using progressive disclosure.
+
 ## Contributing
 
 1. Create a branch from `main`

--- a/plugins/ci-cd-tools/skills/developing-buildkite-pipelines/SKILL.md
+++ b/plugins/ci-cd-tools/skills/developing-buildkite-pipelines/SKILL.md
@@ -53,7 +53,7 @@ When editing pipeline steps that use plugins:
    - Default org `buildkite-plugins` if no org specified
    - Parse explicit org from `{org}/{plugin}#version` format
 3. **Load documentation:**
-   - **Cached:** Check `@references/plugins/{plugin-name}.md`
+   - **Cached:** Check [references/plugins/{plugin-name}.md](references/plugins/)
    - **Official (not cached):** Fetch from Buildkite directory or GitHub
    - **Internal:** Fetch README from `github.com/{org}/{plugin}-buildkite-plugin`
 4. **Match versions** - If pipeline specifies version, fetch that version's docs from GitHub tag
@@ -74,7 +74,7 @@ https://github.com/{org}/{plugin-name}-buildkite-plugin/tree/{version}
 
 **"Is there a plugin for X?"**
 
-1. Check `@references/plugins/index.md` for common plugins by category
+1. Check [references/plugins/index.md](references/plugins/index.md) for common plugins by category
 2. Fetch Buildkite directory: `https://buildkite.com/resources/plugins/`
 3. Search by task type (caching, docker, secrets, etc.)
 
@@ -101,7 +101,7 @@ Before writing or modifying pipeline YAML:
 ```markdown
 **I need to reference the Buildkite documentation for [specific feature].**
 
-Let me check: @references/[relevant-doc].md
+Let me read [references/[relevant-doc].md](references/).
 ```
 
 **For buildkite-builder pipelines:**
@@ -111,7 +111,7 @@ Before writing or modifying pipeline.rb:
 ```markdown
 **I need to reference buildkite-builder documentation for [specific feature].**
 
-Let me check: @references/buildkite-builder/[relevant-doc].md
+Let me read [references/buildkite-builder/[relevant-doc].md](references/buildkite-builder/).
 ```
 
 **Available references:**
@@ -122,9 +122,9 @@ Let me check: @references/buildkite-builder/[relevant-doc].md
 - `conditionals.md` - if/branches for conditional execution
 - `artifacts.md` - Uploading and downloading build artifacts
 
-See `@references/index.md` for complete list.
+See [references/index.md](references/index.md) for complete list.
 
-**Plugin references (see @references/plugins/index.md for full list):**
+**Plugin references (see [references/plugins/index.md](references/plugins/index.md) for full list):**
 - `plugins/docker.md` - Docker container execution
 - `plugins/docker-compose.md` - Multi-container environments
 - `plugins/artifacts.md` - Artifact upload/download
@@ -143,7 +143,7 @@ See `@references/index.md` for complete list.
 - `buildkite-builder/plugins.md` - Plugin usage in DSL
 - `buildkite-builder/environment.md` - Environment variables
 
-See `@references/buildkite-builder/index.md` for complete guide.
+See [references/buildkite-builder/index.md](references/buildkite-builder/index.md) for complete guide.
 
 ### 3. Validate Syntax
 
@@ -186,12 +186,12 @@ Before modifying any step with plugins:
 
 1. **Identify all plugins** in the step's `plugins:` block
 2. **For each plugin:**
-   - Check `@references/plugins/{name}.md` for cached docs
+   - Check [references/plugins/{name}.md](references/plugins/) for cached docs
    - If not cached, fetch from Buildkite directory or GitHub
    - If version specified, fetch version-specific docs
 3. **Then proceed** with changes using accurate configuration reference
 
-See `@references/plugins/index.md` for lookup workflow and common plugins.
+See [references/plugins/index.md](references/plugins/index.md) for lookup workflow and common plugins.
 
 ## buildkite-builder Troubleshooting Mode
 

--- a/plugins/dev-tools/skills/working-with-mise/SKILL.md
+++ b/plugins/dev-tools/skills/working-with-mise/SKILL.md
@@ -186,7 +186,7 @@ mise use node@20  # Adds to project config
 
 **Symptom**: Tools work in terminal but not in IDE/scripts
 
-See `@references/dev-tools/shims-html.md` for detailed explanation.
+See [references/dev-tools/shims-html.md](references/dev-tools/shims-html.md) for detailed explanation.
 
 **Quick fix** for non-interactive contexts:
 ```bash
@@ -225,12 +225,12 @@ echo $PATH | tr ':' '\n' | grep mise
 
 ## Available References
 
-- `@references/cli/use-html.md` - Full `mise use` documentation
-- `@references/cli/doctor-html.md` - Diagnostic commands
-- `@references/cli/activate-html.md` - Shell activation
-- `@references/cli/which-html.md` - Path resolution
-- `@references/dev-tools/shims-html.md` - Shims vs PATH activation
-- `@references/guides/getting-started.md` - Setup guide
+- [references/cli/use-html.md](references/cli/use-html.md) - Full `mise use` documentation
+- [references/cli/doctor-html.md](references/cli/doctor-html.md) - Diagnostic commands
+- [references/cli/activate-html.md](references/cli/activate-html.md) - Shell activation
+- [references/cli/which-html.md](references/cli/which-html.md) - Path resolution
+- [references/dev-tools/shims-html.md](references/dev-tools/shims-html.md) - Shims vs PATH activation
+- [references/guides/getting-started.md](references/guides/getting-started.md) - Setup guide
 
 ## Red Flags - You're About to Violate
 


### PR DESCRIPTION
## Summary

- The `@path/to/file` import syntax only works in CLAUDE.md files, not SKILL.md
- Skills should use standard markdown links which Claude reads on demand
- Adds documentation to CLAUDE.md to guide future skill authors

## Changes

- Convert `@references/` patterns to `[path](path)` markdown links in:
  - `developing-buildkite-pipelines/SKILL.md` (9 patterns)
  - `working-with-mise/SKILL.md` (7 patterns)
- Add "Skill Authoring" section to CLAUDE.md documenting correct pattern

## Evidence

From Claude Code official docs:
- `memory.md`: "CLAUDE.md files can import additional files using `@path/to/import` syntax"
- `skills.md`: Shows referencing files with standard markdown links `[reference.md](reference.md)`

## Test plan

- [ ] Verify skills still load correctly
- [ ] Confirm Claude can follow the markdown links to read reference files

🤖 Generated with [Claude Code](https://claude.com/claude-code)