### PR TITLE
fix(agent-meta): resolve session ID via Bash in park skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "1.1.0"
+      "version": "1.2.0"
     }
   ]
 }

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -43,13 +43,18 @@ Resolve location in order:
 
 Ensure the directory exists. If using `.parkinglot/`, check it's gitignored.
 
+## Before Writing
+
+1. Run `echo $CLAUDE_SESSION_ID` via Bash to get the current session ID. If empty, use "unknown".
+2. Gather git branch, worktree path, and other context.
+
 ## Output Format
 
 ```markdown
 # Parked: [Topic]
 
 **Parked:** [Date/time]
-**Session:** [value of $CLAUDE_SESSION_ID if available]
+**Session:** [session ID from Bash]
 **Branch:** [branch-name]
 **Worktree:** [path if applicable]
 

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -49,6 +49,7 @@ Ensure the directory exists. If using `.parkinglot/`, check it's gitignored.
 # Parked: [Topic]
 
 **Parked:** [Date/time]
+**Session:** [value of $CLAUDE_SESSION_ID if available]
 **Branch:** [branch-name]
 **Worktree:** [path if applicable]
 

--- a/plugins/agent-meta/skills/unpark/SKILL.md
+++ b/plugins/agent-meta/skills/unpark/SKILL.md
@@ -77,6 +77,16 @@ Options:
 
 If option A: Update the handoff file with current findings, then recommend running `/unpark` again.
 
+## Session Chains
+
+Handoff docs may contain a `Session:` field with the session ID that parked the work. This enables tracing work across park/unpark cycles. If present, the session chain looks like:
+
+```
+Session A (parked) -> handoff.md -> Session B (unparked) -> parked again -> ...
+```
+
+Session tracking tools (if available) can use this to link sessions together.
+
 ## Edge Cases
 
 - **Branch doesn't exist:** Offer to create it or pick a different branch


### PR DESCRIPTION
## Summary

- The park skill template referenced `$CLAUDE_SESSION_ID` but the Write tool doesn't do shell expansion, so handoff files got the literal string instead of the actual session ID
- Added a "Before Writing" prep step that tells Claude to run `echo $CLAUDE_SESSION_ID` via Bash first and use the result
- Updated the template placeholder to reference the resolved value

Closes gt-x48t

## Test plan

- [ ] Invoke `/park` in a session and verify the handoff file contains the actual session UUID, not `$CLAUDE_SESSION_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)