### PR TITLE
feat(second-brain): decouple capture from processing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.7.0"
+      "version": "1.8.0"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/commands/distill-conversation.md
+++ b/plugins/second-brain/commands/distill-conversation.md
@@ -7,11 +7,6 @@ allowed-tools:
   - Write(~/.claude/vaults/**/*.md)
   - Edit(~/.claude/vaults/**/*.md)
   - Bash(npx @techpickles/sb:*)
-  - Bash(which:qmd)
-  - Bash(qmd:query *)
-  - Bash(qmd:collection list)
-  - Bash(qmd:get *)
-  - Bash(qmd:status)
 ---
 
 # Distill Conversation
@@ -48,10 +43,7 @@ Load skill references:
 - `second-brain:obsidian` for tool mechanics
 - `references/sb-cli.md` for sb command patterns
 - `references/zettelkasten.md` for naming
-- `references/note-patterns.md` for Insight Note template
-- `references/routing.md` for destination matching
-- `references/connecting.md` for connection discovery
-- `references/daily-linking.md` for linking to daily note
+- `references/note-patterns.md` for note template patterns
 
 ## Step 2: Review the Conversation
 
@@ -100,186 +92,55 @@ Include "None - skip capture" option.
 
 ## Step 5: Capture Selected
 
-For each selected insight, create note scaffold with sb, then write body with Write tool:
+For each selected insight, append as a bullet to the session notes file.
 
-**5a. Create scaffold:**
+**5a. Get or create session notes file:**
+
+Check if a session file exists in the vault by querying sb:
+```bash
+npx @techpickles/sb note list --type session-notes
+```
+
+If none exists, create one with session context:
 ```bash
 npx @techpickles/sb note create \
   --source auto \
-  --title "{insight title}"
+  --title "{session context}" \
+  --type session-notes
 ```
 
 Parse the returned JSON to get the file path.
 
-**5b. Write note body:**
+**5b. Build metadata:**
 
-Read the created file to get the exact frontmatter, then use the Write tool to write the full note (frontmatter + body) using **Insight Note** pattern.
+Collect session context:
+- Current repo (if in a worktree)
+- Current branch (if in a worktree)
+- Current bean ID (if available from context)
+- Session topic (topic of conversation)
+- Timestamp (ISO 8601)
 
-**5c. Repeat** for each selected insight.
+**5c. Append insights as bullets:**
 
-This handles:
-- Zettelkasten timestamp filename generation (sb)
-- Provenance tracking via git context (sb)
-- Writing to inbox with proper frontmatter (sb)
-- Clean prose content (Write tool)
+For each selected insight, append a clean bullet point:
+- Keep prose concise and standalone
+- Include minimal metadata as needed (source, why this matters)
+- Format: `- {insight description}` or `- {insight description} ({context})`
 
-Show confirmation:
-```
-Capturing {N} insights...
+Use the Write tool to update the session file, preserving frontmatter and adding bullets to the content.
 
-✓ {filename1}
-✓ {filename2}
-✓ {filename3}
-
-All captured to inbox.
-```
-
-## Step 6: Batch Routing
-
-Load `references/routing.md` and analyze all captured notes together.
-
-**1. Discover vault structure once:**
-```bash
-npx @techpickles/sb vault structure
-```
-
-Parse JSON output to get available PARA destinations (Areas, Resources, Projects).
-
-**2. Load disambiguation rules from vault CLAUDE.md:**
-
-Read `~/.claude/vaults/{name}/CLAUDE.md`:
-- Find `### Disambiguation:` sections
-- Extract key questions, category tables, edge case mappings
-- These override generic matching for semantically similar areas
-
-**3. Score each captured note:**
-
-For each note, get routing context:
-```bash
-npx @techpickles/sb note context --note "{note-path}"
-```
-
-Parse JSON output for keywords, category, related notes.
-
-*Apply disambiguation rules first (if loaded):*
-- Check edge case mappings (explicit rules)
-- Apply key question matches (+25% boost)
-- Apply category table matches (+15% boost)
-- Apply disambiguation mismatch penalty (-20%)
-
-*Then apply generic signals:*
-- Keyword match, related notes, PARA fit, recency
-
-**4. Present batch summary table:**
-```
-Analyzing captured notes for routing...
-
-| Note | Suggested Destination | Confidence | Rule Applied |
-|------|----------------------|------------|--------------|
-| "insight about caching" | Areas/AI/agentic development/ | High (82%) | - |
-| "tmux-comma-parsing" | Areas/tool sharpening/ | High (95%) | edge case |
-| "debugging approach" | (leave in inbox) | None | - |
-
-Routing explanations:
-- "insight about caching" → keyword "claude" matches, related notes exist
-- "tmux-comma-parsing" → vault rule: tmux config → tool sharpening
-- "debugging approach" → no strong destination match
-```
-
-**5. Use AskUserQuestion:**
-
-**Question:** "How should I route these?"
-
-**Options:**
-1. Route all as suggested (Recommended)
-2. Route individually (I'll ask about each)
-3. Leave all in inbox for now
-
-**6. Execute based on selection:**
-
-For "Route all" or per-note confirmation:
-```bash
-npx @techpickles/sb note move \
-  --from "inbox/{filename}" \
-  --to "{destination-path}/"
-```
-
-**Important:** Only suggest destinations that exist (from `vault structure` output). Never suggest paths that weren't discovered.
-
-## Step 7: Batch Connection Discovery
-
-Follow `references/connecting.md` to find connections for captured notes.
-
-**1. Check prerequisites:**
-```bash
-which qmd
-```
-
-If qmd is not available, skip to Step 8 (don't fail the capture).
-
-**2. Run discovery for each captured note:**
-
-For each note, extract query terms and run `qmd query`. Filter and rank candidates per the connecting reference.
-
-**3. Collect results and present as batch:**
+**5d. Confirm:**
 
 ```
-Found connections for {M} of {N} captured notes:
-
-- {Note A title}: {count} related notes
-- {Note C title}: {count} related notes
-- {Note E title}: no connections found
-
-(A) Review and connect all
-(B) Skip connections for now
+✓ Captured {N} insights to {session-file}
 ```
 
-**4. If user picks (A):** Walk through each note's connections using the standard presentation and multi-select flow from the connecting reference. For each note:
-- Show candidates with scores and snippets
-- Let user multi-select which to connect
-- Add forward links (## Related section)
-- Offer backlink weaving
-
-**5. If user picks (B):** Skip connections, continue to daily linking.
-
-Note: Newly captured notes won't be in qmd's index yet. That's fine. We search FROM each note's content, not for it.
-
-## Step 8: Batch Link to Daily Note
-
-Follow `references/daily-linking.md` to connect all captured notes to today's daily note.
-
-**1. Get today's daily note path:**
-```bash
-npx @techpickles/sb daily path
-```
-
-**2. If daily note exists, batch-add links to `## Links` section:**
-
-Build combined content:
-```markdown
-- [[{filename1 without .md}]] - {description1}
-- [[{filename2 without .md}]] - {description2}
-- [[{filename3 without .md}]] - {description3}
-```
-
-Append all at once:
-```bash
-npx @techpickles/sb daily append \
-  --section "Links" \
-  --content "{combined-links}"
-```
-
-**3. Confirm:**
-```
-✓ Linked {N} notes to daily note: Fleeting/{date}.md
-```
-
-If daily note doesn't exist, skip silently (notes are already captured).
+Show the file path so user can find the notes later.
 
 ## Constraints
 
 - **Be selective** - Only genuinely valuable insights
 - **Categorize clearly** - Help user understand knowledge type
-- **Batch efficiently** - Don't make user go through many dialogs
 - **Clean prose** - Each insight standalone, useful months later
-- **Zettelkasten naming** - Handled by sb (YYYYMMDDHHMM title.md)
+- **Metadata included** - Capture repo, branch, bean, session topic for context
+- **Processing deferred** - Routing, connecting, and daily linking happen later via `/second-brain:process-inbox`

--- a/plugins/second-brain/commands/insight.md
+++ b/plugins/second-brain/commands/insight.md
@@ -8,16 +8,13 @@ allowed-tools:
   - Write(~/.claude/vaults/**/*.md)
   - Edit(~/.claude/vaults/**/*.md)
   - Bash(npx @techpickles/sb:*)
-  - Bash(which:qmd)
-  - Bash(qmd:query *)
-  - Bash(qmd:collection list)
-  - Bash(qmd:get *)
-  - Bash(qmd:status)
 ---
 
 # Capture Insight
 
-Capture an insight from the current conversation to your Obsidian vault.
+Capture an insight from the current conversation to your Obsidian vault inbox.
+
+This command captures raw insights quickly. Processing, routing, and connection discovery happen later via `/second-brain:process-inbox`.
 
 ## Step 1: Load Configuration
 
@@ -41,16 +38,12 @@ Second brain not configured. Run /second-brain:setup first.
 
 Use the symlink path `~/.claude/vaults/{name}` to access the vault for reading CLAUDE.md (e.g., `~/.claude/vaults/primary`).
 
-Read vault's `CLAUDE.md` for structure and routing rules.
+Read vault's `CLAUDE.md` for structure rules.
 
 Load skill references:
 - `second-brain:obsidian` for tool mechanics
 - `references/sb-cli.md` for sb invocation details
 - `references/zettelkasten.md` for naming
-- `references/note-patterns.md` for Insight Note template
-- `references/routing.md` for destination matching
-- `references/connecting.md` for connection discovery
-- `references/daily-linking.md` for linking to daily note
 
 ## Step 2: Identify the Insight
 
@@ -62,200 +55,77 @@ Ask: "What insight would you like to capture?"
 
 Also review recent conversation context to suggest what might be worth capturing.
 
-## Step 3: Create Note Scaffold
+## Step 3: Create or Append to Session Notes
 
-Create the note scaffold using sb CLI (without --content):
+Session notes files collect all insights from a conversation in one place, with cheap metadata attached at capture time.
 
+**Check if session file already exists in this conversation.**
+
+If this is the first `/insight` command in this conversation:
+1. Create a new session notes file using sb CLI:
 ```bash
 npx @techpickles/sb note create \
   --source auto \
-  --title "short descriptive title"
+  --title "{session context}"
 ```
 
-sb creates the file with frontmatter and title heading only. Returns JSON with the created path:
-```json
-{
-  "path": "/path/to/vault/Inbox/202603111430 short-descriptive-title.md",
-  "filename": "202603111430 short-descriptive-title.md"
-}
-```
+Generate the title from conversation context: repo name, current branch, bean ID if available, and what you're working on (e.g., "Debugging auth timeout in zenpayroll").
 
-The `--source auto` flag tells sb to:
-- Use `source: claude-conversation` in frontmatter
-- Collect git provenance (repo, branch, commit) if in a repo
-- Add `captured: {ISO timestamp}` to frontmatter
-- Generate Zettelkasten filename with current timestamp
+The file is created with frontmatter. Read the created file to preserve the exact frontmatter sb wrote.
 
-Then write the note body using Claude's **Write tool** at the returned path. Read the created file first (to get the exact frontmatter sb wrote), then rewrite with the full note content:
+Add `type: session-notes` to the frontmatter if not present. The frontmatter should include:
+- `status: raw`
+- `type: session-notes`
+- `source-session: {topic}`
+- `repo: {repo-name}` (from git context if available)
+- `branch: {branch-name}` (from git context if available)
+- `bean: {bean-id}` (from git context if available)
+- `captured: {ISO timestamp}`
 
-Use **Insight Note** pattern with cleaned up prose (1-3 paragraphs):
+Then write the note structure:
 
-```
-{frontmatter from sb, preserved exactly}
-
-# {Insight Title}
-
-{The insight, cleaned up and clearly written. 1-3 paragraphs.}
-
-## Context
-
-Captured while {brief description of what you were working on/discussing}.
-
+```markdown
 ---
-*Captured via /second-brain:insight*
+status: raw
+type: session-notes
+source-session: {topic}
+repo: {repo-name}
+branch: {branch-name}
+bean: {bean-id}
+captured: {ISO timestamp}
+---
+
+# Session: {Session Title}
+
+- {Insight bullet 1}
 ```
 
-**Why two steps?** The sb call is a short, easy-to-approve Bash command. The Write tool has a clean approval UI for file content. Together they're much easier to review than a single Bash command with embedded multi-paragraph prose.
+Use Write tool with the file content.
 
-## Step 4: Confirm and Analyze for Routing
+**If session file already exists** (was created in an earlier `/insight` call in this same conversation):
+1. Append the new insight as a bullet using Edit tool
+2. Insert under the bulleted list in the session notes file
+3. Write the insight as clean prose (1-3 words to a sentence, not raw conversation)
 
-After creation, sb returns the created note's path as JSON. Parse and confirm:
-```
-✓ Captured to inbox: {filename}
-
-Analyzing for routing...
-```
-
-Get routing context from sb:
-```bash
-npx @techpickles/sb note context --note "{note-path}"
+Example:
+```markdown
+- Redis TTL per-key is better than Memcached for sessions
+- Auth timeout varies by environment: 30s prod, 2m staging, 10m dev
 ```
 
-This returns JSON with:
-- Keywords extracted from title and body
-- Content category (architecture, debugging, tool config, etc.)
-- Related notes in the vault
-- Source context from provenance
+## Confirm Capture
 
-Also discover vault structure:
-```bash
-npx @techpickles/sb vault structure
+After creating or appending, confirm with one line:
+```
+Captured to inbox: {filename}
 ```
 
-This returns PARA folders (Areas, Resources, Projects) as structured JSON.
-
-Load disambiguation rules from vault CLAUDE.md (read via Claude's Read tool):
-- Find `### Disambiguation:` sections
-- Extract key questions, category tables, edge case mappings
-- These override generic matching for semantically similar areas
-
-## Step 5: Score Destinations
-
-For each discovered destination from vault structure:
-
-**If disambiguation rules apply:**
-- Check edge case mappings first (explicit rules)
-- Apply key question matches (+25% boost)
-- Apply category table matches (+15% boost)
-- Apply disambiguation mismatch penalty (-20%)
-
-**Then apply generic signals:**
-- Keyword match in folder name (40%)
-- Related notes exist in folder (30%)
-- PARA category fit (20%)
-- Recency of folder activity (10%)
-
-**Calculate confidence levels:**
-- High (80-100%): Strong match, often with disambiguation support
-- Medium (50-79%): Partial match
-- Low (20-49%): Weak signals
-- None (<20%): Leave in inbox
-
-## Step 6: Suggest Routing
-
-Present findings with explanations:
-```
-Routing suggestions for "{filename}":
-
-1. **{Areas/path/}** (85% - High)
-   → Matches keywords: "keyword1", "keyword2"
-   → Related note exists: "{related-note.md}"
-   → [If disambiguation applied] Vault rule: "{edge case or key question}"
-
-2. **{Resources/path/}** (48% - Low)
-   → Generic category fit
-
-3. **Leave in Inbox** (Safe default)
-   → Route later when destination is clearer
-```
-
-When disambiguation rules influenced the result, explain which rule applied.
-
-Use AskUserQuestion with discovered options:
-- Only include destinations that actually exist (from vault structure)
-- Show confidence and explanation for each
-- Always include "Leave in inbox for now" option
-
-If user selects a destination, move the file using sb:
-```bash
-npx @techpickles/sb note move \
-  --from "{inbox-note-path}" \
-  --to "{selected-destination}/"
-```
-
-If all destinations score <20%, recommend inbox without asking.
-
-## Step 8: Discover Connections
-
-Follow `references/connecting.md` algorithm to find related notes in the vault.
-
-**1. Check prerequisites:**
-```bash
-which qmd
-```
-
-If qmd is not available, skip to Step 9 (don't fail the capture).
-
-**2. Extract query terms** from the captured note's title and body.
-
-**3. Run semantic search:**
-```bash
-qmd query "{terms}" -c {collection} -n 15 --json
-```
-
-**4. Filter and rank** per the connecting reference (remove self, already-linked, low-relevance, daily notes; enrich with TK/See Also signals; rank).
-
-**5. If connections found (any candidates above 30%):**
-
-Present candidates and let user multi-select which to connect.
-
-**6. For selected connections:**
-- Add `## Related` section to the captured note with wiki-links
-- Offer backlink weaving for notes with See Also/Related/TK sections
-
-**7. If no connections above threshold,** skip silently and continue.
-
-Note: The captured note won't be in qmd's index yet. That's fine. We're searching FROM the note's content, not for it.
-
-## Step 9: Link to Daily Note
-
-Link the captured note to today's daily note using sb:
-
-```bash
-npx @techpickles/sb daily append \
-  --section "Links" \
-  --content "- [[{filename without .md}]] - {brief description of the insight}"
-```
-
-The sb CLI handles:
-- Finding today's daily note path from .obsidian config
-- Creating the daily note if it doesn't exist
-- Finding or creating the `## Links` section
-- Appending the link
-
-Confirm linking:
-```
-✓ Linked to daily note: {date}.md
-```
-
-If daily note linking fails (sb returns error), skip silently. The note is already captured.
+That's it. No routing, no connecting, no daily linking. Those happen later via `/second-brain:process-inbox`.
 
 ## Constraints
 
-- **Always write to inbox first** - Never skip this step
-- **Use skill references** - Get paths from skill, not hardcoded
-- **Use sb CLI for data operations** - Note creation, moving, structure discovery
-- **Use Claude's Read/Write/Edit for prose** - Reading CLAUDE.md, editing note content
-- **Zettelkasten naming** - sb handles `YYYYMMDDHHMM title.md` format automatically
-- **Show analysis before asking** - Don't just ask, show reasoning
-- **Clean prose** - Well-written insight, not raw conversation paste
+- **Always write to inbox** - Inbox capture only, no routing
+- **Use sb CLI for note creation** - sb handles timestamps, frontmatter, vault structure
+- **Capture cheap metadata** - repo, branch, bean ID from git/provenance context
+- **Clean prose for bullets** - Each insight is a polished sentence or short phrase
+- **No routing, connecting, or linking** - Processing moves to the separate `process-inbox` skill

--- a/plugins/second-brain/commands/route.md
+++ b/plugins/second-brain/commands/route.md
@@ -4,6 +4,8 @@ argument-hint: [filename | "all"]
 allowed-tools:
   - Read(~/.claude/vaults/**/CLAUDE.md)
   - Read(~/.claude/vaults/**/*.md)
+  - Write(~/.claude/vaults/**/.routing-memory.md)
+  - Edit(~/.claude/vaults/**/.routing-memory.md)
   - Bash(npx @techpickles/sb:*)
 ---
 
@@ -43,6 +45,7 @@ Load skill references:
 - `second-brain:obsidian` for tool mechanics
 - `references/routing.md` for routing algorithm
 - `references/sb-cli.md` for sb command reference
+- `references/routing-memory.md` for routing correction format
 
 ## Step 2: Identify Notes to Route
 
@@ -126,6 +129,21 @@ If found, extract:
 
 These rules override generic matching for semantically similar areas.
 
+## Step 4b: Load Routing Memory
+
+Read `.routing-memory.md` from vault root (via symlink path, e.g. `~/.claude/vaults/primary/.routing-memory.md`). If it doesn't exist, skip this step (no corrections yet).
+
+If the file exists, parse:
+- `auto-route-threshold` from frontmatter
+- `## Corrections` entries with:
+  - Date, original suggestion, user's correction, and reason
+  - Extract patterns: what topics have been corrected before
+- `## Patterns Learned` entries:
+  - Stable routing rules distilled from corrections
+  - Pattern → destination mappings
+
+Store this context for Step 5 scoring.
+
 ## Step 5: Analyze and Score
 
 For each selected note, follow `references/routing.md` algorithm:
@@ -154,19 +172,24 @@ Example output:
 }
 ```
 
-2. **Apply disambiguation rules** (if loaded):
+2. **Apply routing memory** (if loaded in Step 4b):
+   - Check if any correction matches this note's topic/keywords (exact or close match). If so, strongly favor the corrected destination (+40% to that destination).
+   - Check if any learned pattern matches the note's topic/keywords. If so, boost that destination (+20%).
+   - These take precedence over generic signals but come after exact topic matches from corrections.
+
+3. **Apply disambiguation rules** (if loaded):
    - Check edge case mappings first (explicit rules)
    - Apply key question matches (+25% boost)
    - Apply category table matches (+15% boost)
    - Apply disambiguation mismatch penalty (-20%)
 
-3. **Score with generic signals:**
+4. **Score with generic signals:**
    - Keyword match in folder name (40%)
    - Related notes exist in folder (30%)
    - PARA category fit (20%)
    - Recency of folder activity (10%)
 
-4. **Calculate confidence:**
+5. **Calculate confidence:**
    - High (80-100%): Strong match, often with disambiguation support
    - Medium (50-79%): Partial match
    - Low (20-49%): Weak signals
@@ -230,6 +253,39 @@ sb handles the filesystem operation and returns confirmation.
 
 3 notes processed: 2 routed, 1 remaining in inbox
 ```
+
+## Step 8b: Capture Corrections
+
+For each note where the user chose a destination different from the top suggestion:
+
+1. Read `.routing-memory.md` from vault root. If it doesn't exist, create it with defaults:
+   ```markdown
+   ---
+   auto-route-threshold: 70
+   ---
+
+   ## Corrections
+
+   ## Patterns Learned
+   ```
+
+2. Ask: "Quick note on why {chosen} over {suggested}?" (keep it to one sentence)
+
+3. Append the correction to `## Corrections`:
+   ```
+   - {YYYY-MM-DD}: "{note title}" routed to "{suggested}", corrected to "{chosen}"
+     Reason: {user's reason}
+   ```
+
+4. Write/Edit the updated file using the Edit tool
+
+Example correction entry:
+```markdown
+- 2026-03-31: "tmux conditional parsing" routed to "Resources/software engineering/", corrected to "Areas/tool sharpening/"
+  Reason: tmux is a personal tool config, not a programming pattern
+```
+
+This correction becomes available in Step 4b of future routing operations, feeding the learning loop.
 
 ## Examples
 

--- a/plugins/second-brain/skills/connect/SKILL.md
+++ b/plugins/second-brain/skills/connect/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: connect
+description: Find related notes via semantic search and weave links. Stage 4 of the processing pipeline.
+allowed-tools:
+  - Read(~/.claude/vaults/**/*.md)
+  - Write(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/*.md)
+  - Bash(which:qmd)
+  - Bash(qmd:query *)
+  - Bash(qmd:collection list)
+  - Bash(qmd:get *)
+  - Bash(qmd:status)
+---
+
+# Connect Stage
+
+Find related notes via semantic search (qmd) and weave forward/backward links.
+
+See `references/pipeline.md` for stage definitions and status flow.
+See `references/connecting.md` for the connection discovery algorithm.
+
+## Input
+
+A routed note with `status: routed`.
+
+## Process
+
+1. Check qmd availability:
+   ```bash
+   which qmd
+   ```
+   If not available, log "Skipped connections: qmd not available", set `status: connected`, and return.
+
+2. Extract query terms from the note's title and body
+
+3. Run semantic search:
+   ```bash
+   qmd query "{terms}" -c {collection} -n 15 --json
+   ```
+
+4. Filter and rank per `references/connecting.md`:
+   - Remove self
+   - Remove already-linked notes
+   - Remove daily notes
+   - Remove low-relevance results (below 30%)
+
+5. If candidates found, present to human (when called by orchestrator):
+   - Show candidates with scores and snippets
+   - Let user multi-select which to connect
+
+6. For selected connections:
+   - Add `## Related` section to the note with wiki-links
+   - Offer backlink weaving for notes that have See Also/Related/TK sections
+
+7. Update status to `connected`
+
+## Output
+
+- Note with `## Related` section added (if connections found)
+- `status: connected`
+
+## Constraints
+
+- Graceful skip if qmd unavailable (always log that it was skipped)
+- The note being processed won't be in qmd's index yet. Search FROM its content, not for it.
+- Don't add connections the user didn't approve
+- Backlink weaving is optional (offer, don't force)

--- a/plugins/second-brain/skills/distill-rules/SKILL.md
+++ b/plugins/second-brain/skills/distill-rules/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: distill-rules
+description: Review routing corrections and propose updates to vault CLAUDE.md routing rules.
+allowed-tools:
+  - Read(~/.claude/vaults/**/CLAUDE.md)
+  - Read(~/.claude/vaults/**/.routing-memory.md)
+  - Write(~/.claude/vaults/**/CLAUDE.md)
+  - Write(~/.claude/vaults/**/.routing-memory.md)
+  - Edit(~/.claude/vaults/**/CLAUDE.md)
+  - Edit(~/.claude/vaults/**/.routing-memory.md)
+  - Bash(npx @techpickles/sb:*)
+---
+
+# Distill Rules
+
+Review accumulated routing corrections in `.routing-memory.md` and propose updates to the vault's CLAUDE.md routing rules.
+
+See `references/routing-memory.md` for correction format and learning loop.
+
+## Process
+
+1. Read `.routing-memory.md` from vault root
+2. Read vault CLAUDE.md
+
+3. Analyze corrections for patterns:
+   - Group corrections by destination
+   - Identify repeated corrections (same type of note going to same destination)
+   - Look for corrections that contradict existing CLAUDE.md rules
+
+4. Propose updates:
+   - New edge case mappings for disambiguation sections
+   - New category table entries
+   - New learned patterns for `.routing-memory.md`
+   - Corrections to existing rules that have been consistently overridden
+
+5. Present proposals to user:
+   ```
+   Found {n} patterns in {m} corrections:
+
+   1. Add edge case: "{scenario}" -> {destination}
+      Based on: {n} corrections over {date range}
+
+   2. Add to category table: "{tool}" under {area}
+      Based on: {n} corrections
+
+   3. Update rule: "{old rule}" -> "{new rule}"
+      Based on: consistently overridden {n} times
+
+   Apply these updates?
+   (A) Apply all
+   (B) Review individually
+   (C) Skip for now
+   ```
+
+6. Apply selected updates:
+   - Edit vault CLAUDE.md with new rules
+   - Move applied corrections to an `## Archived` section in `.routing-memory.md`
+   - Promote stable patterns to `## Patterns Learned`
+
+## Constraints
+
+- Never auto-apply. Always present proposals for approval.
+- Preserve existing CLAUDE.md structure and formatting
+- Archive corrections, don't delete them (audit trail)
+- Only propose rules backed by multiple corrections (minimum 2)

--- a/plugins/second-brain/skills/enrich/SKILL.md
+++ b/plugins/second-brain/skills/enrich/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: enrich
+description: Turn an ingested insight into a proper zettelkasten note with clean prose. Stage 2 of the processing pipeline.
+allowed-tools:
+  - Read(~/.claude/vaults/**/*.md)
+  - Write(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/*.md)
+---
+
+# Enrich Stage
+
+Turn an ingested insight note into a proper zettelkasten note with a clean title, well-written prose, and complete frontmatter.
+
+See `references/pipeline.md` for stage definitions and status flow.
+See `references/note-patterns.md` for the Insight Note template.
+See `references/zettelkasten.md` for naming conventions.
+
+## Input
+
+An insight note in the inbox with `status: ingested` and `type: insight`.
+
+## Process
+
+1. Read the ingested note
+2. Rewrite the body as clean prose (1-3 paragraphs) using the Insight Note pattern from `references/note-patterns.md`
+3. Improve the title if needed (should be descriptive and specific)
+4. Add a `## Context` section with brief description of what session produced this
+5. Update status to `enriched` in frontmatter
+6. Write the updated note using the Write tool (read first, then rewrite)
+
+## Output
+
+The same file, now with:
+- Clean, well-written prose body
+- Descriptive title
+- Context section
+- `status: enriched`
+
+## Constraints
+
+- Don't create a new file. Enrich in place.
+- Preserve all existing frontmatter fields (provenance, source-session, etc.)
+- The note should be useful months later to someone with no context
+- Keep it concise. 1-3 paragraphs, not an essay.

--- a/plugins/second-brain/skills/ingest/SKILL.md
+++ b/plugins/second-brain/skills/ingest/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ingest
+description: Split a raw session notes file into individual insight notes in the inbox. Stage 1 of the processing pipeline.
+allowed-tools:
+  - Read(~/.claude/vaults/**/*.md)
+  - Write(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/*.md)
+  - Bash(npx @techpickles/sb:*)
+---
+
+# Ingest Stage
+
+Split a raw session notes file (type: `session-notes`) into individual insight notes.
+
+See `references/pipeline.md` for stage definitions and status flow.
+
+## Input
+
+A session notes file in the inbox with `status: raw` and `type: session-notes`.
+
+## Process
+
+1. Read the session notes file
+2. Extract each bullet point as a separate insight
+3. For each insight, create a new note via `sb note create --source auto --title "{insight title}"` with:
+   - `status: ingested`
+   - `type: insight`
+   - `source-session: {original session filename}`
+   - Inherited metadata: `repo`, `branch`, `bean` from the parent session file
+4. Write the note body (the bullet text, cleaned up into a sentence or short paragraph) using the Write tool
+5. Update the original session file's status to `ingested` using the Edit tool (change `status: raw` to `status: ingested` in frontmatter)
+
+## Output
+
+- N new insight notes in the inbox, each with `status: ingested`
+- Original session file updated to `status: ingested`
+
+## Constraints
+
+- Preserve all provenance metadata from the parent session file
+- Each extracted note gets its own zettelkasten timestamp (via sb)
+- The `source-session` field links back to the original session file
+- Don't merge or combine bullets. One bullet, one note.
+- Skip empty or trivial bullets (single words, fragments)

--- a/plugins/second-brain/skills/link-daily/SKILL.md
+++ b/plugins/second-brain/skills/link-daily/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: link-daily
+description: Link a processed note to today's daily note. Stage 5 of the processing pipeline.
+allowed-tools:
+  - Read(~/.claude/vaults/**/*.md)
+  - Write(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/*.md)
+  - Bash(npx @techpickles/sb:*)
+---
+
+# Link Daily Stage
+
+Add an entry for the processed note to today's daily note.
+
+See `references/pipeline.md` for stage definitions and status flow.
+See `references/daily-linking.md` for linking mechanics.
+
+## Input
+
+A note with `status: connected`. (The connect skill sets this even when qmd is unavailable and connections are skipped.)
+
+## Process
+
+1. Link to daily note:
+   ```bash
+   npx @techpickles/sb daily append \
+     --section "Links" \
+     --content "- [[{filename without .md}]] - {brief description}"
+   ```
+
+2. Update status to `complete`
+
+If daily note linking fails (sb returns error), log the error but don't fail. The note is already processed. Set status to `complete` anyway.
+
+## Output
+
+- Entry added to today's daily note
+- `status: complete`
+
+## Constraints
+
+- Don't fail the pipeline if daily linking fails
+- Use the note's title for the brief description
+- sb handles daily note creation if it doesn't exist

--- a/plugins/second-brain/skills/obsidian/SKILL.md
+++ b/plugins/second-brain/skills/obsidian/SKILL.md
@@ -104,3 +104,5 @@ For methodology (tool-agnostic):
 - `references/note-patterns.md` - Note templates
 - `references/routing.md` - Routing algorithm with disambiguation support
 - `references/daily-linking.md` - Linking captured notes to daily note
+- `references/pipeline.md` - Processing pipeline stages and status flow
+- `references/routing-memory.md` - Routing correction and learning loop

--- a/plugins/second-brain/skills/obsidian/references/pipeline.md
+++ b/plugins/second-brain/skills/obsidian/references/pipeline.md
@@ -1,0 +1,60 @@
+# Processing Pipeline Reference
+
+The inbox processing pipeline breaks into five independent stages. Each stage is a skill that can be invoked individually or composed by the `process-inbox` orchestrator.
+
+## Stages
+
+| Stage | Skill | Input Status | Output Status | Confidence |
+|-------|-------|-------------|---------------|------------|
+| 1. Ingest | `ingest` | `raw` | `ingested` | High (mechanical) |
+| 2. Enrich | `enrich` | `ingested` | `enriched` | High (prose cleanup) |
+| 3. Route | `route` | `enriched` | `routed` or `pending-review` | Variable |
+| 4. Connect | `connect` | `routed` | `connected` | Variable |
+| 5. Link Daily | `link-daily` | `connected` | `complete` | High (mechanical) |
+
+## Status Values
+
+Each note carries its pipeline state in frontmatter:
+
+| Status | Meaning |
+|--------|---------|
+| `raw` | Just landed in inbox. Session notes file with bullet points. |
+| `ingested` | Individual insights extracted from session note into separate files. |
+| `enriched` | Proper zettelkasten note with clean prose and title. |
+| `routed` | Moved to destination folder. |
+| `connected` | Related notes linked via `## Related` section. |
+| `complete` | All stages done, daily note linked. |
+| `pending-review` | Route stage needs human input (low confidence). |
+
+Notes without a `status` field are treated as `raw`.
+
+## Status Flow
+
+```
+raw -> ingested -> enriched -> routed -> connected -> complete
+                          \-> pending-review (low confidence at route stage)
+```
+
+After human resolves `pending-review` (picks a destination), status moves to `routed` and continues through the pipeline.
+
+## Note Types
+
+| Type | Frontmatter `type` | Created By | Processed By |
+|------|-------------------|------------|--------------|
+| Session notes | `session-notes` | `/insight`, `/distill-conversation` | `ingest` stage |
+| Insight | `insight` | `ingest` stage | `enrich` through `link-daily` |
+
+Session notes files contain multiple bullet points from a working session. The `ingest` stage splits them into individual insight notes.
+
+## Confidence Model
+
+The `route` stage scores destinations using three sources (priority order):
+
+1. Recent corrections in `.routing-memory.md` (recency wins)
+2. Learned patterns in `.routing-memory.md`
+3. Vault CLAUDE.md disambiguation rules + generic signals
+
+Notes scoring above the `auto-route-threshold` (from `.routing-memory.md` frontmatter, default 70) are auto-routed. Notes below the threshold get `pending-review`.
+
+See `references/routing-memory.md` for the correction and learning loop.
+See `references/routing.md` for the scoring algorithm.

--- a/plugins/second-brain/skills/obsidian/references/routing-memory.md
+++ b/plugins/second-brain/skills/obsidian/references/routing-memory.md
@@ -1,0 +1,90 @@
+# Routing Memory Reference
+
+`.routing-memory.md` lives in the vault root. It captures routing corrections and learned patterns, enabling the routing system to improve over time.
+
+## File Format
+
+```yaml
+---
+auto-route-threshold: 70
+---
+```
+
+The file has two sections:
+
+### Corrections
+
+Captured automatically when a user overrides a routing suggestion. Each correction records what happened and why.
+
+```markdown
+## Corrections
+
+- 2026-03-31: "tmux parsing" routed to "dev environment", corrected to "tool sharpening"
+  Reason: tmux is a tool, config/parsing work goes to tool sharpening
+
+- 2026-03-31: "Redis caching insight" routed to "infrastructure", corrected to "backend-patterns"
+  Reason: caching strategy is a pattern, not infra concern
+```
+
+### Patterns Learned
+
+Distilled from accumulated corrections (via `distill-rules` skill). These are stable routing rules that have proven themselves across multiple corrections.
+
+```markdown
+## Patterns Learned
+
+- CLI tool configs, dotfiles, shell customization -> Areas/tool sharpening/
+- Messaging patterns (Karafka, Kafka, SQS) -> Resources/kafka-patterns/
+- Caching strategies, data access patterns -> Areas/backend-patterns/
+```
+
+## Consultation Order
+
+When the `route` skill (or `commands/route.md`) makes a routing decision:
+
+1. **Check corrections first.** Recent corrections override everything. A correction from today beats a CLAUDE.md rule.
+2. **Check learned patterns.** These are distilled corrections, more stable than individual entries.
+3. **Check vault CLAUDE.md disambiguation rules.** The baseline routing algorithm (see `references/routing.md`).
+
+A correction that contradicts a CLAUDE.md rule wins. The `distill-rules` skill eventually promotes stable corrections into CLAUDE.md rules, at which point the corrections can be archived.
+
+## Capturing Corrections
+
+When the `route` skill suggests a destination and the user picks a different one:
+
+1. Append a new entry to `## Corrections` with date, original suggestion, user's choice, and reason
+2. Ask the user: "Why did you pick {destination} over {suggested}?" (one sentence is fine)
+3. Record the reason
+
+This happens in both the pipeline `route` skill and the standalone `commands/route.md` command.
+
+## Auto-Route Threshold
+
+The `auto-route-threshold` frontmatter value (0-100) controls graduated autonomy:
+
+- Notes scoring **above** the threshold are auto-routed without prompting
+- Notes scoring **below** are marked `pending-review` for human input
+- Default: 70 (conservative start)
+- Raise it as routing quality improves
+
+## Creating the File
+
+`.routing-memory.md` is created on first use by whichever skill needs it (usually `route`). Initial content:
+
+```markdown
+---
+auto-route-threshold: 70
+---
+
+## Corrections
+
+## Patterns Learned
+```
+
+## When to Run `distill-rules`
+
+The `distill-rules` skill reads corrections, finds stable patterns, and proposes CLAUDE.md rule updates. Run it when:
+
+- You've accumulated 10+ corrections
+- You notice the same type of correction repeating
+- You want to raise the auto-route threshold and want better rules to support it

--- a/plugins/second-brain/skills/process-inbox/SKILL.md
+++ b/plugins/second-brain/skills/process-inbox/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: process-inbox
+description: Process accumulated inbox notes through the full pipeline (ingest, enrich, route, connect, link). User-facing orchestrator.
+allowed-tools:
+  - Read(~/.claude/vaults/**/CLAUDE.md)
+  - Read(~/.claude/vaults/**/.obsidian/*.json)
+  - Read(~/.claude/vaults/**/*.md)
+  - Read(~/.claude/vaults/**/.routing-memory.md)
+  - Write(~/.claude/vaults/**/*.md)
+  - Write(~/.claude/vaults/**/.routing-memory.md)
+  - Edit(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/.routing-memory.md)
+  - Bash(npx @techpickles/sb:*)
+  - Bash(which:qmd)
+  - Bash(qmd:query *)
+  - Bash(qmd:collection list)
+  - Bash(qmd:get *)
+  - Bash(qmd:status)
+---
+
+# Process Inbox
+
+Process accumulated inbox notes through the full pipeline: ingest, enrich, route, connect, link to daily note.
+
+See `references/pipeline.md` for stage definitions and status flow.
+
+## Step 1: Load Configuration
+
+```bash
+npx @techpickles/sb config default
+npx @techpickles/sb config vaults
+```
+
+If no vault configured:
+```
+Second brain not configured. Run /second-brain:setup first.
+```
+
+Load skill references:
+- `second-brain:obsidian` for tool mechanics
+- `references/pipeline.md` for stage definitions
+- `references/routing-memory.md` for learning loop
+- `references/routing.md` for scoring algorithm
+- `references/connecting.md` for connection discovery
+- `references/daily-linking.md` for daily note linking
+- `references/sb-cli.md` for sb command reference
+
+## Step 2: Survey Inbox
+
+```bash
+npx @techpickles/sb inbox list --detail
+```
+
+Parse the JSON response. Group notes by `status` field (notes without status are `raw`).
+
+Check for stale notes (captured more than 14 days ago based on `captured` frontmatter field).
+
+Present summary:
+
+```
+Inbox: {total} notes
+  {n} raw (session notes awaiting ingestion)
+  {n} ingested (insights awaiting enrichment)
+  {n} enriched (notes awaiting routing)
+  {n} pending-review (need your input)
+  {n} routed (awaiting connection)
+  {n} connected (awaiting daily linking)
+
+{If stale notes exist:}
+  Heads up: {n} notes have been in the inbox for over 2 weeks.
+```
+
+If inbox is empty:
+```
+Inbox is empty. Nothing to process.
+```
+
+## Step 3: Process by Stage
+
+Work through notes in pipeline order. Each stage picks up notes at its expected input status.
+
+### 3a: Ingest raw session notes
+
+For each note with `status: raw` and `type: session-notes`:
+- Follow the `ingest` skill to split into individual insight notes
+- Report: `Ingested: {session filename} -> {n} insights`
+
+### 3b: Enrich ingested insights
+
+For each note with `status: ingested` and `type: insight`:
+- Follow the `enrich` skill to create proper zettelkasten notes
+- Report: `Enriched: {filename}`
+
+### 3c: Route enriched notes
+
+For each note with `status: enriched`:
+- Follow the `route` skill
+- If auto-routed: `Routed: {filename} -> {destination}`
+- If pending-review: pause and present suggestions to user
+  - Show the note title, top destinations with scores, and reasoning
+  - Let user pick destination or leave in inbox
+  - If user overrides, capture correction per `references/routing-memory.md`
+  - After user decides, continue to next note
+
+Also process any pre-existing `pending-review` notes from previous runs.
+
+### 3d: Connect routed notes
+
+For each note with `status: routed`:
+- Follow the `connect` skill
+- If qmd unavailable: `Skipped connections: qmd not available` (once, not per note)
+- If connections found: present batch summary, let user multi-select
+- If no connections: skip silently
+
+### 3e: Link to daily note
+
+For each note with `status: connected`:
+- Follow the `link-daily` skill
+- Batch all links into a single `sb daily append` call when possible
+- Report: `Linked {n} notes to daily note`
+
+## Step 4: Summary
+
+```
+Pipeline complete:
+  {n} session notes ingested -> {m} insights extracted
+  {n} insights enriched
+  {n} notes routed ({auto} auto, {manual} manual)
+  {n} notes connected ({links} links added)
+  {n} notes linked to daily note
+  {n} notes still pending review
+```
+
+## Constraints
+
+- Process stages in order (ingest before enrich, enrich before route, etc.)
+- Pause for human input only on low-confidence routing and connection selection
+- Don't fail the pipeline if one stage errors on a note. Log the error and continue.
+- Batch operations where possible (daily linking)
+- One vault at a time (uses default vault)

--- a/plugins/second-brain/skills/route/SKILL.md
+++ b/plugins/second-brain/skills/route/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: route
+description: Analyze an enriched note and route to the best vault destination. Stage 3 of the processing pipeline.
+allowed-tools:
+  - Read(~/.claude/vaults/**/CLAUDE.md)
+  - Read(~/.claude/vaults/**/*.md)
+  - Read(~/.claude/vaults/**/.routing-memory.md)
+  - Write(~/.claude/vaults/**/.routing-memory.md)
+  - Edit(~/.claude/vaults/**/.routing-memory.md)
+  - Bash(npx @techpickles/sb:*)
+---
+
+# Route Stage
+
+Analyze an enriched note against routing memory, vault rules, and generic signals. Move to destination or mark for review.
+
+See `references/pipeline.md` for stage definitions and status flow.
+See `references/routing.md` for the scoring algorithm.
+See `references/routing-memory.md` for the correction and learning loop.
+
+## Input
+
+An enriched note in the inbox with `status: enriched`.
+
+## Process
+
+1. Load routing context:
+   - Read `.routing-memory.md` from vault root (create with defaults if missing)
+   - Read vault CLAUDE.md for disambiguation rules
+   - Run `sb vault structure` for available destinations
+   - Run `sb note context --note "{note-path}"` for keywords and signals
+
+2. Score destinations (priority order):
+   a. Check `.routing-memory.md` corrections for matching topics/keywords
+   b. Check `.routing-memory.md` learned patterns
+   c. Apply vault CLAUDE.md disambiguation rules
+   d. Apply generic signal scoring (per `references/routing.md`)
+
+3. Apply threshold:
+   - Score >= `auto-route-threshold`: auto-route, move file, set `status: routed`
+   - Score < threshold: set `status: pending-review`, return without moving
+
+4. If auto-routing, move the file:
+   ```bash
+   npx @techpickles/sb note move --from "{note-path}" --to "{destination}/"
+   ```
+   Update frontmatter: `status: routed`
+
+5. If pending-review, present suggestions to human (when called by orchestrator):
+   - Show top 2-3 destinations with scores and reasoning
+   - Include "Leave in inbox" option
+   - If user overrides suggestion, capture correction to `.routing-memory.md`
+
+## Capturing Corrections
+
+When the user picks a destination different from the top suggestion:
+
+1. Ask: "Quick note on why {chosen} over {suggested}?"
+2. Append to `## Corrections` in `.routing-memory.md`:
+   ```
+   - {YYYY-MM-DD}: "{note title}" routed to "{suggested}", corrected to "{chosen}"
+     Reason: {user's reason}
+   ```
+
+## Output
+
+- Note moved to destination with `status: routed`, OR
+- Note marked `status: pending-review` for human input
+
+## Constraints
+
+- Only suggest destinations from `sb vault structure` output
+- Always include "Leave in inbox" for pending-review notes
+- Show reasoning for all suggestions
+- Capture corrections on every override (this is how routing improves)


### PR DESCRIPTION
## Summary

- Strip `/insight` and `/distill-conversation` to cheap inbox-only capture (session notes files with metadata)
- Add 5-stage processing pipeline as new skills: `ingest`, `enrich`, `route`, `connect`, `link-daily`
- Add `process-inbox` orchestrator skill as user-facing entry point
- Add routing learning loop (`.routing-memory.md`) with graduated autonomy
- Add `distill-rules` skill for promoting corrections into vault CLAUDE.md rules
- Update standalone `commands/route.md` to also consult routing memory

Core idea: working sessions drop cheap notes into the inbox. A dedicated pipeline processes them later in a separate session.

Design spec: `projects/second-brain-agent/plans/2026-03-31-capture-processing-split-design.md`

## Test plan

- [ ] Run `/insight` in a working session, verify it creates a session notes file in inbox without routing
- [ ] Run `/distill-conversation`, verify it scans and dumps without processing
- [ ] Run `/second-brain:process-inbox` on accumulated inbox notes
- [ ] Verify routing memory captures corrections when overriding suggestions
- [ ] Verify `sb inbox list --detail` shows status progression through pipeline stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)