### PR TITLE
feat(second-brain): use two-step flow for note creation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.6.0"
+      "version": "1.7.0"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/commands/distill-conversation.md
+++ b/plugins/second-brain/commands/distill-conversation.md
@@ -100,20 +100,28 @@ Include "None - skip capture" option.
 
 ## Step 5: Capture Selected
 
-For each selected insight, create note with sb:
+For each selected insight, create note scaffold with sb, then write body with Write tool:
 
+**5a. Create scaffold:**
 ```bash
 npx @techpickles/sb note create \
   --source auto \
-  --title "{insight title}" \
-  --content "{insight content with provenance}"
+  --title "{insight title}"
 ```
 
+Parse the returned JSON to get the file path.
+
+**5b. Write note body:**
+
+Read the created file to get the exact frontmatter, then use the Write tool to write the full note (frontmatter + body) using **Insight Note** pattern.
+
+**5c. Repeat** for each selected insight.
+
 This handles:
-- Zettelkasten timestamp filename generation
-- Provenance tracking (git context)
-- Writing to inbox with proper frontmatter
-- Daily note date stamping
+- Zettelkasten timestamp filename generation (sb)
+- Provenance tracking via git context (sb)
+- Writing to inbox with proper frontmatter (sb)
+- Clean prose content (Write tool)
 
 Show confirmation:
 ```

--- a/plugins/second-brain/commands/insight.md
+++ b/plugins/second-brain/commands/insight.md
@@ -62,20 +62,38 @@ Ask: "What insight would you like to capture?"
 
 Also review recent conversation context to suggest what might be worth capturing.
 
-## Step 3: Create Note with Provenance
+## Step 3: Create Note Scaffold
 
-Create the note in inbox using sb CLI, which automatically:
-- Generates Zettelkasten filename (YYYYMMDDHHMM format)
-- Collects provenance (repo, branch, commit, timestamp)
-- Writes to inbox
-
-Use **Insight Note** pattern with cleaned up prose (1-3 paragraphs):
+Create the note scaffold using sb CLI (without --content):
 
 ```bash
 npx @techpickles/sb note create \
   --source auto \
-  --title "short descriptive title" \
-  --content "# {Insight Title}
+  --title "short descriptive title"
+```
+
+sb creates the file with frontmatter and title heading only. Returns JSON with the created path:
+```json
+{
+  "path": "/path/to/vault/Inbox/202603111430 short-descriptive-title.md",
+  "filename": "202603111430 short-descriptive-title.md"
+}
+```
+
+The `--source auto` flag tells sb to:
+- Use `source: claude-conversation` in frontmatter
+- Collect git provenance (repo, branch, commit) if in a repo
+- Add `captured: {ISO timestamp}` to frontmatter
+- Generate Zettelkasten filename with current timestamp
+
+Then write the note body using Claude's **Write tool** at the returned path. Read the created file first (to get the exact frontmatter sb wrote), then rewrite with the full note content:
+
+Use **Insight Note** pattern with cleaned up prose (1-3 paragraphs):
+
+```
+{frontmatter from sb, preserved exactly}
+
+# {Insight Title}
 
 {The insight, cleaned up and clearly written. 1-3 paragraphs.}
 
@@ -84,14 +102,10 @@ npx @techpickles/sb note create \
 Captured while {brief description of what you were working on/discussing}.
 
 ---
-*Captured via /second-brain:insight*"
+*Captured via /second-brain:insight*
 ```
 
-The `--source auto` flag tells sb to:
-- Use `source: claude-conversation` in frontmatter
-- Collect git provenance (repo, branch, commit) if in a repo
-- Add `captured: {ISO timestamp}` to frontmatter
-- Generate Zettelkasten filename with current timestamp
+**Why two steps?** The sb call is a short, easy-to-approve Bash command. The Write tool has a clean approval UI for file content. Together they're much easier to review than a single Bash command with embedded multi-paragraph prose.
 
 ## Step 4: Confirm and Analyze for Routing
 

--- a/plugins/second-brain/skills/obsidian/references/sb-cli.md
+++ b/plugins/second-brain/skills/obsidian/references/sb-cli.md
@@ -37,8 +37,9 @@ Or install globally for faster execution: npm i -g @techpickles/sb
 - `npx @techpickles/sb vault structure` - discover PARA folders as JSON
 
 ### Notes
-- `npx @techpickles/sb note create --source auto --title "..." --content "..."` - create Zettelkasten note in inbox
-- `npx @techpickles/sb note create --source auto --title "..." --content "..." --dry-run` - preview without writing
+- `npx @techpickles/sb note create --source auto --title "..."` - create note scaffold in inbox (frontmatter + heading, returns path as JSON)
+- `npx @techpickles/sb note create --source auto --title "..." --content "..."` - create note with body (use for short content only)
+- `npx @techpickles/sb note create --source auto --title "..." --dry-run` - preview without writing
 - `npx @techpickles/sb note read --note "path/to/note.md"` - parse note as structured JSON
 - `npx @techpickles/sb note context --note "path/to/note.md"` - routing context (keywords, category, related notes)
 - `npx @techpickles/sb note move --from "inbox/note.md" --to "Areas/topic/"` - move note to destination


### PR DESCRIPTION
## Summary

- Update `insight` and `distill-conversation` commands to use a two-step note creation flow: `sb note create` for metadata (frontmatter, Zettelkasten filename, provenance), then Claude's Write tool for the body content
- Update `sb-cli.md` reference to document scaffold-only `note create` (no `--content`)

## Why

Passing multi-paragraph prose via `--content` CLI arg creates a wall of text in the Bash approval prompt. The two-step flow gives one short Bash approval (sb metadata) plus one clean Write tool approval (file content).

Requires `@techpickles/sb@0.2.0` (already published).

## Test Plan

- [ ] Run `/second-brain:insight` end-to-end, verify sb creates scaffold then Write tool fills body
- [ ] Run `/second-brain:distill-conversation`, verify batch creation uses two-step flow
- [ ] Verify approval prompts are cleaner (short Bash + Write instead of wall-of-text Bash)