### PR TITLE
Add timing instrumentation to test-claude

### DIFF
--- a/bin/test-claude
+++ b/bin/test-claude
@@ -21,9 +21,33 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+BLUE='\033[0;34m'
+
 log() { echo -e "${GREEN}[test-claude]${NC} $*"; }
 warn() { echo -e "${YELLOW}[test-claude]${NC} $*"; }
 error() { echo -e "${RED}[test-claude]${NC} $*" >&2; }
+
+# Timing helpers (millisecond precision on macOS, where date lacks %N)
+_now_ms() {
+    perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'
+}
+
+_elapsed_ms() {
+    local start=$1
+    local end=$(_now_ms)
+    echo $(( end - start ))
+}
+
+_format_ms() {
+    local ms=$1
+    if [ "$ms" -lt 1000 ]; then
+        echo "${ms}ms"
+    else
+        local secs=$(( ms / 1000 ))
+        local remainder=$(( ms % 1000 ))
+        printf "%d.%03ds" "$secs" "$remainder"
+    fi
+}
 
 usage() {
     cat << EOF
@@ -44,6 +68,7 @@ EOF
 }
 
 setup_config() {
+    local setup_start=$(_now_ms)
     log "Setting up test config..."
 
     # Create directories
@@ -112,21 +137,33 @@ EOF
 
     # Create empty installed_plugins.json
     echo '{"version": 2, "plugins": {}}' > "$TEST_CONFIG/plugins/installed_plugins.json"
+
+    log "  Config created in $(_format_ms $(_elapsed_ms $setup_start))"
 }
 
 install_all_plugins() {
+    local install_start=$(_now_ms)
+    local plugin_count=0
+    local failed_count=0
     log "Installing plugins from local-test marketplace..."
 
     # Find all plugins with .claude-plugin directories
     for plugin_dir in "$REPO_ROOT"/plugins/*/; do
         if [ -d "$plugin_dir/.claude-plugin" ]; then
             plugin_name=$(basename "$plugin_dir")
-            log "  Installing $plugin_name..."
-            CLAUDE_CONFIG_DIR="$TEST_CONFIG" claude plugin install "$plugin_name@local-test" 2>/dev/null || {
-                warn "  Failed to install $plugin_name (may not be in marketplace.json)"
+            local plugin_start=$(_now_ms)
+            CLAUDE_CONFIG_DIR="$TEST_CONFIG" claude plugin install "$plugin_name@local-test" 2>/dev/null && {
+                log "  ${BLUE}$plugin_name${NC} installed in $(_format_ms $(_elapsed_ms $plugin_start))"
+                plugin_count=$((plugin_count + 1))
+            } || {
+                warn "  $plugin_name failed ($(_format_ms $(_elapsed_ms $plugin_start)))"
+                failed_count=$((failed_count + 1))
             }
         fi
     done
+
+    local total_install=$(_format_ms $(_elapsed_ms $install_start))
+    log "$plugin_count plugins installed in $total_install$([ $failed_count -gt 0 ] && echo ", $failed_count failed")"
 }
 
 clean_config() {
@@ -149,9 +186,10 @@ esac
 
 # Setup if needed
 if [ ! -d "$TEST_CONFIG" ]; then
+    total_start=$(_now_ms)
     setup_config
     install_all_plugins
-    log "Setup complete!"
+    log "Setup complete in $(_format_ms $(_elapsed_ms $total_start))"
 fi
 
 # Run claude with test config


### PR DESCRIPTION
## Summary

- Adds millisecond-precision timing to `bin/test-claude` setup, reporting config creation time, per-plugin install duration, and overall setup time
- Uses perl `Time::HiRes` instead of python3 for lower overhead on macOS (where BSD `date` lacks `%N`)
- Shows plugin count and failure summary in install output

## Context

While writing a blog post about plugin testing, realized `test-claude` had zero timing visibility. The blog claimed "maybe 10 seconds" for a clean setup. Actual measured time: **~3.4s** for 9 plugins.

Sample output after this change:
```
[test-claude] Setting up test config...
[test-claude]   Config created in 54ms
[test-claude] Installing plugins from local-test marketplace...
[test-claude]   agent-meta installed in 303ms
[test-claude]   ci-cd-tools installed in 513ms
[test-claude]   ...
[test-claude] 9 plugins installed in 3.332s
[test-claude] Setup complete in 3.419s
```

## Test plan

- [ ] Run `bin/test-claude --clean && bin/test-claude` and verify timing output appears
- [ ] Verify `perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'` works (macOS ships perl with Time::HiRes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)