### PR TITLE
docs: standardize installation instructions across all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,26 @@ pickled-claude-plugins/
 
 ## Installation
 
-### Automatic (via technicalpickles/dotfiles)
-
-If you use [technicalpickles/dotfiles](https://github.com/technicalpickles/dotfiles), the marketplace is installed automatically via `install.sh`.
-
-### Manual Installation
+### Add the Marketplace
 
 ```bash
-git clone https://github.com/technicalpickles/claude-skills ~/.claude/plugins/technicalpickles
+/plugin marketplace add technicalpickles/pickled-claude-plugins
 ```
 
-The marketplace structure allows Claude Code to discover all plugins within the repository.
+### Install a Plugin
+
+```bash
+/plugin install <plugin-name>@pickled-claude-plugins
+```
+
+For example:
+
+```bash
+/plugin install git@pickled-claude-plugins
+/plugin install dev-tools@pickled-claude-plugins
+```
+
+See individual plugin READMEs for details on what each plugin provides.
 
 ## Plugins
 
@@ -118,11 +127,16 @@ Hooks run automatically on configured events (like SessionStart for monorepo det
 
 ## Development
 
-To modify plugins and skills:
+To modify plugins:
 
-1. Edit files in `~/workspace/claude-skills/plugins/`
-2. Changes are immediately available to Claude (if installed via symlink)
-3. Commit and push to share across machines
+1. Edit files in `plugins/` within this repository
+2. Reinstall the plugin to pick up changes:
+   ```bash
+   /plugin uninstall <plugin>@pickled-claude-plugins
+   /plugin install <plugin>@pickled-claude-plugins
+   ```
+3. Restart Claude Code
+4. Commit and push to share across machines
 
 ### Plugin Structure
 

--- a/plugins/agent-meta/README.md
+++ b/plugins/agent-meta/README.md
@@ -50,6 +50,8 @@ Default location: `.parkinglot/` in project root (gitignored).
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
 /plugin install agent-meta@pickled-claude-plugins
 ```

--- a/plugins/ci-cd-tools/README.md
+++ b/plugins/ci-cd-tools/README.md
@@ -34,6 +34,8 @@ Use when creating or modifying Buildkite pipeline configurations and working wit
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
 /plugin install ci-cd-tools@pickled-claude-plugins
 ```

--- a/plugins/debugging-tools/README.md
+++ b/plugins/debugging-tools/README.md
@@ -17,6 +17,8 @@ Use when user mentions MCPProxy/MCP tools or when you need to discover or call t
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
 /plugin install debugging-tools@pickled-claude-plugins
 ```

--- a/plugins/dev-tools/README.md
+++ b/plugins/dev-tools/README.md
@@ -2,6 +2,14 @@
 
 Developer productivity tools and utilities.
 
+## Installation
+
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
+```bash
+/plugin install dev-tools@pickled-claude-plugins
+```
+
 ## Skills
 
 ### working-in-scratch-areas

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -78,6 +78,8 @@ Update your branch with upstream changes, intelligently resolving conflicts.
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
 /plugin install git@pickled-claude-plugins
 ```

--- a/plugins/mcpproxy/README.md
+++ b/plugins/mcpproxy/README.md
@@ -23,6 +23,8 @@ Use when working with MCPProxy and MCP tools - detecting connection status, disc
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
 /plugin install mcpproxy@pickled-claude-plugins
 ```

--- a/plugins/second-brain/README.md
+++ b/plugins/second-brain/README.md
@@ -4,8 +4,10 @@ Knowledge management for Obsidian vaults. Capture insights from conversations, p
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
-claude plugin add pickled-claude-plugins/second-brain
+/plugin install second-brain@pickled-claude-plugins
 ```
 
 ## Quick Start

--- a/plugins/session-analyzer/README.md
+++ b/plugins/session-analyzer/README.md
@@ -38,6 +38,8 @@ Find failed tool calls in Claude session logs.
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
 /plugin install session-analyzer@pickled-claude-plugins
 ```

--- a/plugins/stay-on-target/README.md
+++ b/plugins/stay-on-target/README.md
@@ -17,6 +17,8 @@ A Claude Code plugin that enforces intentional, focused development.
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
 /plugin install stay-on-target@pickled-claude-plugins
 ```

--- a/plugins/tool-routing/README.md
+++ b/plugins/tool-routing/README.md
@@ -4,10 +4,10 @@ Intercepts tool calls and suggests better alternatives. When Claude tries to use
 
 ## Installation
 
-Add to your Claude Code plugins:
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
 
 ```bash
-claude plugin add pickled-claude-plugins/tool-routing
+/plugin install tool-routing@pickled-claude-plugins
 ```
 
 ## Quick Example

--- a/plugins/working-in-monorepos/README.md
+++ b/plugins/working-in-monorepos/README.md
@@ -53,6 +53,8 @@ uv run pytest tests/ -v
 
 ## Installation
 
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
 ```bash
 /plugin install working-in-monorepos@pickled-claude-plugins
 ```


### PR DESCRIPTION
## Summary

- Replace `git clone` in repo README with `/plugin marketplace add` command
- Normalize `second-brain` and `tool-routing` from `claude plugin add` to `/plugin install` format
- Add missing installation section to `dev-tools`
- Add marketplace prerequisite note with link back to repo README in all 11 plugin READMEs
- Fix stale path references (`~/workspace/claude-skills/`)

## Test plan

- [x] Verify `/plugin marketplace add technicalpickles/pickled-claude-plugins` works for a fresh setup
- [ ] Verify `/plugin install <name>@pickled-claude-plugins` works after marketplace is added
- [x] Confirm relative links (`../../README.md#installation`) resolve correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)