### PR TITLE
fix(tool-routing): anchor cat-heredoc pattern to command boundary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "tool-routing",
       "source": "./plugins/tool-routing",
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     {
       "name": "stay-on-target",

--- a/plugins/tool-routing/hooks/tool-routes.yaml
+++ b/plugins/tool-routing/hooks/tool-routes.yaml
@@ -6,7 +6,7 @@ routes:
   # cat heredoc - use Write tool instead
   bash-cat-heredoc:
     tool: Bash
-    pattern: "cat\\s+.*<<[-]?\\s*['\"]?\\w+['\"]?(?!.*\\|)"
+    pattern: "(?:^|[;&|]\\s*)cat\\s+.*<<[-]?\\s*['\"]?\\w+['\"]?(?!.*\\|)"
     message: |
       Don't use cat with heredocs for file creation or display.
 
@@ -33,6 +33,18 @@ routes:
           tool_name: Bash
           tool_input:
             command: "cat <<EOF | jq .\n{\"key\": \"value\"}\nEOF"
+        expect: allow
+      - desc: "cat heredoc inside command substitution should allow"
+        input:
+          tool_name: Bash
+          tool_input:
+            command: "jj commit -m \"$(cat <<'EOF'\nCommit message\nEOF\n)\""
+        expect: allow
+      - desc: "git commit with cat heredoc should allow"
+        input:
+          tool_name: Bash
+          tool_input:
+            command: "git commit -m \"$(cat <<'EOF'\nFix the bug\n\nCo-Authored-By: Claude\nEOF\n)\""
         expect: allow
 
   # chained echo - output directly instead


### PR DESCRIPTION
## Summary

- Fix false positive where `bash-cat-heredoc` route blocked `jj commit -m "$(cat <<'EOF'...)"` and similar commit commands
- Add `(?:^|[;&|]\s*)` anchor so `cat` must be at a command boundary, not inside `$(...)` subshells
- Add test cases for jj and git commit heredoc patterns

## Why

[Claude Code system prompt](https://github.com/Piebald-AI/claude-code-system-prompts/blob/main/system-prompts/agent-prompt-quick-git-commit.md) intentionally tells claude to use cat heredocs for commits, so it tends to hit this all the time.

## Test plan

- [x] All 13 route pattern tests pass (including 2 new ones)
- [x] Edge cases verified: cat after `&&`/`;` still blocked, cat inside `$(...)` allowed

Generated with [Claude Code](https://claude.com/claude-code)
