### PR TITLE
feat(agent-meta): use shell script for session ID in park skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "1.2.0"
+      "version": "1.3.0"
     }
   ]
 }

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: park
 description: Save current work context for later resumption
+allowed-tools: Bash(scripts/get-session-id.sh)
 ---
 
 # Park
@@ -45,7 +46,7 @@ Ensure the directory exists. If using `.parkinglot/`, check it's gitignored.
 
 ## Before Writing
 
-1. Run `echo $CLAUDE_SESSION_ID` via Bash to get the current session ID. If empty, use "unknown".
+1. Run [scripts/get-session-id.sh](scripts/get-session-id.sh) via Bash to get the current session ID. If empty, use "unknown".
 2. Gather git branch, worktree path, and other context.
 
 ## Output Format

--- a/plugins/agent-meta/skills/park/scripts/get-session-id.sh
+++ b/plugins/agent-meta/skills/park/scripts/get-session-id.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "$CLAUDE_SESSION_ID"


### PR DESCRIPTION
## Summary
- Replace `echo $CLAUDE_SESSION_ID` with a co-located `scripts/get-session-id.sh` shell script in the park skill
- Add `allowed-tools: Bash(scripts/get-session-id.sh)` frontmatter to avoid permission prompts
- Addresses gt-t1yh: permission prompt friction when parking sessions

## Test plan
- [ ] Install updated plugin, park a session, confirm session ID resolves without permission prompt
- [ ] Verify fallback to "unknown" still works when CLAUDE_SESSION_ID is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)