### PR TITLE
feat(second-brain): integrate sb CLI into plugin commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/commands/distill-conversation.md
+++ b/plugins/second-brain/commands/distill-conversation.md
@@ -1,17 +1,12 @@
 ---
 description: Extract and capture multiple insights from this conversation
 allowed-tools:
-  - Read(~/.claude/second-brain.md)
   - Read(~/.claude/vaults/**/CLAUDE.md)
   - Read(~/.claude/vaults/**/.obsidian/*.json)
   - Read(~/.claude/vaults/**/*.md)
   - Write(~/.claude/vaults/**/*.md)
   - Edit(~/.claude/vaults/**/*.md)
-  - Bash(ls:*)
-  - Bash(date:*)
-  - Bash(git rev-parse:*)
-  - Bash(git branch:*)
-  - Bash(mv:*)
+  - Bash(npx @techpickles/sb:*)
 ---
 
 # Distill Conversation
@@ -20,17 +15,33 @@ Review the current conversation and extract insights worth capturing.
 
 ## Step 1: Load Configuration
 
-Read `~/.claude/second-brain.md` for vault name and path.
+Verify sb CLI is available:
+```bash
+npx @techpickles/sb --version
+```
 
-If missing:
+If unavailable:
+```
+sb CLI is required but not available. Install Node.js and npm, then try again.
+Or install globally for faster execution: npm i -g @techpickles/sb
+```
+
+Load configuration via sb:
+```bash
+npx @techpickles/sb config default
+npx @techpickles/sb config vaults
+```
+
+If no default vault configured:
 ```
 Second brain not configured. Run /second-brain:setup first.
 ```
 
-Use the symlink path `~/.claude/vaults/{name}` to access the vault (e.g., `~/.claude/vaults/primary`).
+Use the symlink path `~/.claude/vaults/{name}` to Read vault files (e.g., `~/.claude/vaults/primary/CLAUDE.md`).
 
 Load skill references:
 - `second-brain:obsidian` for tool mechanics
+- `references/sb-cli.md` for sb command patterns
 - `references/zettelkasten.md` for naming
 - `references/note-patterns.md` for Insight Note template
 - `references/routing.md` for destination matching
@@ -83,12 +94,22 @@ Include "None - skip capture" option.
 
 ## Step 5: Capture Selected
 
-For each selected insight, follow `/second-brain:insight` flow:
-1. Gather provenance
-2. Generate Zettelkasten filename
-3. Write to inbox with Insight Note pattern
-4. Show confirmation
+For each selected insight, create note with sb:
 
+```bash
+npx @techpickles/sb note create \
+  --source auto \
+  --title "{insight title}" \
+  --content "{insight content with provenance}"
+```
+
+This handles:
+- Zettelkasten timestamp filename generation
+- Provenance tracking (git context)
+- Writing to inbox with proper frontmatter
+- Daily note date stamping
+
+Show confirmation:
 ```
 Capturing {N} insights...
 
@@ -105,17 +126,26 @@ Load `references/routing.md` and analyze all captured notes together.
 
 **1. Discover vault structure once:**
 ```bash
-ls -d "{vault}"/*Areas*/*/     2>/dev/null
-ls -d "{vault}"/*Resources*/*/ 2>/dev/null
-ls -d "{vault}"/*Projects*/*/  2>/dev/null
+npx @techpickles/sb vault structure
 ```
 
+Parse JSON output to get available PARA destinations (Areas, Resources, Projects).
+
 **2. Load disambiguation rules from vault CLAUDE.md:**
+
+Read `~/.claude/vaults/{name}/CLAUDE.md`:
 - Find `### Disambiguation:` sections
 - Extract key questions, category tables, edge case mappings
 - These override generic matching for semantically similar areas
 
 **3. Score each captured note:**
+
+For each note, get routing context:
+```bash
+npx @techpickles/sb note context --note "{note-path}"
+```
+
+Parse JSON output for keywords, category, related notes.
 
 *Apply disambiguation rules first (if loaded):*
 - Check edge case mappings (explicit rules)
@@ -152,32 +182,39 @@ Routing explanations:
 3. Leave all in inbox for now
 
 **6. Execute based on selection:**
-- "Route all": Move files with confidence > 20% to suggested destinations
-- "Route individually": Use AskUserQuestion for each note separately
-- "Leave all": Skip routing, notes stay in inbox
 
+For "Route all" or per-note confirmation:
 ```bash
-# For each routed note:
-mv "{inbox}/{filename}" "{vault}/{destination}/"
+npx @techpickles/sb note move \
+  --from "inbox/{filename}" \
+  --to "{destination-path}/"
 ```
 
-**Important:** Only suggest destinations that exist (from `ls` output). Never suggest paths that weren't discovered.
+**Important:** Only suggest destinations that exist (from `vault structure` output). Never suggest paths that weren't discovered.
 
 ## Step 7: Batch Link to Daily Note
 
 Follow `references/daily-linking.md` to connect all captured notes to today's daily note.
 
-**1. Find today's daily note:**
+**1. Get today's daily note path:**
 ```bash
-cat "{vault}/.obsidian/daily-notes.json" 2>/dev/null
-date +"%Y-%m-%d"
+npx @techpickles/sb daily path
 ```
 
 **2. If daily note exists, batch-add links to `## Links` section:**
+
+Build combined content:
 ```markdown
 - [[{filename1 without .md}]] - {description1}
 - [[{filename2 without .md}]] - {description2}
 - [[{filename3 without .md}]] - {description3}
+```
+
+Append all at once:
+```bash
+npx @techpickles/sb daily append \
+  --section "Links" \
+  --content "{combined-links}"
 ```
 
 **3. Confirm:**
@@ -185,7 +222,7 @@ date +"%Y-%m-%d"
 ✓ Linked {N} notes to daily note: Fleeting/{date}.md
 ```
 
-If daily note doesn't exist, skip silently - notes are already captured.
+If daily note doesn't exist, skip silently (notes are already captured).
 
 ## Constraints
 
@@ -193,4 +230,4 @@ If daily note doesn't exist, skip silently - notes are already captured.
 - **Categorize clearly** - Help user understand knowledge type
 - **Batch efficiently** - Don't make user go through many dialogs
 - **Clean prose** - Each insight standalone, useful months later
-- **Zettelkasten naming** - Must use `YYYYMMDDHHMM title.md`
+- **Zettelkasten naming** - Handled by sb (YYYYMMDDHHMM title.md)

--- a/plugins/second-brain/commands/insight.md
+++ b/plugins/second-brain/commands/insight.md
@@ -2,17 +2,12 @@
 description: Capture an insight from conversation to your second brain
 argument-hint: [insight to capture]
 allowed-tools:
-  - Read(~/.claude/second-brain.md)
   - Read(~/.claude/vaults/**/CLAUDE.md)
   - Read(~/.claude/vaults/**/.obsidian/*.json)
   - Read(~/.claude/vaults/**/*.md)
   - Write(~/.claude/vaults/**/*.md)
   - Edit(~/.claude/vaults/**/*.md)
-  - Bash(ls:*)
-  - Bash(date:*)
-  - Bash(git rev-parse:*)
-  - Bash(git branch:*)
-  - Bash(mv:*)
+  - Bash(npx @techpickles/sb:*)
 ---
 
 # Capture Insight
@@ -21,19 +16,31 @@ Capture an insight from the current conversation to your Obsidian vault.
 
 ## Step 1: Load Configuration
 
-Read `~/.claude/second-brain.md` for vault name and path.
+Load configuration using sb CLI:
 
-If missing, inform user:
+```bash
+npx @techpickles/sb config default    # Get default vault name
+npx @techpickles/sb config vaults     # List all configured vaults
+```
+
+If sb is not available, inform user:
+```
+sb CLI is required but not available. Install Node.js and npm, then try again.
+Or install globally for faster execution: npm i -g @techpickles/sb
+```
+
+If no vaults are configured, inform user:
 ```
 Second brain not configured. Run /second-brain:setup first.
 ```
 
-Use the symlink path `~/.claude/vaults/{name}` to access the vault (e.g., `~/.claude/vaults/primary`).
+Use the symlink path `~/.claude/vaults/{name}` to access the vault for reading CLAUDE.md (e.g., `~/.claude/vaults/primary`).
 
 Read vault's `CLAUDE.md` for structure and routing rules.
 
 Load skill references:
 - `second-brain:obsidian` for tool mechanics
+- `references/sb-cli.md` for sb invocation details
 - `references/zettelkasten.md` for naming
 - `references/note-patterns.md` for Insight Note template
 - `references/routing.md` for destination matching
@@ -49,48 +56,20 @@ Ask: "What insight would you like to capture?"
 
 Also review recent conversation context to suggest what might be worth capturing.
 
-## Step 3: Gather Provenance
+## Step 3: Create Note with Provenance
 
-Collect context about where this insight came from:
+Create the note in inbox using sb CLI, which automatically:
+- Generates Zettelkasten filename (YYYYMMDDHHMM format)
+- Collects provenance (repo, branch, commit, timestamp)
+- Writes to inbox
 
-```bash
-# Get repo info (if in a repo)
-git rev-parse --show-toplevel 2>/dev/null || echo "none"
-git branch --show-current 2>/dev/null || echo "none"
-git rev-parse --short HEAD 2>/dev/null || echo "none"
-
-# Get timestamp
-date -u +"%Y-%m-%dT%H:%M:%SZ"
-```
-
-## Step 4: Generate Filename
-
-Use Zettelkasten format: `YYYYMMDDHHMM short-title.md`
+Use **Insight Note** pattern with cleaned up prose (1-3 paragraphs):
 
 ```bash
-date +"%Y%m%d%H%M"
-```
-
-Create short, descriptive title (3-5 words, lowercase, hyphenated).
-
-Example: `202601211430 redis-over-memcached-sessions.md`
-
-## Step 5: Write to Inbox
-
-Get inbox path from vault's `CLAUDE.md` or `.obsidian/app.json`.
-
-Use **Insight Note** pattern from `references/note-patterns.md`:
-
-```markdown
----
-captured: {ISO timestamp}
-source: claude-conversation
-repo: {repo name or "none"}
-branch: {branch name or "none"}
-commit: {short commit hash or "none"}
----
-
-# {Insight Title}
+npx @techpickles/sb note create \
+  --source auto \
+  --title "short descriptive title" \
+  --content "# {Insight Title}
 
 {The insight, cleaned up and clearly written. 1-3 paragraphs.}
 
@@ -99,58 +78,70 @@ commit: {short commit hash or "none"}
 Captured while {brief description of what you were working on/discussing}.
 
 ---
-*Captured via /second-brain:insight*
+*Captured via /second-brain:insight*"
 ```
 
-## Step 6: Confirm and Analyze for Routing
+The `--source auto` flag tells sb to:
+- Use `source: claude-conversation` in frontmatter
+- Collect git provenance (repo, branch, commit) if in a repo
+- Add `captured: {ISO timestamp}` to frontmatter
+- Generate Zettelkasten filename with current timestamp
 
-After writing, confirm capture:
+## Step 4: Confirm and Analyze for Routing
+
+After creation, sb returns the created note's path as JSON. Parse and confirm:
 ```
 ✓ Captured to inbox: {filename}
 
 Analyzing for routing...
 ```
 
-Load `references/routing.md` and follow the algorithm:
-
-**1. Discover vault structure:**
+Get routing context from sb:
 ```bash
-ls -d "{vault}"/*Areas*/*/     2>/dev/null
-ls -d "{vault}"/*Resources*/*/ 2>/dev/null
-ls -d "{vault}"/*Projects*/*/  2>/dev/null
+npx @techpickles/sb note context --note "{note-path}"
 ```
 
-**2. Extract signals from captured note:**
-- Keywords from title and body
+This returns JSON with:
+- Keywords extracted from title and body
 - Content category (architecture, debugging, tool config, etc.)
-- Source context from provenance (repo, branch)
+- Related notes in the vault
+- Source context from provenance
 
-**3. Load disambiguation rules from vault CLAUDE.md:**
+Also discover vault structure:
+```bash
+npx @techpickles/sb vault structure
+```
+
+This returns PARA folders (Areas, Resources, Projects) as structured JSON.
+
+Load disambiguation rules from vault CLAUDE.md (read via Claude's Read tool):
 - Find `### Disambiguation:` sections
 - Extract key questions, category tables, edge case mappings
 - These override generic matching for semantically similar areas
 
-**4. Score each discovered destination:**
+## Step 5: Score Destinations
 
-*If disambiguation rules apply:*
+For each discovered destination from vault structure:
+
+**If disambiguation rules apply:**
 - Check edge case mappings first (explicit rules)
 - Apply key question matches (+25% boost)
 - Apply category table matches (+15% boost)
 - Apply disambiguation mismatch penalty (-20%)
 
-*Then apply generic signals:*
+**Then apply generic signals:**
 - Keyword match in folder name (40%)
 - Related notes exist in folder (30%)
 - PARA category fit (20%)
 - Recency of folder activity (10%)
 
-**5. Calculate confidence levels:**
+**Calculate confidence levels:**
 - High (80-100%): Strong match, often with disambiguation support
 - Medium (50-79%): Partial match
 - Low (20-49%): Weak signals
 - None (<20%): Leave in inbox
 
-## Step 7: Suggest Routing
+## Step 6: Suggest Routing
 
 Present findings with explanations:
 ```
@@ -171,44 +162,48 @@ Routing suggestions for "{filename}":
 When disambiguation rules influenced the result, explain which rule applied.
 
 Use AskUserQuestion with discovered options:
-- Only include destinations that actually exist (from `ls` output)
+- Only include destinations that actually exist (from vault structure)
 - Show confidence and explanation for each
 - Always include "Leave in inbox for now" option
 
-If user selects a destination, move the file:
+If user selects a destination, move the file using sb:
 ```bash
-mv "{inbox}/{filename}" "{vault}/{selected-destination}/"
+npx @techpickles/sb note move \
+  --from "{inbox-note-path}" \
+  --to "{selected-destination}/"
 ```
 
 If all destinations score <20%, recommend inbox without asking.
 
-## Step 8: Link to Daily Note
+## Step 7: Link to Daily Note
 
-Follow `references/daily-linking.md` to connect the captured note to today's daily note.
+Link the captured note to today's daily note using sb:
 
-**1. Find today's daily note:**
 ```bash
-# Get daily notes folder from config
-cat "{vault}/.obsidian/daily-notes.json" 2>/dev/null
-date +"%Y-%m-%d"
+npx @techpickles/sb daily append \
+  --section "Links" \
+  --content "- [[{filename without .md}]] - {brief description of the insight}"
 ```
 
-**2. If daily note exists, add link to `## Links` section:**
-```markdown
-- [[{filename without .md}]] - {brief description of the insight}
+The sb CLI handles:
+- Finding today's daily note path from .obsidian config
+- Creating the daily note if it doesn't exist
+- Finding or creating the `## Links` section
+- Appending the link
+
+Confirm linking:
+```
+✓ Linked to daily note: {date}.md
 ```
 
-**3. Confirm linking:**
-```
-✓ Linked to daily note: Fleeting/{date}.md
-```
-
-If daily note doesn't exist, skip silently - the note is already captured.
+If daily note linking fails (sb returns error), skip silently. The note is already captured.
 
 ## Constraints
 
 - **Always write to inbox first** - Never skip this step
 - **Use skill references** - Get paths from skill, not hardcoded
-- **Zettelkasten naming** - Must use `YYYYMMDDHHMM title.md` format
+- **Use sb CLI for data operations** - Note creation, moving, structure discovery
+- **Use Claude's Read/Write/Edit for prose** - Reading CLAUDE.md, editing note content
+- **Zettelkasten naming** - sb handles `YYYYMMDDHHMM title.md` format automatically
 - **Show analysis before asking** - Don't just ask, show reasoning
 - **Clean prose** - Well-written insight, not raw conversation paste

--- a/plugins/second-brain/commands/process-daily.md
+++ b/plugins/second-brain/commands/process-daily.md
@@ -2,15 +2,14 @@
 description: Process voice transcriptions in today's daily note
 argument-hint: [date, e.g. 2026-01-21]
 allowed-tools:
-  - Read(~/.claude/second-brain.md)
   - Read(~/.claude/vaults/**/CLAUDE.md)
   - Read(~/.claude/vaults/**/.obsidian/*.json)
   - Read(~/.claude/vaults/**/Glossary.md)
   - Read(~/.claude/vaults/**/*.md)
   - Edit(~/.claude/vaults/**/*.md)
   - Write(~/.claude/vaults/**/*.md)
+  - Bash(npx @techpickles/sb:*)
   - Bash(ls:*)
-  - Bash(date:*)
 ---
 
 # Process Daily Note
@@ -61,14 +60,18 @@ Read `CLAUDE.md` at vault root for:
 
 ### Step 1.2: Find the Daily Note
 
-**If argument provided:** Use as date (parse YYYY-MM-DD format)
-**If no argument:** Use today's date
+Get the daily note path using sb:
 
 ```bash
-date +"%Y-%m-%d"
+npx @techpickles/sb daily path
 ```
 
-Construct path from vault's daily note location (e.g., `Fleeting/{date}.md`).
+**If argument provided:** Pass the date to sb:
+```bash
+npx @techpickles/sb daily path --date "{YYYY-MM-DD}"
+```
+
+sb returns the full path to the daily note based on .obsidian config.
 
 If file doesn't exist, inform user and stop.
 

--- a/plugins/second-brain/commands/route.md
+++ b/plugins/second-brain/commands/route.md
@@ -2,11 +2,9 @@
 description: Route notes from inbox to appropriate vault destinations
 argument-hint: [filename | "all"]
 allowed-tools:
-  - Read(~/.claude/second-brain.md)
   - Read(~/.claude/vaults/**/CLAUDE.md)
   - Read(~/.claude/vaults/**/*.md)
-  - Bash(ls:*)
-  - Bash(mv:*)
+  - Bash(npx @techpickles/sb:*)
 ---
 
 # Route Notes
@@ -15,18 +13,36 @@ Route notes from inbox to appropriate destinations in your vault.
 
 ## Step 1: Load Configuration
 
-Read `~/.claude/second-brain.md` for vault name and path.
+Verify sb CLI availability:
 
-If missing:
+```bash
+npx @techpickles/sb --version
+```
+
+If this fails:
+```
+sb CLI is required but not available. Install Node.js and npm, then try again.
+Or install globally for faster execution: npm i -g @techpickles/sb
+```
+
+Load configuration:
+
+```bash
+npx @techpickles/sb config default
+npx @techpickles/sb config vaults
+```
+
+If no vault configured:
 ```
 Second brain not configured. Run /second-brain:setup first.
 ```
 
-Use the symlink path `~/.claude/vaults/{name}` to access the vault (e.g., `~/.claude/vaults/primary`).
+Use the symlink path `~/.claude/vaults/{name}` to Read vault files (e.g., `~/.claude/vaults/primary/CLAUDE.md`).
 
 Load skill references:
 - `second-brain:obsidian` for tool mechanics
 - `references/routing.md` for routing algorithm
+- `references/sb-cli.md` for sb command reference
 
 ## Step 2: Identify Notes to Route
 
@@ -40,9 +56,28 @@ List all files in inbox for batch routing.
 List inbox contents and let user select:
 
 ```bash
-ls "{vault}/{inbox}/"
+npx @techpickles/sb inbox list
 ```
 
+Example output:
+```json
+{
+  "notes": [
+    {
+      "filename": "202601251430 redis-session-caching.md",
+      "timestamp": "202601251430",
+      "title": "redis-session-caching"
+    },
+    {
+      "filename": "202601251445 claude-code-hooks.md",
+      "timestamp": "202601251445",
+      "title": "claude-code-hooks"
+    }
+  ]
+}
+```
+
+Present to user:
 ```
 Notes in inbox:
 1. 202601251430 redis-session-caching.md
@@ -57,16 +92,32 @@ Use AskUserQuestion with multi-select to let user choose.
 ## Step 3: Discover Vault Structure
 
 ```bash
-ls -d "{vault}"/*Areas*/*/     2>/dev/null
-ls -d "{vault}"/*Resources*/*/ 2>/dev/null
-ls -d "{vault}"/*Projects*/*/  2>/dev/null
+npx @techpickles/sb vault structure
 ```
 
-Build destination map from actual paths only.
+Example output:
+```json
+{
+  "areas": [
+    "Areas/AI/agentic development",
+    "Areas/tool sharpening"
+  ],
+  "resources": [
+    "Resources/software engineering",
+    "Resources/mental models"
+  ],
+  "projects": [
+    "Projects/pickletown",
+    "Projects/claude-plugins"
+  ]
+}
+```
+
+Build destination map from returned paths only.
 
 ## Step 4: Load Disambiguation Rules
 
-Read the vault's `CLAUDE.md` and look for `### Disambiguation:` sections.
+Read the vault's `CLAUDE.md` via symlink (e.g., `~/.claude/vaults/primary/CLAUDE.md`) and look for `### Disambiguation:` sections.
 
 If found, extract:
 - **Key questions** - Decision heuristics for each area
@@ -79,11 +130,29 @@ These rules override generic matching for semantically similar areas.
 
 For each selected note, follow `references/routing.md` algorithm:
 
-1. **Extract signals** from note content:
-   - Keywords from title (after Zettelkasten prefix)
-   - Key terms from body
-   - Category (architecture, debugging, tool, etc.)
-   - Source context from frontmatter
+1. **Extract signals** using sb:
+
+```bash
+npx @techpickles/sb note context --note "inbox/202601251430 redis-session-caching.md"
+```
+
+Example output:
+```json
+{
+  "keywords": ["redis", "session", "caching"],
+  "category": "architecture",
+  "relatedNotes": [
+    {
+      "path": "Areas/AI/agentic development/Redis patterns.md",
+      "similarity": 0.85
+    }
+  ],
+  "sourceContext": {
+    "origin": "slack",
+    "thread": "https://..."
+  }
+}
+```
 
 2. **Apply disambiguation rules** (if loaded):
    - Check edge case mappings first (explicit rules)
@@ -147,8 +216,10 @@ Use AskUserQuestion:
 For each note being routed:
 
 ```bash
-mv "{inbox}/{filename}" "{vault}/{destination}/"
+npx @techpickles/sb note move --from "inbox/202601251430 redis-session-caching.md" --to "Areas/AI/agentic development/"
 ```
+
+sb handles the filesystem operation and returns confirmation.
 
 ## Step 8: Report Success
 
@@ -175,7 +246,7 @@ mv "{inbox}/{filename}" "{vault}/{destination}/"
 
 ## Constraints
 
-- **Never suggest non-existent paths** - Only use `ls` output
+- **Never suggest non-existent paths** - Only use `vault structure` output
 - **Always include inbox option** - Safe default for uncertain cases
 - **Show reasoning** - Users should understand why
 - **Preserve filenames** - Don't rename when moving

--- a/plugins/second-brain/commands/search.md
+++ b/plugins/second-brain/commands/search.md
@@ -2,8 +2,8 @@
 description: Search your second brain using semantic search
 argument-hint: <query>
 allowed-tools:
-  - Read(~/.claude/second-brain.md)
   - Read(~/.claude/vaults/**/*.md)
+  - Bash(npx @techpickles/sb:*)
   - Bash(which:qmd)
   - Bash(qmd:query *)
   - Bash(qmd:collection list)
@@ -36,10 +36,13 @@ Then configure a collection:
 
 ## Step 2: Load Configuration
 
-Read `~/.claude/second-brain.md` for vault configuration.
+Get the qmd collection name via sb:
 
-Extract collection name from the `qmd_collection` setting under the vault's settings section.
-If not set, default to `second-brain`.
+```bash
+npx @techpickles/sb config qmd-collection
+```
+
+This returns the configured collection name (defaults to `second-brain` if not set).
 
 Verify the collection exists:
 ```bash

--- a/plugins/second-brain/commands/setup.md
+++ b/plugins/second-brain/commands/setup.md
@@ -2,79 +2,83 @@
 description: Set up second-brain vault configuration
 allowed-tools:
   - Read(~/.claude/second-brain.md)
-  - Write(~/.claude/second-brain.md)
   - Read(~/.claude/vaults/**/CLAUDE.md)
-  - Read(~/.claude/vaults/**/.obsidian/*.json)
   - Write(~/.claude/vaults/**/CLAUDE.md)
+  - Bash(npx @techpickles/sb:*)
   - Bash(ls:*)
   - Bash(mkdir:*)
   - Bash(ln:*)
-  - Bash(readlink:*)
 ---
 
 # Second Brain Setup
 
 Configure vault paths and scaffold vault CLAUDE.md.
 
-## Step 1: Check Existing Config
+For sb CLI details, see [references/sb-cli.md](../skills/obsidian/references/sb-cli.md).
 
-Read `~/.claude/second-brain.md` if it exists.
+## Step 1: Check Prerequisites
 
-If exists, show current vaults and ask:
+Verify sb CLI is available:
+
+```bash
+npx @techpickles/sb --version
+```
+
+If this fails:
+```
+sb CLI is required but not available. Install Node.js and npm, then try again.
+Or install globally for faster execution: npm i -g @techpickles/sb
+```
+
+## Step 2: Check Existing Config
+
+Check if vaults are already configured:
+
+```bash
+npx @techpickles/sb config vaults
+```
+
+This returns JSON with configured vaults.
+
+If vaults exist, show current and ask:
 - Add another vault?
 - Reconfigure existing vault?
 - Cancel
 
-## Step 2: Get Vault Path
+## Step 3: Get Vault Path
 
-Ask user for vault path. No assumed locations - just ask directly:
+Ask user for vault path. No assumed locations, just ask directly:
 
 "Where is your Obsidian vault located? (full path)"
 
-## Step 3: Validate Vault
+## Step 4: Validate Vault
 
-Check the path:
+Check the path exists:
 
 ```bash
-# Path exists?
 ls -d "{path}" 2>/dev/null
-
-# Is it an Obsidian vault?
-ls -d "{path}/.obsidian" 2>/dev/null
 ```
 
-If `.obsidian/` missing:
-- Might not be an Obsidian vault
-- Offer to continue anyway (for plain markdown repos)
-- Or user can open folder in Obsidian first to initialize
-
-## Step 4: Parse .obsidian/ Config
-
-If `.obsidian/` exists, read settings:
+Parse .obsidian config (if present):
 
 ```bash
-# Daily notes
-cat "{path}/.obsidian/daily-notes.json" 2>/dev/null
-
-# Templates
-cat "{path}/.obsidian/templates.json" 2>/dev/null
-
-# Zettelkasten/inbox
-cat "{path}/.obsidian/zk-prefixer.json" 2>/dev/null
-
-# General settings
-cat "{path}/.obsidian/app.json" 2>/dev/null
+npx @techpickles/sb vault obsidian --path "{path}"
 ```
 
-Extract:
+This outputs JSON with:
 - Daily notes folder and template
 - Templates folder
 - Inbox/new notes folder
 - Attachments folder
 
+If `.obsidian/` missing, sb will indicate this in the output:
+- Might not be an Obsidian vault
+- Offer to continue anyway (for plain markdown repos)
+- Or user can open folder in Obsidian first to initialize
+
 ## Step 5: Confirm Settings
 
-Show detected settings:
+Show detected settings from the sb output:
 
 ```
 Detected from .obsidian/:
@@ -94,21 +98,23 @@ Ask for short identifier:
 
 Suggest "primary" if this is the first vault.
 
-## Step 7: Write Global Config
+## Step 7: Initialize Configuration
 
 Create or update `~/.claude/second-brain.md`:
 
-```markdown
-# Second Brain Configuration
-
-## Vaults
-
-- {name}: {path}
-
-Default: {name}
+```bash
+npx @techpickles/sb init --name "{name}" --path "{path}"
 ```
 
-If file exists, append new vault to list.
+Add `--scaffold` flag if user wants to create vault CLAUDE.md:
+
+```bash
+npx @techpickles/sb init --name "{name}" --path "{path}" --scaffold
+```
+
+This command:
+- Writes the vault configuration to `~/.claude/second-brain.md`
+- Optionally creates `{vault}/CLAUDE.md` with detected settings
 
 ## Step 8: Create Vault Symlink
 
@@ -127,15 +133,18 @@ ls -la ~/.claude/vaults/{name}
 
 This symlink provides a well-known path for permissions and access.
 
-## Step 9: Scaffold Vault CLAUDE.md
+## Step 9: Show Permissions
 
-Check if `{vault}/CLAUDE.md` exists.
+Generate permission entries for Claude Code settings:
 
-If missing, offer to create from template:
+```bash
+npx @techpickles/sb permissions --vault "{name}"
+```
 
-"Your vault doesn't have a CLAUDE.md. Create one with detected settings? [Yes] [No]"
-
-If yes, use `templates/vault-claude-md.md` as base, filling in detected values.
+This outputs the exact permission strings needed for:
+- Read/Write on the vault path
+- Read/Write on CLAUDE.md
+- Read on .obsidian config
 
 ## Step 10: Confirm Complete
 
@@ -146,6 +155,9 @@ Vault: {name} → {path}
 Symlink: ~/.claude/vaults/{name}
 Config: ~/.claude/second-brain.md
 
+Add these permissions to your Claude Code settings:
+{output from sb permissions}
+
 Next steps:
 - Use /second-brain:insight to capture from any repo
 - Use /second-brain:link-project to connect a repo to your vault
@@ -154,10 +166,12 @@ Next steps:
 
 ## Adding Additional Vaults
 
-If `~/.claude/second-brain.md` already exists:
+If vaults already exist (shown in Step 2):
 
-1. Show current vaults
+1. Show current vaults from `npx @techpickles/sb config vaults`
 2. Ask for new vault path
-3. Follow same validation/detection flow
-4. Append to existing config
-5. Ask if this should be the new default
+3. Follow same validation/detection flow (Steps 3-5)
+4. Run `npx @techpickles/sb init --name "{name}" --path "{path}"` (appends to config)
+5. Create symlink for new vault (Step 8)
+6. Generate and show permissions (Step 9)
+7. Ask if this should be the new default

--- a/plugins/second-brain/docs/plans/2026-03-10-sb-cli-integration.md
+++ b/plugins/second-brain/docs/plans/2026-03-10-sb-cli-integration.md
@@ -1,0 +1,85 @@
+# sb CLI Integration into Second-Brain Plugin
+
+Bean: gt-szcn
+Parent epic: gt-meu3 (Batch 5)
+Date: 2026-03-10
+
+## Goal
+
+Refactor second-brain plugin commands to delegate data operations to the sb CLI (`@techpickles/sb`) instead of raw Bash/Read/Write calls. Reduces tool call count, improves reliability, and centralizes vault logic in a tested CLI.
+
+## Architecture Decisions
+
+### sb handles data, Claude handles decisions
+
+sb does structured operations: note creation, moving, vault discovery, config, provenance. Claude keeps native Read/Write/Edit for prose editing, reading vault files for decision-making, and all routing/selection logic.
+
+### Invocation via npx
+
+All commands call sb as `npx @techpickles/sb <command>`. A shared reference file (`references/sb-cli.md`) defines the invocation pattern. Swapping to global install or a different package name later is a one-file change.
+
+### Symlinks stay (for now)
+
+`~/.claude/vaults/{name}` symlinks remain for `allowed-tools` permissions in command frontmatter. sb handles the actual vault operations. Symlinks can be removed when Claude Code supports dynamic permissions or sb handles all file access.
+
+### allowed-tools changes
+
+For commands that adopt sb:
+- Remove: `Bash(date:*)`, `Bash(git rev-parse:*)`, `Bash(git branch:*)`, `Bash(mv:*)`
+- Add: `Bash(npx @techpickles/sb:*)`
+- Keep: `Read`/`Write`/`Edit` on vault symlink paths (for prose editing, reading notes)
+- Keep: `Bash(ls:*)` only where still needed
+
+## New File
+
+### `skills/obsidian/references/sb-cli.md`
+
+Single source of truth for sb invocation pattern and available commands. All commands that call sb load this reference. Contains prerequisite check, invocation prefix, and command quick-reference.
+
+## Command Changes
+
+### `insight` (heavy rewrite)
+
+Before: 8+ tool calls (Read config, Bash git x3, Bash date, Write note, Bash ls for structure, Bash mv, Edit daily note)
+
+After:
+1. `sb note create --source auto --title "..." --content "..."` (provenance + date + filename + write)
+2. `sb note context --note "..."` (structure discovery + keyword extraction)
+3. Claude reads vault CLAUDE.md, makes routing decision
+4. `sb note move --from "..." --to "..."` (routing execution)
+5. `sb daily append --section "Links" --content "..."` (daily linking)
+
+Still uses Claude native tools for: vault CLAUDE.md disambiguation rules, AskUserQuestion for routing, writing insight prose.
+
+### `distill-conversation` (heavy rewrite)
+
+Same sb calls as insight, batched. Conversation review and insight identification (pure Claude reasoning) unchanged. Batch routing uses `sb vault structure` once, then `sb note context` + `sb note move` per note. Batch daily linking uses `sb daily append` once with all links.
+
+### `route` (heavy rewrite)
+
+Before: Bash ls for structure, Read notes for analysis, Bash mv
+After: `sb inbox list` to enumerate, `sb note context` per note, `sb vault structure` for destinations, `sb note move` to execute. Claude still makes routing decisions with disambiguation rules.
+
+### `setup` (heavy rewrite)
+
+Before: Manual config writing, symlink creation, .obsidian parsing
+After: `sb init --name "..." --path "..."` for config writing. `sb permissions` for permission entries. Symlink creation stays. sb does .obsidian parsing, setup reads results for confirmation display.
+
+### `search` (light touch)
+
+Replace manual config parsing for collection name with `sb config qmd-collection`. qmd calls unchanged.
+
+### `process-daily` (light touch)
+
+Replace `date` + manual path construction with `sb daily path`. Prose cleaning, restructuring (bulk of command) unchanged.
+
+### `link-project` (no change)
+
+Deferred. Rarely used, symlinks staying anyway.
+
+## Verification
+
+1. Valid YAML frontmatter with updated `allowed-tools` on all changed commands
+2. All sb-calling commands reference `references/sb-cli.md`
+3. No orphaned raw Bash calls for operations sb now handles
+4. Smoke test: reinstall plugin, run `/second-brain:insight` end-to-end with real vault

--- a/plugins/second-brain/skills/obsidian/references/sb-cli.md
+++ b/plugins/second-brain/skills/obsidian/references/sb-cli.md
@@ -1,0 +1,62 @@
+# sb CLI Reference
+
+The second-brain plugin uses `sb` for vault data operations (note creation, moving, config, structure discovery). This file defines how to invoke it.
+
+## Invocation
+
+```bash
+npx @techpickles/sb <command> [options]
+```
+
+All sb commands output JSON for structured parsing.
+
+## Prerequisite Check
+
+Before the first sb call in any command flow, verify availability:
+
+```bash
+npx @techpickles/sb --version
+```
+
+If this fails:
+```
+sb CLI is required but not available. Install Node.js and npm, then try again.
+Or install globally for faster execution: npm i -g @techpickles/sb
+```
+
+## Commands
+
+### Configuration
+- `npx @techpickles/sb config vaults` - list configured vaults as JSON
+- `npx @techpickles/sb config default` - get default vault name
+- `npx @techpickles/sb config qmd-collection` - qmd collection name for semantic search
+
+### Vault
+- `npx @techpickles/sb vault info` - vault metadata
+- `npx @techpickles/sb vault obsidian` - parse .obsidian config as JSON
+- `npx @techpickles/sb vault structure` - discover PARA folders as JSON
+
+### Notes
+- `npx @techpickles/sb note create --source auto --title "..." --content "..."` - create Zettelkasten note in inbox
+- `npx @techpickles/sb note create --source auto --title "..." --content "..." --dry-run` - preview without writing
+- `npx @techpickles/sb note read --note "path/to/note.md"` - parse note as structured JSON
+- `npx @techpickles/sb note context --note "path/to/note.md"` - routing context (keywords, category, related notes)
+- `npx @techpickles/sb note move --from "inbox/note.md" --to "Areas/topic/"` - move note to destination
+
+### Daily Notes
+- `npx @techpickles/sb daily path` - today's daily note path
+- `npx @techpickles/sb daily append --section "Links" --content "- [[note]]"` - append to daily note section
+
+### Inbox
+- `npx @techpickles/sb inbox list` - list inbox notes (lightweight: filename, timestamp, title)
+- `npx @techpickles/sb inbox list --detail` - with parsed frontmatter
+
+### Setup
+- `npx @techpickles/sb init --name "..." --path "..."` - initialize vault configuration
+- `npx @techpickles/sb init --name "..." --path "..." --scaffold` - also create vault CLAUDE.md
+- `npx @techpickles/sb permissions` - generate Claude Code permission entries for vault
+- `npx @techpickles/sb permissions --vault "name"` - for a specific vault
+
+### Context
+- `npx @techpickles/sb provenance` - git context (repo, branch, commit) as JSON
+- `npx @techpickles/sb describe <command>` - runtime schema introspection


### PR DESCRIPTION
## Summary

Refactors second-brain plugin commands to delegate data operations to the [`@techpickles/sb`](https://www.npmjs.com/package/@techpickles/sb) CLI instead of raw Bash/Read/Write calls. This is Batch 5 of the sb public release effort (gt-meu3).

- **Heavy rewrites:** insight, distill-conversation, route, setup now use sb for note creation, moving, vault discovery, config, provenance, and daily linking
- **Light touch:** search uses `sb config qmd-collection`, process-daily uses `sb daily path`
- **New reference:** `references/sb-cli.md` defines invocation pattern in one place (currently `npx @techpickles/sb`, swappable to global install later)
- **Unchanged:** link-project (deferred, rarely used)

### What sb replaces

| Before | After |
|--------|-------|
| `git rev-parse`, `git branch` for provenance | `sb note create --source auto` |
| `date +"%Y%m%d%H%M"` for timestamps | sb handles internally |
| `ls -d` for PARA structure discovery | `sb vault structure` |
| `mv` for routing | `sb note move` |
| Manual daily note path construction | `sb daily path` / `sb daily append` |
| Reading `~/.claude/second-brain.md` for config | `sb config vaults` / `sb config default` |
| Manual `.obsidian/*.json` parsing | `sb vault obsidian` |

### Design decisions

- **Symlinks stay** (`~/.claude/vaults/{name}`) for `allowed-tools` permissions. Removal deferred until Claude Code supports dynamic permissions.
- **Claude keeps Read/Write/Edit** for prose editing and reading vault CLAUDE.md for disambiguation rules. sb handles structured data operations.
- Design doc: `plugins/second-brain/docs/plans/2026-03-10-sb-cli-integration.md`

## Test plan

- [ ] Verify YAML frontmatter parses correctly on all changed commands
- [ ] Smoke test `/second-brain:insight` end-to-end with a real vault
- [ ] Verify `/second-brain:setup` flow works with sb init
- [ ] Confirm no orphaned raw Bash calls for replaced operations

Bean: gt-szcn | Epic: gt-meu3

🤖 Generated with [Claude Code](https://claude.com/claude-code)