### PR TITLE
fix(sandbox-first): only flag sandbox-shaped errors in PostToolUseFailure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "sandbox-first",
       "source": "./plugins/sandbox-first",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "name": "buildkite",

--- a/plugins/sandbox-first/src/sandbox_first/checker.py
+++ b/plugins/sandbox-first/src/sandbox_first/checker.py
@@ -27,6 +27,23 @@ FAILURE_CONTEXT = (
 # sandbox-warning context when the error clearly matches one of these
 # signatures. Everything else (command-not-found, ENOENT, git warnings, test
 # assertion failures, application exceptions, etc.) stays silent.
+#
+# Covered EPERM shapes (empirical — from sandbox test sessions):
+#   - tool-prefixed:   touch: cannot touch 'path': Operation not permitted
+#                      mkdir: cannot create directory 'path': Operation not permitted
+#                      mkdir: \u2018path\u2019: Operation not permitted  (smart-quote variant)
+#   - shell-eval:      (eval):1: operation not permitted: /path
+#   - git single-fatal: fatal: could not create leading directories of '.git': Operation not permitted
+#                       fatal: cannot copy 'src' to 'dst': Operation not permitted
+#   - git error+fatal: error: could not write config file <path>: Operation not permitted
+#                      fatal: could not set 'core.repositoryformatversion' to '0'
+#                      (second fatal line is paired with the first; matched together)
+#
+# NOT covered by design:
+#   - cascading ENOENT: a blocked sandbox mkdir causes a *subsequent* command to emit
+#     "No such file or directory" without any EPERM. Matching "no such file or directory"
+#     would catch real ENOENT errors (missing files, bad paths) as false positives, so
+#     this case requires transcript-level context to detect safely.
 SANDBOX_ERROR_SIGNATURES = (
     "operation not permitted",
     "sandbox-exec",

--- a/plugins/sandbox-first/src/sandbox_first/checker.py
+++ b/plugins/sandbox-first/src/sandbox_first/checker.py
@@ -22,6 +22,30 @@ FAILURE_CONTEXT = (
     "and explain what restriction was hit."
 )
 
+# Error substrings (case-insensitive) that strongly suggest a sandbox-caused
+# failure. This is intentionally a conservative allow-list: we only add the
+# sandbox-warning context when the error clearly matches one of these
+# signatures. Everything else (command-not-found, ENOENT, git warnings, test
+# assertion failures, application exceptions, etc.) stays silent.
+SANDBOX_ERROR_SIGNATURES = (
+    "operation not permitted",
+    "sandbox-exec",
+    "read-only file system",
+    "connection refused",
+    "could not resolve host",
+    "couldn't resolve host",
+    "network is unreachable",
+    "failed to connect",
+)
+
+
+def _looks_like_sandbox_error(error: str) -> bool:
+    """True if the error text matches a known sandbox-failure signature."""
+    if not error:
+        return False
+    lowered = error.lower()
+    return any(sig in lowered for sig in SANDBOX_ERROR_SIGNATURES)
+
 
 def check_pre_tool_use(hook_input: dict) -> dict | None:
     """Check a PreToolUse Bash call. Returns JSON output dict or None to allow."""
@@ -54,6 +78,10 @@ def check_post_tool_use_failure(hook_input: dict) -> dict | None:
     tool_input = hook_input.get("tool_input", {})
     if tool_input.get("dangerouslyDisableSandbox"):
         return None  # Already unsandboxed, not a sandbox issue
+
+    error = hook_input.get("error", "")
+    if not _looks_like_sandbox_error(error):
+        return None  # Error doesn't look sandbox-shaped, stay silent
 
     return {
         "hookSpecificOutput": {

--- a/plugins/sandbox-first/tests/test_checker.py
+++ b/plugins/sandbox-first/tests/test_checker.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from sandbox_first.checker import check_pre_tool_use, check_post_tool_use_failure
 
 
@@ -99,3 +101,101 @@ class TestCheckPostToolUseFailure:
             "error": "some error",
         }
         assert check_post_tool_use_failure(hook_input) is None
+
+    # Regression tests for task 34 (false positive findings): the hook
+    # was flagging non-sandbox failures as sandbox-related, pushing the
+    # model toward dangerouslyDisableSandbox unnecessarily. These cases
+    # were witnessed in real sessions and must NOT be flagged.
+    @pytest.mark.parametrize(
+        "case,command,error",
+        [
+            (
+                "ls-enoent",
+                "ls plugins/nonexistent/",
+                "Exit code 2\nls: cannot access 'plugins/nonexistent/': No such file or directory",
+            ),
+            (
+                "git-config-write-warning",
+                "git branch -D feature",
+                "warning: unable to access '.git/config': some write warning",
+            ),
+            (
+                "git-not-a-repo",
+                "git worktree list",
+                "fatal: not a git repository: .git/refs/remotes/",
+            ),
+            (
+                "1password-ipc",
+                "op-ssh-sign",
+                "1Password IPC error: agent not running",
+            ),
+            (
+                "command-not-found",
+                "nonexistent-tool --help",
+                "bash: nonexistent-tool: command not found",
+            ),
+            (
+                "ruby-exception",
+                "ruby script.rb",
+                "script.rb:5:in `<main>': undefined method `foo' for nil:NilClass (NoMethodError)",
+            ),
+            (
+                "test-assertion-failure",
+                "pytest tests/",
+                "AssertionError: expected 3 but got 4",
+            ),
+        ],
+    )
+    def test_non_sandbox_errors_return_none(self, case, command, error):
+        """Sandboxed Bash failures with non-sandbox-shaped errors stay silent."""
+        hook_input = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "error": error,
+        }
+        assert check_post_tool_use_failure(hook_input) is None, (
+            f"case {case!r} should not be flagged as sandbox-related"
+        )
+
+    # Positive cases: errors that ARE sandbox-shaped should still get flagged.
+    @pytest.mark.parametrize(
+        "case,command,error",
+        [
+            (
+                "fs-operation-not-permitted",
+                "touch /outside",
+                "touch: cannot touch '/outside': Operation not permitted",
+            ),
+            (
+                "network-connection-refused",
+                "curl http://blocked.example.com",
+                "curl: (7) Failed to connect to blocked.example.com port 80: Connection refused",
+            ),
+            (
+                "network-could-not-resolve",
+                "curl https://blocked.example.com",
+                "curl: (6) Could not resolve host: blocked.example.com",
+            ),
+            (
+                "sandbox-exec-deny",
+                "touch /etc/foo",
+                "sandbox-exec: file-write-create /etc/foo deny",
+            ),
+            (
+                "read-only-fs",
+                "touch /usr/foo",
+                "touch: /usr/foo: Read-only file system",
+            ),
+        ],
+    )
+    def test_sandbox_shaped_errors_return_context(self, case, command, error):
+        """Sandbox-shaped errors on sandboxed calls still get the warning."""
+        hook_input = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "error": error,
+        }
+        result = check_post_tool_use_failure(hook_input)
+        assert result is not None, f"case {case!r} should be flagged"
+        ctx = result["hookSpecificOutput"]["additionalContext"]
+        assert "sandbox" in ctx.lower()

--- a/plugins/sandbox-first/tests/test_checker.py
+++ b/plugins/sandbox-first/tests/test_checker.py
@@ -186,6 +186,36 @@ class TestCheckPostToolUseFailure:
                 "touch /usr/foo",
                 "touch: /usr/foo: Read-only file system",
             ),
+            (
+                "mkdir-operation-not-permitted",
+                "mkdir .vscode",
+                "mkdir: cannot create directory '.vscode': Operation not permitted",
+            ),
+            (
+                "mkdir-smart-quote-variant",
+                "mkdir -p /tmp/outside/.git",
+                "mkdir: \u2018/tmp/outside/.git\u2019: Operation not permitted",
+            ),
+            (
+                "shell-eval-operation-not-permitted",
+                "sh -c 'touch /path/.git/config'",
+                "(eval):1: operation not permitted: /private/tmp/sandbox-clone-test/dotfiles-probe/.git/config",
+            ),
+            (
+                "git-single-fatal-leading-dirs",
+                "git worktree add ../outside-wt -b probe",
+                "Preparing worktree (new branch 'probe')\nfatal: could not create leading directories of '../outside-wt/.git': Operation not permitted",
+            ),
+            (
+                "git-single-fatal-copy-templates",
+                "git clone /src /tmp/outside/dest",
+                "fatal: cannot copy '/usr/share/git-core/templates/hooks/pre-commit.sample' to '/tmp/outside/dest/.git/hooks/pre-commit.sample': Operation not permitted",
+            ),
+            (
+                "git-error-then-fatal-pair",
+                "git clone /src /tmp/outside/dest",
+                "error: could not write config file /tmp/outside/dest/.git/config: Operation not permitted\nfatal: could not set 'core.repositoryformatversion' to '0'",
+            ),
         ],
     )
     def test_sandbox_shaped_errors_return_context(self, case, command, error):

--- a/plugins/sandbox-first/tests/test_cli.py
+++ b/plugins/sandbox-first/tests/test_cli.py
@@ -76,6 +76,16 @@ class TestPostToolUseFailureCLI:
         assert result.returncode == 0
         assert result.stdout.strip() == ""
 
+    def test_non_sandbox_error_on_sandboxed_call_exits_0_no_output(self):
+        """Regression: sandboxed Bash failure with non-sandbox error stays silent."""
+        result = run_cli("post-tool-use-failure", {
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls plugins/nonexistent/"},
+            "error": "ls: cannot access 'plugins/nonexistent/': No such file or directory",
+        })
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
     def test_unknown_subcommand_exits_0(self):
         result = run_cli("unknown-thing", {
             "tool_name": "Bash",


### PR DESCRIPTION
## Summary

- `check_post_tool_use_failure` was adding its sandbox warning context to every failed sandboxed Bash call, regardless of what the error actually said, producing false positives on ENOENT, git warnings, command-not-found, test assertion failures, application exceptions, and 1Password IPC errors.
- Add a conservative allow-list of error substrings that strongly indicate a sandbox-caused failure (`Operation not permitted`, `sandbox-exec`, `Read-only file system`, `Connection refused`, `Could not resolve host`, `Network is unreachable`, `Read-only file system`, `Failed to connect`). Only emit the warning when the error matches. Everything else stays silent.
- Add parametrized regression tests in `test_checker.py` for each false-positive pattern, plus a CLI-layer regression test in `test_cli.py` to guard the wire format.

## Context

Root cause found via systematic debugging: compared `check_pre_tool_use` (which has a meaningful predicate) to `check_post_tool_use_failure` (which had *no* predicate on error content). The plugin was conflating "sandboxed call that failed" with "call that failed because of the sandbox". These are different sets, and the asymmetry was the bug.

Witnessed live during the investigation session on three unrelated Bash failures: `ls` ENOENT, `git worktree remove` "contains modified files", and a `git add` path mismatch. All three were flagged as maybe-sandbox-related under the old code. All three stay quiet under this fix.

## Test plan

- [x] `uv run pytest` — 34/34 green (up from 21 baseline; 12 new function-level + 1 CLI-level regression)
- [x] RED → GREEN verified at function layer (7 failing cases, then all green)
- [x] RED → GREEN verified at CLI/subprocess layer (temp-reverted predicate, saw failure through the wire, then restored)
- [ ] Manual verification after PR merge: reinstall the plugin (`/plugin uninstall && /plugin install`) and confirm that running a command with a non-sandbox failure no longer fires `PostToolUseFailure:Bash` context.

## Not addressed in this PR

- The `PreToolUse` retry-friction bug (task 34 annotation #2) — separate fix, requires smarter transcript analysis
- The real sandbox-config gaps (task 34 annotation #3 / task 50) — `git worktree add` writing to `.vscode/settings.json`, etc. — those need sandbox config changes, not hook logic changes
- `find_recent_sandboxed_failure` in `transcript.py` has the same "classify by call flag, not error content" conflation. Scope-limited here because that function is only consulted on the retry path, which is its own investigation.