### PR TITLE
fix(tool-routing): use file-based capture for plugin list discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "tool-routing",
       "source": "./plugins/tool-routing",
-      "version": "1.2.2"
+      "version": "1.2.3"
     },
     {
       "name": "stay-on-target",

--- a/docs/known-claude-code-bugs.md
+++ b/docs/known-claude-code-bugs.md
@@ -1,0 +1,57 @@
+# Known Claude Code Bugs Affecting Plugins
+
+Bugs in Claude Code that affect plugin development and behavior. These are tracked upstream but worth knowing about when debugging plugin issues.
+
+## 64KB Pipe Truncation
+
+**Issue:** [#36685](https://github.com/anthropics/claude-code/issues/36685), [#31408](https://github.com/anthropics/claude-code/issues/31408) (closed/locked)
+
+`claude plugin list --json` silently truncates at 64KB when captured via subprocess pipe. File redirect produces the full output. With enough plugins installed (~235 across projects), the JSON exceeds 64KB and gets cut off mid-object, producing invalid JSON.
+
+**Impact:** Any code that shells out to `claude plugin list --json` and reads stdout via pipe gets broken silently. This broke tool-routing's route discovery (no routes found, hooks never block).
+
+**Workaround:** Use file-based capture instead of pipe:
+
+```python
+# Broken: truncates at 64KB
+result = subprocess.run(["claude", "plugin", "list", "--json"],
+                        capture_output=True, text=True)
+json.loads(result.stdout)  # JSONDecodeError
+
+# Works: file redirect captures full output
+with open(tmp_path, "w") as f:
+    subprocess.run(["claude", "plugin", "list", "--json"], stdout=f)
+json.loads(Path(tmp_path).read_text())  # OK
+```
+
+**Root cause (likely):** Node.js stdout flushing. `process.exit()` called before the write buffer (default `highWaterMark`: 64KB) drains to pipe. The constant `65536` appears in multiple places in the codebase (#29088, #35085).
+
+## enabledPlugins Scope Bug
+
+**Issue:** [#27247](https://github.com/anthropics/claude-code/issues/27247)
+
+`enabledPlugins` in settings only works at user scope (`~/.claude/settings.json`). Project (`.claude/settings.json`) and local (`.claude/settings.local.json`) scopes are silently ignored for hook loading.
+
+**Impact:** Plugins installed with `claude plugin install --scope local` (what fitout does) appear in `claude plugin list` but report `enabled: false`. Hooks from these plugins never fire.
+
+**Nuance:** Skills DO load from locally-scoped plugins. Only hooks are affected. So a plugin's skills work fine, but its hooks silently don't.
+
+**Workaround:** Add plugins to `~/.claude/settings.json` enabledPlugins manually:
+
+```json
+{
+  "enabledPlugins": {
+    "tool-routing@pickled-claude-plugins": true,
+    "git@pickled-claude-plugins": true
+  }
+}
+```
+
+## Debugging Checklist
+
+When hooks aren't firing, check in this order:
+
+1. **Is the plugin enabled globally?** Check `~/.claude/settings.json` enabledPlugins (not just project/local settings)
+2. **Does `claude plugin list --json` produce valid JSON?** Pipe it to `wc -c`. If exactly 65536/65537 bytes, you're hitting the truncation bug.
+3. **Did you restart Claude Code?** Hooks are captured at startup.
+4. **Is hooks.json formatted correctly?** Run `claude plugin validate <path>` and check the plugin structure tests.

--- a/plugins/tool-routing/docs/route-discovery.md
+++ b/plugins/tool-routing/docs/route-discovery.md
@@ -224,21 +224,33 @@ Use `gh pr view <number>` for GitHub PRs.
 
 ### Routes Not Being Discovered
 
-**Symptom:** `tool-routing list` shows fewer sources than expected.
+**Symptom:** `tool-routing list` shows "No routes found" or fewer sources than expected.
 
-**Common causes:**
+**Common causes (check in this order):**
 
-1. **Missing routes.json manifest** - Ensure `.claude-plugin/routes.json` exists
+1. **64KB pipe truncation** (Claude Code bug [#36685](https://github.com/anthropics/claude-code/issues/36685)) - If you have many plugins installed, `claude plugin list --json` output may exceed 64KB and get silently truncated when captured via pipe, producing invalid JSON. Discovery fails silently and returns zero routes.
+
+   Check: `claude plugin list --json | wc -c`. If output is exactly 65536/65537 bytes, you're hitting this.
+
+   **Fixed in tool-routing 1.2.1** (uses file-based capture instead of pipe). If running an older version, update.
+
+2. **enabledPlugins scope bug** (Claude Code bug [#27247](https://github.com/anthropics/claude-code/issues/27247)) - Plugins installed at project/local scope (`--scope local`) report `enabled: false` in the CLI, even though they're in settings. Only plugins in `~/.claude/settings.json` enabledPlugins are treated as enabled for hooks.
+
+   Workaround: Add your plugins to `~/.claude/settings.json` enabledPlugins.
+
+   See [docs/known-claude-code-bugs.md](../../../docs/known-claude-code-bugs.md) for details on both bugs.
+
+3. **Missing routes.json manifest** - Ensure `.claude-plugin/routes.json` exists
    ```bash
    cat ~/.claude/plugins/cache/{marketplace}/{plugin}/{version}/.claude-plugin/routes.json
    ```
 
-2. **Plugin not enabled** - Check with Claude CLI
+4. **Plugin not enabled** - Check with Claude CLI
    ```bash
    claude plugin list --json | jq '.[] | select(.enabled == true) | .id'
    ```
 
-3. **Project path mismatch (local-scoped plugins)** - Local-scoped plugins use **exact path matching**. The plugin's `projectPath` must exactly equal `CLAUDE_PROJECT_ROOT` (or cwd if unset).
+5. **Project path mismatch (local-scoped plugins)** - Local-scoped plugins use **exact path matching**. The plugin's `projectPath` must exactly equal `CLAUDE_PROJECT_ROOT` (or cwd if unset).
 
    Check the plugin's project path:
    ```bash

--- a/plugins/tool-routing/src/tool_routing/discovery.py
+++ b/plugins/tool-routing/src/tool_routing/discovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import tempfile
 from pathlib import Path
 
 
@@ -17,20 +18,31 @@ def get_enabled_plugins(project_path: str | None = None) -> list[dict]:
     Returns:
         List of enabled plugin dicts with id, installPath, scope, etc.
     """
-    result = subprocess.run(
-        ["claude", "plugin", "list", "--json"],
-        capture_output=True,
-        text=True,
-        timeout=10
-    )
-
-    if result.returncode != 0:
-        return []
+    # Use a temp file instead of pipe capture to avoid 64KB truncation.
+    # `claude plugin list --json` output exceeds pipe buffer limits when
+    # many plugins are installed across projects.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+        tmp_path = tmp.name
 
     try:
-        plugins = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return []
+        with open(tmp_path, "w") as outfile:
+            result = subprocess.run(
+                ["claude", "plugin", "list", "--json"],
+                stdout=outfile,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=10,
+            )
+
+        if result.returncode != 0:
+            return []
+
+        try:
+            plugins = json.loads(Path(tmp_path).read_text())
+        except json.JSONDecodeError:
+            return []
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
 
     # Filter to enabled plugins
     enabled = []

--- a/plugins/tool-routing/tests/test_discovery_new.py
+++ b/plugins/tool-routing/tests/test_discovery_new.py
@@ -2,9 +2,18 @@
 
 import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import pytest
+
+
+def _mock_subprocess_run_to_file(mock_output, returncode=0):
+    """Create a side_effect that writes mock_output to the stdout file arg."""
+    def side_effect(cmd, stdout=None, **kwargs):
+        if stdout is not None and hasattr(stdout, 'write'):
+            stdout.write(mock_output)
+        return MagicMock(returncode=returncode)
+    return side_effect
 
 
 def test_get_enabled_plugins_parses_claude_output():
@@ -26,12 +35,8 @@ def test_get_enabled_plugins_parses_claude_output():
         }
     ])
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=mock_output,
-            stderr=""
-        )
+    with patch("tool_routing.discovery.subprocess.run",
+               side_effect=_mock_subprocess_run_to_file(mock_output)):
         plugins = get_enabled_plugins()
 
     assert len(plugins) == 1
@@ -86,12 +91,8 @@ routes:
         "installPath": str(plugin_path)
     }])
 
-    with patch("tool_routing.discovery.subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=mock_output,
-            stderr=""
-        )
+    with patch("tool_routing.discovery.subprocess.run",
+               side_effect=_mock_subprocess_run_to_file(mock_output)):
         paths = discover_all_routes()
 
     assert len(paths) == 1


### PR DESCRIPTION
## Summary

- `claude plugin list --json` silently truncates at 64KB when captured via subprocess pipe
- With 235 plugins installed across projects, the output is ~93KB, producing invalid JSON
- Route discovery fails silently: no routes found, hooks never block anything
- Fix: write stdout to a temp file instead of using `capture_output=True`

## Root cause

`subprocess.run(capture_output=True)` uses pipe-based capture which has a 64KB buffer limit. When the JSON exceeds this, it gets silently cut off mid-object, causing `json.loads()` to fail.

File redirect (`stdout=open(file, 'w')`) captures the full output.

## Test plan

- [x] `uv run pytest tests/test_discovery_new.py -v` passes (3/3)
- [x] `CLAUDE_PROJECT_ROOT=$PWD uv run tool-routing list` shows Routes merged from 4 sources
- [x] Full test suite: 40 pass, 1 pre-existing failure (unrelated exit code assertion)

## Related

- Claude Code issue: https://github.com/anthropics/claude-code/issues/27247
- Bean: gt-wdxi (tracking upstream 64KB truncation bug)