### PR TITLE
feat(second-brain): add connection layer for note linking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/commands/connect.md
+++ b/plugins/second-brain/commands/connect.md
@@ -1,0 +1,208 @@
+---
+description: Connect a note to related notes in your vault using semantic search
+argument-hint: [path/to/note.md]
+allowed-tools:
+  - Read(~/.claude/second-brain.md)
+  - Read(~/.claude/vaults/**/CLAUDE.md)
+  - Read(~/.claude/vaults/**/.obsidian/*.json)
+  - Read(~/.claude/vaults/**/*.md)
+  - Write(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/*.md)
+  - Bash(which:qmd)
+  - Bash(qmd:query *)
+  - Bash(qmd:collection list)
+  - Bash(qmd:get *)
+  - Bash(qmd:status)
+  - Bash(ls:*)
+  - Bash(date:*)
+  - Bash(find:*)
+  - Bash(stat:*)
+---
+
+# Connect Notes
+
+Connect a note to related notes in your vault, or discover connection opportunities across the vault.
+
+## Step 1: Load Configuration
+
+Read `~/.claude/second-brain.md` for vault name and path.
+
+If missing:
+```
+Second brain not configured. Run /second-brain:setup first.
+```
+
+Use the symlink path `~/.claude/vaults/{name}` to access the vault (e.g., `~/.claude/vaults/primary`).
+
+Load skill references:
+- `second-brain:obsidian` for tool mechanics
+- `references/connecting.md` for connection discovery algorithm
+
+## Step 2: Check Prerequisites
+
+Follow `references/connecting.md` prerequisites:
+
+```bash
+which qmd
+```
+
+If qmd is not available:
+```
+qmd is not installed. Connection discovery requires qmd for semantic search.
+Install via: bun add -g qmd
+Then configure: qmd collection add ~/path/to/vault --name second-brain
+```
+
+Verify collection exists:
+```bash
+qmd collection list
+```
+
+Load collection name from `~/.claude/second-brain.md` (`qmd_collection` setting). Default: `second-brain`.
+
+## Step 3: Determine Mode
+
+**If argument provided (note path):** Go to Step 4 (Connect Specific Note)
+**If no argument:** Go to Step 7 (Connection Gardening)
+
+---
+
+## Connect Specific Note
+
+### Step 4: Load Target Note
+
+Resolve the path. Accept:
+- Vault-relative path: `Areas/gusto/202501121430 kafka-consumer-groups.md`
+- Absolute path: `~/Vaults/pickled-knowledge/.../file.md`
+- Just the filename: `202501121430 kafka-consumer-groups.md` (search for it)
+
+If just a filename, find it:
+```bash
+find "{vault}" -name "{filename}" -type f 2>/dev/null
+```
+
+Read the note content.
+
+If note not found:
+```
+Note not found: {path}
+Check the path and try again.
+```
+
+### Step 5: Run Connection Discovery
+
+Follow the full `references/connecting.md` algorithm:
+
+1. Extract query terms from the note's title and body
+2. Run `qmd query "{terms}" -c {collection} -n 15 --json`
+3. Filter noise (self, already-linked, low-relevance, daily notes)
+4. Enrich candidates (check for See Also, Related, TK sections)
+5. Rank by connection value
+6. Present candidates for multi-select
+
+### Step 6: Apply Connections
+
+Based on user selection:
+
+1. Add forward links (## Related section) to the target note
+2. Offer backlink weaving for selected notes
+3. Confirm what was connected
+
+Done. Skip to Step 10.
+
+---
+
+## Connection Gardening (No-Arg Mode)
+
+### Step 7: Find Connection Opportunities
+
+Scan the vault for notes that might benefit from connections:
+
+**Priority 1: Recent inbox notes without connections**
+```bash
+# Notes in inbox without ## Related section
+find "{vault}"/📫\ Inbox/ -name "*.md" -type f -mtime -30 2>/dev/null
+```
+
+For each, check if it has a `## Related` section. Notes without one are candidates.
+
+**Priority 2: Notes with TK placeholders**
+Search for notes containing `TK` in See Also or Related sections:
+```bash
+qmd query "TK see also related" -c {collection} -n 10 --json
+```
+
+Or use grep if qmd doesn't help here:
+```bash
+find "{vault}" -name "*.md" -exec grep -l "TK" {} \; 2>/dev/null | head -20
+```
+
+**Priority 3: Recently captured notes with no outgoing wiki-links**
+```bash
+# Recently modified notes
+find "{vault}" -name "*.md" -type f -mtime -7 2>/dev/null | head -20
+```
+
+For each, check if it has any `[[wiki-links]]` in the body.
+
+### Step 8: Present Opportunities
+
+```
+Connection gardening: found {N} notes that could use connections:
+
+Inbox notes without connections:
+1. **{title}** - captured {date}, no Related section
+2. **{title}** - captured {date}, no Related section
+
+Notes waiting for connections (TK):
+3. **{title}** - has TK in See Also section
+4. **{title}** - has TK placeholder
+
+Recent notes with no outgoing links:
+5. **{title}** - modified {date}, no wiki-links
+```
+
+Use AskUserQuestion:
+**Question:** "Which note would you like to connect?"
+**Options:** Top 3-4 candidates, plus "None, I'm done gardening"
+
+### Step 9: Connect Selected Note
+
+When user picks a note, run the same flow as Steps 4-6 (Connect Specific Note):
+1. Read the selected note
+2. Run connection discovery
+3. Present candidates
+4. Apply connections
+
+After connecting, offer to continue gardening:
+```
+Want to connect another note?
+(A) Yes, show me more opportunities
+(B) Done for now
+```
+
+If (A), loop back to Step 7 with already-connected notes excluded.
+
+---
+
+## Step 10: Summary
+
+After all connections are done:
+
+```
+Connection session complete:
+- {N} notes connected
+- {M} forward links added
+- {K} backlinks woven
+
+Run /second-brain:connect again anytime to tend the garden.
+```
+
+## Constraints
+
+- **User always chooses** - Present candidates, never auto-connect
+- **Best-effort** - Skip gracefully if qmd fails or returns nothing
+- **Wiki-link format** - Use `[[filename]]` not `[text](path)`
+- **Descriptive links** - Always include relationship description
+- **Respect structure** - Append to existing sections, don't reorganize
+- **Gardening is optional** - If no opportunities found, say so and exit

--- a/plugins/second-brain/commands/distill-conversation.md
+++ b/plugins/second-brain/commands/distill-conversation.md
@@ -12,6 +12,11 @@ allowed-tools:
   - Bash(git rev-parse:*)
   - Bash(git branch:*)
   - Bash(mv:*)
+  - Bash(which:qmd)
+  - Bash(qmd:query *)
+  - Bash(qmd:collection list)
+  - Bash(qmd:get *)
+  - Bash(qmd:status)
 ---
 
 # Distill Conversation
@@ -34,6 +39,7 @@ Load skill references:
 - `references/zettelkasten.md` for naming
 - `references/note-patterns.md` for Insight Note template
 - `references/routing.md` for destination matching
+- `references/connecting.md` for connection discovery
 - `references/daily-linking.md` for linking to daily note
 
 ## Step 2: Review the Conversation
@@ -163,7 +169,45 @@ mv "{inbox}/{filename}" "{vault}/{destination}/"
 
 **Important:** Only suggest destinations that exist (from `ls` output). Never suggest paths that weren't discovered.
 
-## Step 7: Batch Link to Daily Note
+## Step 7: Batch Connection Discovery
+
+Follow `references/connecting.md` to find connections for captured notes.
+
+**1. Check prerequisites:**
+```bash
+which qmd
+```
+
+If qmd is not available, skip to Step 8 (don't fail the capture).
+
+**2. Run discovery for each captured note:**
+
+For each note, extract query terms and run `qmd query`. Filter and rank candidates per the connecting reference.
+
+**3. Collect results and present as batch:**
+
+```
+Found connections for {M} of {N} captured notes:
+
+- {Note A title}: {count} related notes
+- {Note C title}: {count} related notes
+- {Note E title}: no connections found
+
+(A) Review and connect all
+(B) Skip connections for now
+```
+
+**4. If user picks (A):** Walk through each note's connections using the standard presentation and multi-select flow from the connecting reference. For each note:
+- Show candidates with scores and snippets
+- Let user multi-select which to connect
+- Add forward links (## Related section)
+- Offer backlink weaving
+
+**5. If user picks (B):** Skip connections, continue to daily linking.
+
+Note: Newly captured notes won't be in qmd's index yet. That's fine. We search FROM each note's content, not for it.
+
+## Step 8: Batch Link to Daily Note
 
 Follow `references/daily-linking.md` to connect all captured notes to today's daily note.
 

--- a/plugins/second-brain/commands/insight.md
+++ b/plugins/second-brain/commands/insight.md
@@ -13,6 +13,11 @@ allowed-tools:
   - Bash(git rev-parse:*)
   - Bash(git branch:*)
   - Bash(mv:*)
+  - Bash(which:qmd)
+  - Bash(qmd:query *)
+  - Bash(qmd:collection list)
+  - Bash(qmd:get *)
+  - Bash(qmd:status)
 ---
 
 # Capture Insight
@@ -37,6 +42,7 @@ Load skill references:
 - `references/zettelkasten.md` for naming
 - `references/note-patterns.md` for Insight Note template
 - `references/routing.md` for destination matching
+- `references/connecting.md` for connection discovery
 - `references/daily-linking.md` for linking to daily note
 
 ## Step 2: Identify the Insight
@@ -182,7 +188,39 @@ mv "{inbox}/{filename}" "{vault}/{selected-destination}/"
 
 If all destinations score <20%, recommend inbox without asking.
 
-## Step 8: Link to Daily Note
+## Step 8: Discover Connections
+
+Follow `references/connecting.md` algorithm to find related notes in the vault.
+
+**1. Check prerequisites:**
+```bash
+which qmd
+```
+
+If qmd is not available, skip to Step 9 (don't fail the capture).
+
+**2. Extract query terms** from the captured note's title and body.
+
+**3. Run semantic search:**
+```bash
+qmd query "{terms}" -c {collection} -n 15 --json
+```
+
+**4. Filter and rank** per the connecting reference (remove self, already-linked, low-relevance, daily notes; enrich with TK/See Also signals; rank).
+
+**5. If connections found (any candidates above 30%):**
+
+Present candidates and let user multi-select which to connect.
+
+**6. For selected connections:**
+- Add `## Related` section to the captured note with wiki-links
+- Offer backlink weaving for notes with See Also/Related/TK sections
+
+**7. If no connections above threshold,** skip silently and continue.
+
+Note: The captured note won't be in qmd's index yet. That's fine. We're searching FROM the note's content, not for it.
+
+## Step 9: Link to Daily Note
 
 Follow `references/daily-linking.md` to connect the captured note to today's daily note.
 

--- a/plugins/second-brain/skills/obsidian/references/connecting.md
+++ b/plugins/second-brain/skills/obsidian/references/connecting.md
@@ -1,0 +1,329 @@
+# Connection Discovery Reference
+
+Systematic algorithm for finding related notes in the vault and weaving connections between them.
+
+**Key principle:** Connections are bidirectional. When you link a new note to an existing one, also offer to update the existing note to link back. Notes with `TK` placeholders or `## See Also` sections are explicitly waiting for connections.
+
+## Prerequisites
+
+Before running connection discovery:
+
+```bash
+# Verify qmd is available
+which qmd
+```
+
+If not found, inform user and skip connections (don't fail the capture workflow):
+```
+qmd not installed - skipping connection discovery.
+Install via: bun add -g qmd
+```
+
+Load collection name from `~/.claude/second-brain.md` (`qmd_collection` setting under the vault's settings section). If not set, default to `second-brain`.
+
+Verify the collection exists:
+```bash
+qmd collection list
+```
+
+---
+
+## Step 1: Extract Query Terms
+
+From the note being connected, build a natural language query string:
+
+1. **Title keywords** - Strip the Zettelkasten timestamp prefix, use the remaining words
+2. **Key phrases from body** - Extract the most distinctive 2-3 phrases (not generic words like "the" or "about")
+3. **Tags** - Include any frontmatter tags or inline tags
+
+Build a single query string. Keep it natural, not a keyword dump. qmd handles expansion and semantic matching.
+
+**Example:**
+- Note title: `202603041430 karafka consumer group rebalancing strategy`
+- Body mentions: "multi-tenant consumers", "cooperative sticky assignor", "session timeout"
+- Query: `karafka consumer group rebalancing multi-tenant cooperative sticky assignor`
+
+---
+
+## Step 2: Run Semantic Search
+
+```bash
+qmd query "{query}" -c {collection} -n 15 --json
+```
+
+Request 15 results to allow for filtering. The JSON output contains:
+- `file`: `qmd://{collection}/{path}` (strip the prefix to get vault-relative path)
+- `score`: 0.0-1.0 relevance score
+- `title`: document title
+- `snippet`: matching content with context markers
+
+---
+
+## Step 3: Filter Noise
+
+Remove results that shouldn't be connection candidates:
+
+### 3a: Remove Self
+
+If the note being connected appears in results, remove it. Match by filename (the Zettelkasten timestamp prefix is unique enough).
+
+### 3b: Remove Already-Linked Notes
+
+Parse the note's content for existing `[[wiki-links]]`. Any note already referenced is not a new connection candidate.
+
+```
+Pattern: \[\[([^\]]+)\]\]
+```
+
+Extract link targets, match against result filenames (without extension).
+
+### 3c: Remove Low-Relevance Results
+
+Drop any result with score below 0.30 (30%). This is a starting threshold, may need tuning.
+
+### 3d: Remove Daily Notes
+
+Filter out results that are daily notes (`Fleeting/YYYY-MM-DD.md` pattern). These are temporal, not topical connections. They add noise without value.
+
+---
+
+## Step 4: Enrich Candidates
+
+For each remaining candidate, gather connection signals:
+
+### 4a: Check for Connection-Ready Sections
+
+Read the candidate note (use `qmd get` for efficiency) and check for:
+
+- **`## See Also`** section exists
+- **`## Related`** section exists
+- **`TK`** appears in the note body (placeholder explicitly waiting for content)
+
+### 4b: Check PARA Location
+
+Extract the candidate's PARA category from its path:
+- `*Projects*/` = active project context
+- `*Areas*/` = ongoing area of responsibility
+- `*Resources*/` = reference material
+- `Fleeting/` or `Inbox/` = not yet organized
+
+Compare to the note being connected. Same PARA area = topically adjacent.
+
+### 4c: Check Modification Recency
+
+From qmd metadata or file stat, note when the candidate was last modified. Recent = more likely to be actively relevant.
+
+---
+
+## Step 5: Rank by Connection Value
+
+Score each candidate using the qmd relevance as baseline, then apply boosts:
+
+| Signal | Effect | Reasoning |
+|--------|--------|-----------|
+| qmd relevance score | Primary (0-100%) | Semantic similarity is the strongest signal |
+| Has `TK` placeholder | +15% boost | Note is explicitly waiting for connections |
+| Same PARA area | +5% boost | Topically adjacent, likely related |
+| Modified in last 30 days | +5% boost | Fresh content, more actively relevant |
+
+Cap final score at 99%.
+
+Sort candidates by final score, descending.
+
+---
+
+## Step 6: Present Candidates
+
+Show the top candidates (max 7, enough for a meaningful selection without overwhelming):
+
+```
+Found {N} related notes:
+
+1. **{title}** ({score}%)
+   `{path relative to vault}`
+   > "{snippet, 1-2 lines}"
+   {signals: "(has TK placeholder)", "(same area)", etc.}
+
+2. **{title}** ({score}%)
+   ...
+```
+
+Use AskUserQuestion with multi-select to let the user choose which to connect:
+
+**Question:** "Which notes should I connect to {note title}?"
+
+Include option: "Skip connections" (always available)
+
+If no candidates above threshold after filtering, skip silently or note:
+```
+No strong connections found for this note.
+```
+
+---
+
+## Step 7: Add Forward Links
+
+For each selected connection, add a wiki-link in the note being connected.
+
+### If `## Related` Section Exists
+
+Append to it:
+
+```markdown
+## Related
+
+- [[existing-link]] - existing description
+- [[{new-connection-filename}]] - {brief description of relationship}
+```
+
+### If No `## Related` Section
+
+Add one before the trailing `---` and capture signature (if present), or at the end of the note:
+
+```markdown
+## Related
+
+- [[{new-connection-filename}]] - {brief description of relationship}
+```
+
+### Link Description Guidelines
+
+The description should capture WHY these notes are related, not just repeat the title:
+
+| Good | Bad |
+|------|-----|
+| "Consumer group architecture patterns" | "Kafka consumer groups" |
+| "Same rebalancing issue in production" | "Related note" |
+| "Guild discussion on DLQs and consumer groups" | "Meeting notes" |
+
+---
+
+## Step 8: Offer Backlink Weaving
+
+After forward links are added, check if any selected notes have connection-ready sections:
+
+- Has `## See Also` section
+- Has `## Related` section
+- Has `TK` placeholder in body
+
+If any do, offer backlink weaving:
+
+```
+{N} of your selected notes have See Also/Related sections or TK placeholders.
+Want me to add backlinks from them to your new note?
+
+(A) Yes, add backlinks to all that have See Also/Related/TK
+(B) Let me pick which ones
+(C) Skip backlinks, just keep forward links
+```
+
+### Adding Backlinks
+
+For each note where backlinks are accepted:
+
+**If `## See Also` exists:** Append wiki-link to that section
+**If `## Related` exists:** Append wiki-link to that section
+**If both exist:** Use `## See Also` (prefer the existing convention)
+**If neither exists but has `TK`:** Do not add a section, only replace TK if the TK is clearly a placeholder for this connection
+
+### Replacing TK Placeholders
+
+`TK` is "to come" - a deliberate placeholder. Only replace if the TK appears in a context where the new note is a clear fit:
+
+```markdown
+# Before
+See also TK for rebalancing strategies.
+
+# After
+See also [[202603041430 rebalancing-strategy]] for rebalancing strategies.
+```
+
+If the TK context doesn't match the new note, leave it alone.
+
+### Backlink Description
+
+Same format as forward links. Describe the relationship from the existing note's perspective:
+
+```markdown
+- [[202603041430 rebalancing-strategy]] - Rebalancing approach for multi-tenant consumers
+```
+
+---
+
+## Step 9: Confirm Results
+
+After all connections are made, summarize:
+
+```
+Connections added:
+
+Forward links (in {note title}):
+- [[note-a]] - description
+- [[note-b]] - description
+
+Backlinks added:
+- note-a: added to ## See Also
+- note-b: replaced TK placeholder
+
+{N} notes are now connected.
+```
+
+---
+
+## Implementation Pattern
+
+When integrating into a command:
+
+```markdown
+## After Routing: Discover Connections
+
+Follow `references/connecting.md` algorithm:
+
+1. Check qmd prerequisites (skip if not available)
+2. Extract query terms from note content
+3. Run semantic search via qmd
+4. Filter noise (self, already-linked, low-relevance, daily notes)
+5. Enrich and rank candidates
+6. Present candidates for user selection (multi-select)
+7. Add forward links (## Related section)
+8. Offer backlink weaving for selected notes
+9. Confirm what was connected
+
+This step is best-effort: don't fail capture if connection discovery fails.
+```
+
+---
+
+## Batch Connection Discovery
+
+When connecting multiple notes at once (e.g., `/distill-conversation`):
+
+1. Run discovery for each note independently
+2. Collect all suggestions
+3. Present as batch summary:
+
+```
+Found connections for {M} of {N} captured notes:
+
+- {Note A title}: {count} related notes
+- {Note C title}: {count} related notes
+
+(A) Review and connect all
+(B) Skip connections for now
+```
+
+If user picks (A), walk through each note's connections using the standard presentation and selection flow.
+
+**Deduplication:** If the same candidate appears for multiple captured notes, that's fine. Each connection is independent and the relationship description will differ.
+
+---
+
+## Constraints
+
+- **Best-effort** - Don't fail capture or routing if connection discovery fails
+- **User selects** - Never auto-connect, always present candidates for selection
+- **Wiki-link format** - Use `[[filename]]` not `[text](path)`, no `.md` extension in links
+- **Descriptive links** - Always include a brief description of the relationship
+- **Respect existing structure** - Append to existing sections, don't reorganize notes
+- **Skip daily notes** - Daily notes are temporal, not topical connections
+- **Index freshness** - New captures won't be in qmd index yet, that's expected (we query FROM the new note's content, not for it)


### PR DESCRIPTION
## Summary

- Adds a connection discovery engine (`references/connecting.md`) that uses qmd semantic search to find related notes in the vault
- New `/second-brain:connect` command for standalone connection-making and "connection gardening" mode
- Integrates connection discovery into `/second-brain:insight` (Step 8) and `/second-brain:distill-conversation` (Step 7, batched)
- Supports forward links (`## Related`), backlink weaving (`## See Also`/`## Related`), and TK placeholder replacement

## Test plan

- [ ] Run `/second-brain:connect path/to/note.md` on an existing vault note, verify candidates are found and links are added
- [ ] Run `/second-brain:connect` with no args, verify gardening mode finds notes without connections
- [ ] Run `/second-brain:insight` and verify Step 8 offers connection candidates after routing
- [ ] Run `/second-brain:distill-conversation` and verify batch connection summary appears
- [ ] Verify backlink weaving updates existing notes' See Also/Related sections
- [ ] Verify TK placeholders are correctly identified and replacement is offered

Bean: gt-vpsi
Design: `docs/plans/2026-03-02-second-brain-connections-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)