### PR TITLE
docs: add commit scope format rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,23 @@ fix(ci-cd-tools): handle timeout # → patch bump
 chore: update deps               # → no bump
 ```
 
+### Commit Scope Rules
+
+Scope must match `[a-z0-9-]+` (lowercase letters, numbers, hyphens only).
+
+**Valid scopes:**
+- `feat(git): ...` - single plugin name
+- `fix(ci-cd-tools): ...` - plugin with hyphens
+- `fix: ...` - no scope (for cross-cutting changes)
+
+**Invalid scopes:**
+- `fix(ci-cd-tools,dev-tools): ...` - commas not allowed
+- `fix(CI-CD): ...` - uppercase not allowed
+
+For changes touching multiple plugins, either:
+1. Use no scope: `fix: use markdown links in skills`
+2. Make separate commits per plugin
+
 Version bumps happen automatically when PRs are approved.
 
 → Full details: [`docs/versioning.md`](docs/versioning.md)


### PR DESCRIPTION
## Summary

Follow-up to #35. Documents commit scope format rules to prevent CI failures.

## Changes

Added "Commit Scope Rules" section explaining:
- Scope must match `[a-z0-9-]+` (lowercase, numbers, hyphens)
- No commas allowed (use no scope for multi-plugin changes)
- No uppercase allowed

## Why

CI failed in #35 because `fix(ci-cd-tools,dev-tools):` has a comma in the scope, which doesn't match the validation regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)