### PR TITLE
feat(agent-meta): inject session ID via PostToolUse hook on park

### DIFF
--- a/docs/plans/2026-04-11-sandbox-empirical-test-design.md
+++ b/docs/plans/2026-04-11-sandbox-empirical-test-design.md
@@ -1,0 +1,166 @@
+# Sandbox Empirical Test Session — Design
+
+**Date:** 2026-04-11
+**Task:** pickled-claude-plugins #60
+**Status:** DESIGN (not yet executed)
+**Related:** #34 (hook findings), #50 (git worktree add gap), PR #54 (classifier fix)
+
+## Prior empirical results (2026-04-09, plugin build day)
+
+During the sandbox-first plugin build there were integration-test sessions at
+`/private/tmp/sandbox-hook-test` and `/private/tmp/sandbox-integration-test`
+(session JSONLs still exist under `~/.claude/projects/`). They did probe the
+sandbox, but only to verify the hook fired correctly. Established facts:
+
+1. **`/tmp/*` writes are blocked in sandbox.** `touch /tmp/anything` returns
+   `Operation not permitted`. This rules out the "allow-list with /tmp as
+   default-allowed" assumption — Claude's sandbox-exec profile is
+   **allow-list style** (anything not explicitly listed is denied), not
+   deny-list style.
+2. **Two independent write-denial layers exist.** When a sandboxed `touch`
+   failed and the model retried with `dangerouslyDisableSandbox: true`, the
+   retry was *also* blocked — but by a different layer with a different error
+   string: "Claude Code may only create or modify files in the allowed working
+   directories." That's a Claude Code runtime check separate from sandbox-exec.
+   Any fix we propose must name which layer it targets.
+3. The `.git/`, `.vscode/`, and `.worktrees/` paths — the targets of this
+   session — were **never probed** in the plugin-build tests. Prior work only
+   validated the hook's behavior on `/tmp/` denials.
+
+So hypothesis H1 ("`.git/` is explicitly blocked") should be re-phrased as
+H1': "`.git/` writes are not on the sandbox allow-list, so they deny by default."
+Functionally identical, but the fix path differs — we'd be *adding* `.git` to
+`allowWrite`, not removing a deny rule.
+
+## Why this exists
+
+Task 34 (2026-04-10) recorded the observation that `git worktree add` fails in the
+Claude Code sandbox, apparently blocked on `.vscode/settings.json` creation, and
+speculated the cause was "macOS-level protection (xattrs or Data Vault)." That
+observation has since been cited in task 50, PR #52, PR #54, and multiple parked
+sessions — but no one has ever opened the sandbox profile or run a controlled
+write to confirm which layer is enforcing what.
+
+Before changing any sandbox config, we need to know:
+
+1. **Where** the sandbox is enforced (sandbox-exec profile? macOS system
+   integrity? Claude Code hook layer?)
+2. **What** is actually blocked vs. what the task annotations *claim* is blocked
+3. **How** to fix each failure (config edit, command rewrite, or unfixable)
+
+## Hypotheses to test
+
+| # | Hypothesis | Source | Status |
+|---|---|---|---|
+| H1 | `.git/` writes are explicitly denied by Claude's sandbox profile | User intuition, 2026-04-11 | Untested |
+| H2 | `.vscode/settings.json` is blocked by macOS xattrs/Data Vault | Task 34 annotation | Untested |
+| H3 | `git worktree add` fails on `.git/worktrees/<name>/` metadata write, not on `.vscode/settings.json` | Alternative reading of the symptom | Untested |
+| H4 | Repo-relative writes (anything under `$cwd`) are allowed by default | Implicit in current sandbox config (no repo paths in allowWrite) | Untested |
+| H5 | The Claude Code sandbox profile is a readable file on disk | Standard sandbox-exec pattern | Untested |
+| H6 | `git clone` and `git worktree add` fail when placing the destination *inside* the current repo, specifically because they write to the source repo's `.git/` dir (which isn't on the allow-list). The destination's location is a red herring — the blocker is the hidden `.git/` write. | User, 2026-04-11 | Untested |
+| H7 | Task 50's claim that `git worktree add` fails on `.vscode/settings.json` creation was a misattribution — the real failure was the `.git/worktrees/<name>/` metadata write, and `.vscode/settings.json` was just the next failing write after the first one got worked around | Hypothesis from H6 | Untested |
+
+## Method
+
+Two phases, in order. Stop after phase 1 if it answers everything.
+
+### Phase 1: Read the rules (if possible)
+
+Goal: locate the generated sandbox-exec profile and read it directly. If this
+works we can skip most of phase 2.
+
+Tactics to try, in order of cheapness:
+
+1. `ps aux | grep sandbox-exec` while a sandboxed command is mid-flight — the
+   profile path is typically argv[1] or passed via `-f`
+2. Search candidate dirs:
+   - `~/.claude/` (we already listed this, no `.sb` files)
+   - `~/Library/Application Support/Claude/`
+   - `~/Library/Caches/Claude/`
+   - `/tmp/claude-sandbox-*`, `/tmp/claude-*.sb`
+   - Temporarily export a dump-on-open technique if sandbox-exec has debug flags
+3. `lsof` the Claude CLI process to find open file descriptors mentioning `.sb`
+   or `sandbox`
+4. Strings-search the Claude Code binary for `sandbox-exec` invocation patterns
+   (last resort — binary may be bundled/obfuscated)
+
+**Success criterion:** a file we can read whose contents reference
+`allow file-write*` or `deny file-write*` rules.
+
+**If found:** grep it for `.git`, `.vscode`, and any paths under the repo. Done.
+
+### Phase 2: Probe with controlled writes
+
+If the profile can't be read, probe the sandbox empirically from inside a
+sandboxed Claude Code Bash call.
+
+**Setup:**
+- Work in a fresh scratch repo under `scratch/sandbox-probe-repo/` (git init'd,
+  outside `.worktrees/`, outside any existing git structure)
+- Each probe records: command, exit code, stderr, stdout, inferred layer
+- Results go to `docs/plans/2026-04-11-sandbox-empirical-test-results.md`
+
+**Probes (in order, simplest first):**
+
+| # | Command | Expected | Measures |
+|---|---|---|---|
+| P1 | `touch /tmp/sandbox-test-$$` | **blocked** (per prior 2026-04-09 results) | baseline: confirms prior result still holds |
+| P2 | `touch baseline.txt` (in scratch/probe-repo) | ? | H4: is repo cwd writable? |
+| P3 | `touch .vscode/settings.json` (mkdir `.vscode` first if needed) | ? | H2: task 50's claim — is `.vscode/` specifically blocked? |
+| P4 | `touch .git/sandbox-probe` | ? | H1': plain `.git/` write |
+| P5 | `mkdir -p .git/worktrees/probe && touch .git/worktrees/probe/HEAD` | ? | H3: specifically the worktree-metadata path git would use |
+| P6 | `git worktree add .worktrees/probe-inside -b probe-inside` | ? | **H6: inside-repo worktree.** If this fails, capture *which* write triggered the denial (stderr should name the path) |
+| P7 | `git worktree add ../probe-outside-wt -b probe-outside` | ? | H6 control: outside-repo worktree. If this behaves differently from P6, H6 gets stronger |
+| P8 | `mkdir probe-clone-target && git clone https://github.com/technicalpickles/pickled-claude-plugins probe-clone-target/cloned` | ? | H6 extension: clone into subdir of repo. Same `.git/` write pattern as worktree |
+| P9 | `xattr -l .vscode/settings.json` (only if P3 succeeded) | ? | H2: if P3 DID succeed, check whether the file has a Data Vault marker that would block a second write |
+| P10 | `ls -la@ .git/` | allowed | H2 complement: do `.git/` contents carry macOS extended attrs that differ from normal dirs? |
+| P11 | `touch ~/outside-allowwrite-$$` | **blocked** | sanity: unlisted home dir should fail (confirms allow-list semantics still apply) |
+
+For each probe, the exact stderr text matters. Three distinct error shapes will
+tell us the layer:
+- `sandbox-exec: deny file-write-create ...` → Apple seatbelt / Claude profile
+- `Operation not permitted` with no sandbox-exec prefix → macOS system integrity
+  (SIP / Data Vault / rootless)
+- `permission denied` (POSIX EPERM) from git/shell wrapper → same as above, just
+  reported differently by the calling tool
+
+**Success criterion:** every hypothesis above is marked CONFIRMED or REFUTED
+with a direct quote of the error output.
+
+## Out of scope for this session
+
+- Fixing the gaps we find (separate task)
+- Updating the sandbox-first plugin's error signatures based on what we learn
+  (separate task)
+- Proposing changes to `~/.claude/settings.json` (separate task)
+- Investigating the PreToolUse retry-friction bug from task 34 (separate task)
+
+If any of those feel urgent mid-investigation, add a taskwarrior entry and
+continue.
+
+## Deliverables
+
+1. **Results doc**: `docs/plans/2026-04-11-sandbox-empirical-test-results.md` —
+   every probe with its exact output, hypotheses marked CONFIRMED/REFUTED, and
+   a one-paragraph summary of the true blocking rules
+2. **Taskwarrior followups**: one task per real gap found, scoped to the layer
+   that needs changing
+3. **(Optional)** update `plugins/sandbox-first/src/sandbox_first/checker.py`'s
+   `SANDBOX_ERROR_SIGNATURES` if phase 2 surfaces new error shapes the
+   classifier should recognize
+
+## Open design questions
+
+- **Fresh session or here?** Running the probes in this already-polluted session
+  is faster but less reproducible. A fresh session is cleaner but requires
+  context handoff. LEANING: fresh session, with this design doc as the handoff.
+- **Scratch repo location?** `scratch/` is gitignored and existing. Good enough.
+- **Should we capture stderr to files, or rely on tool output?** Files are
+  greppable across probes — lean toward capturing.
+
+## Anti-gaslight provision
+
+This session exists specifically because the sandbox claims have been cited for
+weeks without verification. If any probe result conflicts with a task 34/50
+annotation, the probe wins and the task gets annotated with the correction.
+Observation is not evidence.

--- a/docs/plans/2026-04-11-sandbox-empirical-test-design.md
+++ b/docs/plans/2026-04-11-sandbox-empirical-test-design.md
@@ -127,6 +127,97 @@ tell us the layer:
 **Success criterion:** every hypothesis above is marked CONFIRMED or REFUTED
 with a direct quote of the error output.
 
+### Phase 3: real-repo and workaround probes (added 2026-04-11 after Phase 1/2 results)
+
+Phase 1 and Phase 2 ran against a fresh `/tmp/sandbox-probe-repo` and fully
+refuted H1, H1', H2, H3, H5, H6. See
+`docs/plans/2026-04-11-sandbox-empirical-test-results.md` for the primary record.
+
+But two questions remain that a fresh probe repo can't answer:
+
+1. **Task 34 originated in the `pickled-claude-plugins` repo, not a `/tmp` repo.**
+   Before closing task #63 as "not reproducible," run one more worktree-add in
+   the real repo to rule out the "something specific to this repo" hypothesis.
+2. **P8 (clone-into-subdir) failed due to `**/.git/hooks/**` deny on the
+   destination's seeded hook templates.** Test whether `git clone --template=/dev/null`
+   bypasses it, so task #67's README can document a workaround.
+
+Both probes require a fresh Claude Code session with sandbox enabled. Do not
+run these in a session that's already been brainstorming or synthesizing — the
+cognitive modes are different and results should live in their own JSONL.
+
+#### P12: real-repo `git worktree add`
+
+- **cwd:** `/Users/technicalpickles/github.com/technicalpickles/pickled-claude-plugins`
+- **Hypothesis under test:** H6/H7 (whether task 34's claim reproduces in its
+  original context)
+- **Prior art:** `.worktrees/sandbox-first-false-positives` already exists in this
+  repo — it was successfully created during the PR #54 work in a sandboxed
+  session. So there's already one unverified-but-live success. P12 is a
+  deliberate, captured reproduction of that.
+
+```bash
+# Probe
+git worktree add .worktrees/empirical-test-worktree -b empirical-test-worktree
+echo "exit=$?"
+git worktree list
+
+# Cleanup (MANDATORY — do not leave this worktree around)
+git worktree remove .worktrees/empirical-test-worktree
+git branch -D empirical-test-worktree
+```
+
+**If P12 succeeds:** close task #63 with "not reproducible in real repo; task 34
+observation was a misread." Annotate task 34 with the correction (see #62).
+
+**If P12 fails:** capture full stderr, exit code, and the specific error path.
+This would be a genuinely new finding and overrides the phase 1/2 conclusion for
+this repo specifically.
+
+#### P13: clone with `--template=/dev/null`
+
+- **cwd:** any writable dir (recommend `/tmp/sandbox-probe-repo` if still
+  present, or create a new one)
+- **Hypothesis under test:** whether `--template=/dev/null` is a valid
+  workaround for the `tbq()` `**/.git/hooks/**` deny that blocks normal `git clone`
+- **Source repo:** `/tmp/sandbox-probe-repo` from Phase 2 (has at least one
+  commit from earlier probes). Using a local source rather than GitHub
+  eliminates network and GitHub-specific variables.
+
+```bash
+# Setup
+mkdir -p /tmp/p13-clone-target
+cd /tmp/p13-clone-target
+
+# Probe
+git clone --template=/dev/null /tmp/sandbox-probe-repo destination 2>&1
+echo "exit=$?"
+
+# Sanity check (no hooks dir content, no errors)
+ls -la destination/.git/hooks/ 2>&1
+
+# Cleanup
+rm -rf /tmp/p13-clone-target
+```
+
+**If P13 succeeds:** document `--template=/dev/null` in the sandbox-first
+plugin README as the workaround for clone-into-subdir under sandbox. Feeds task
+#67 directly.
+
+**If P13 fails with the same `commit-msg.sample` error:** the deny happens even
+with no templates — probably because git populates a minimal hooks dir
+regardless. Next workaround to try: clone outside the repo first then move.
+
+**If P13 fails with a different error:** new finding, capture and re-plan.
+
+#### Phase 3 deliverables
+
+- Append results to `docs/plans/2026-04-11-sandbox-empirical-test-results.md`
+  under a new "Phase 3" section. Do not create a separate results doc — keep
+  the record together.
+- Annotate taskwarrior #63 with the P12 outcome.
+- If P13 succeeds, annotate #67 with the confirmed workaround.
+
 ## Out of scope for this session
 
 - Fixing the gaps we find (separate task)

--- a/docs/plans/2026-04-11-sandbox-empirical-test-results.md
+++ b/docs/plans/2026-04-11-sandbox-empirical-test-results.md
@@ -1,0 +1,420 @@
+# Sandbox Empirical Test Session — Results
+
+**Date:** 2026-04-11
+**Task:** pickled-claude-plugins #60
+**Design:** `docs/plans/2026-04-11-sandbox-empirical-test-design.md`
+**Claude Code version:** 2.1.87
+**Probe cwd:** `/private/tmp/sandbox-probe-repo` (symlinked from `/tmp/sandbox-probe-repo`)
+
+## TL;DR
+
+The sandbox profile is **generated in memory per-command** and passed inline via
+`sandbox-exec -p <profile>` — it is **never written to disk as an `.sb` file**,
+which is why every prior search for the profile came up empty.
+
+The true default-deny list relevant to the hypotheses is **hardcoded in the Claude
+Code binary**, not sourced from user config:
+
+- **`.vscode/` — denied** (wholesale, `(deny file-write* (subpath ".../.vscode"))`)
+- **`.idea/` — denied** (wholesale)
+- **`.claude/commands/` — denied**
+- **`.claude/agents/` — denied**
+- **`.git/hooks/**` — denied**
+- **`.git/config` — denied** (unless `allowGitConfig=true`, which defaults to `false`)
+- **`.git/` — NOT denied.** Everything else under `.git/` (HEAD, index, refs, worktrees, objects, packed-refs, etc.) is writable if `.` is on the write allow-list.
+- Dotfiles denied anywhere: `.gitconfig, .gitmodules, .bashrc, .bash_profile, .zshrc, .zprofile, .profile, .ripgreprc, .mcp.json`
+
+**And the headline empirical result:** `git worktree add .worktrees/probe-inside`
+**SUCCEEDED** inside the sandbox. The long-standing claim in task 34 / task 50 / PR #54
+that this operation is blocked is **wrong**. What happens is: the command emits one
+non-fatal `error: could not read IPC response` line (from git trying to talk to the
+`fsmonitor--daemon.ipc` unix socket, which IS blocked by default), then proceeds to
+create the worktree successfully. Whoever first cited this failure saw the "error:"
+line and concluded the command had failed; it hadn't.
+
+## Phase 1 — Profile location
+
+### H5: Sandbox profile is a readable file on disk — **REFUTED**
+
+The profile is built inline in a JS function and passed directly to `sandbox-exec`
+as the `-p` argument:
+
+```js
+let v = shellQuote(["env", ...envVars, "sandbox-exec", "-p", profileString, "bash", "-c", cmd]);
+```
+
+(source: `function Ht1` in the Claude binary, offset ~75188039). No file is ever
+materialized. The obfuscated function names are:
+
+- `$uq()` — top-level profile composer
+- `Huq()` — read-rule generator
+- `_uq()` — write-rule generator
+- `tbq()` — hardcoded deny list composer (the important one)
+- `BE_()` — "denied subpaths" array builder
+- `dv()` — path normalizer with `realpathSync` (resolves `/tmp/X` → `/private/tmp/X`)
+
+### Phase 1 "bonus": full rule sources extracted from the binary
+
+**`tbq(allowGitConfig=false)`** — the hardcoded write-deny list, reconstructed:
+
+```js
+function tbq(allowGitConfig = false) {
+  const cwd = process.cwd();
+  const rules = [];
+  // hQH: dotfiles denied at cwd AND via **/<dotfile> glob
+  const hQH = [".gitconfig", ".gitmodules", ".bashrc", ".bash_profile",
+               ".zshrc", ".zprofile", ".profile", ".ripgreprc", ".mcp.json"];
+  for (const f of hQH) {
+    rules.push(path.resolve(cwd, f));
+    rules.push(`**/${f}`);
+  }
+  // BE_(): directory denies; note that .git is FILTERED OUT of cbq
+  // cbq = [".git", ".vscode", ".idea"]
+  // BE_() = [...cbq.filter(x => x !== ".git"), ".claude/commands", ".claude/agents"]
+  //       = [".vscode", ".idea", ".claude/commands", ".claude/agents"]
+  for (const d of [".vscode", ".idea", ".claude/commands", ".claude/agents"]) {
+    rules.push(path.resolve(cwd, d));
+    rules.push(`**/${d}/**`);
+  }
+  rules.push(path.resolve(cwd, ".git/hooks"));
+  rules.push("**/.git/hooks/**");
+  if (!allowGitConfig) {
+    rules.push(path.resolve(cwd, ".git/config"));
+    rules.push("**/.git/config");
+  }
+  return [...new Set(rules)];
+}
+```
+
+**Critical subtlety**: `BE_()` explicitly filters `.git` OUT of the `cbq` directory
+list. So `.git/` itself is **not** a wholesale-denied subpath — only `.git/hooks/**`
+and (by default) `.git/config` are denied. This is the opposite of what multiple
+earlier tasks had assumed.
+
+**Profile template** (from `$uq()`, simplified):
+
+```scheme
+(version 1)
+(deny default (with message "<logTag>"))
+
+; Essential permissions: process, signal, mach-priv-task-port, user-preference-read,
+; a whitelist of mach services, IPC, IOKit IOSurface, a whitelist of sysctls,
+; distributed notifications, a few device-file ioctls...
+
+; Network (if !needsNetworkRestriction)
+(allow network*)
+; ...otherwise a localhost-only proxy setup
+
+; File read
+(allow file-read*)  ; default when no readConfig is set
+; ... + deny-list from readConfig.denyOnly
+; ... + allow-list exceptions from readConfig.allowWithinDeny
+
+; File write
+; + allow $TMPDIR subpaths
+; + allow each writeConfig.allowOnly (as subpath or regex)
+; + deny each writeConfig.denyWithinAllow (as subpath or regex)
+; + deny each tbq() entry (see above)
+; + deny file-write-unlink on every parent of every denied subpath (via es1())
+```
+
+Note the `es1()` helper: for every denied path, it emits additional
+`(deny file-write-unlink)` rules on every parent directory of the denied path.
+This prevents workarounds like `rm -rf .` to try to bypass the deny by unlinking
+the enclosing directory.
+
+### Corollary: `needsNetworkRestriction` gates all network
+
+If `needsNetworkRestriction` is false (no `readConfig.denyOnly.length > 0` and
+no proxy ports set), the profile emits `(allow network*)` — full network access.
+This matches the observed behavior where github.com access works without explicit
+network allowlisting.
+
+## Phase 2 — Probe results
+
+All probes executed in `/private/tmp/sandbox-probe-repo` (a fresh disposable repo,
+created for this session and safe to pollute).
+
+| # | Command | Result | Exit | stderr (verbatim) | Layer |
+|---|---|---|---|---|---|
+| P1 | `touch /tmp/sandbox-test-3049` | BLOCKED | 1 | `touch: cannot touch '/tmp/sandbox-test-3049': Operation not permitted` | sandbox-exec profile (default-deny; `/tmp` not in user's `allowWrite`) |
+| P2 | `touch baseline.txt` | ALLOWED | 0 | — | cwd is `.` in user's `allowOnly` |
+| P3 | `mkdir .vscode` | BLOCKED | 1 | `mkdir: cannot create directory '.vscode': Operation not permitted` | sandbox-exec profile (`tbq()` deny on `.vscode`) |
+| P3b | `mkdir .idea` | BLOCKED | 1 | `mkdir: cannot create directory '.idea': Operation not permitted` | same, `.idea` deny |
+| P3c | `mkdir -p .claude/commands` | BLOCKED | 1 | `mkdir: cannot create directory '.claude/commands': Operation not permitted` | same, `.claude/commands` deny |
+| P3d | `touch .claude/some-other-file` | ALLOWED | 0 | — | `.claude/` itself is not denied; only `.claude/commands` and `.claude/agents` |
+| P3e | `touch .mcp.json` / `.gitconfig` / `.bashrc` | BLOCKED | 1 | `touch: cannot touch 'X': Operation not permitted` | sandbox-exec profile (`hQH` dotfile denies) |
+| P3f | `touch .claude/settings.json` | BLOCKED | 1 | `touch: cannot touch '.claude/settings.json': Operation not permitted` | sandbox-exec profile (from user's `denyWithinAllow`, not `tbq()`) |
+| P4 | `touch .git/sandbox-probe` | **ALLOWED** | 0 | — | `.git/` itself is not denied — **H1 refuted** |
+| P4b | `touch .git/hooks/post-commit` | BLOCKED | 1 | `touch: cannot touch '.git/hooks/post-commit': Operation not permitted` | `tbq()` deny on `.git/hooks` |
+| P4c | `touch .git/config` | BLOCKED | 1 | `touch: cannot touch '.git/config': Operation not permitted` | `tbq()` deny on `.git/config` (default-deny; `allowGitConfig=false`) |
+| P5 | `mkdir -p .git/worktrees/probe && touch .git/worktrees/probe/HEAD` | ALLOWED | 0 | — | `.git/worktrees/` is not in `tbq()` |
+| P5b | `mkdir -p .git/refs/heads/probe && touch .git/refs/heads/probe-ref` | ALLOWED | 0 | — | `.git/refs/` not denied |
+| P5c | `touch .git/index.lock` | ALLOWED | 0 | — | general `.git/` writes work |
+| P6 | `git worktree add .worktrees/probe-inside -b probe-inside` | **ALLOWED** | 0 | `Preparing worktree (new branch 'probe-inside')` + `error: could not read IPC response` + `HEAD is now at 719d8b2 initial` | **worktree was created successfully**. `git worktree list` confirms it. The "IPC response" error is git's `fsmonitor--daemon.ipc` unix socket, which the sandbox blocks (`allowUnixSockets` not set) — **non-fatal and does not prevent worktree creation** |
+| P7 | `git worktree add ../probe-outside-wt -b probe-outside` | BLOCKED | 128 | `Preparing worktree (new branch 'probe-outside')` + `fatal: could not create leading directories of '../probe-outside-wt/.git': Operation not permitted` | sandbox-exec profile: destination `../probe-outside-wt/` is **outside** `.` (the write allow-list), so creating it fails |
+| P8 | `git clone https://github.com/technicalpickles/pickled-claude-plugins probe-clone-target/cloned` | BLOCKED | 128 | `Cloning into 'probe-clone-target/cloned'...` + `fatal: cannot copy '/usr/local/opt/git/share/git-core/templates/hooks/commit-msg.sample' to '/private/tmp/sandbox-probe-repo/probe-clone-target/cloned/.git/hooks/commit-msg.sample': Operation not permitted` | sandbox-exec profile: `tbq()`'s `**/.git/hooks/**` glob deny matches the nested cloned `.git/hooks/`. **The source repo's `.git/` is NOT the blocker** — it's the destination's new `.git/hooks/` being seeded from templates |
+| P9 | `xattr -l .vscode/settings.json` | N/A | — | — | P3 failed, nothing to check |
+| P10 | `/bin/ls -la@ .git/` | ALLOWED (empty result) | 0 | `.git/` contents show no `@` marker → **no extended attributes** → **H2's Data Vault/xattrs angle is refuted** |
+| P11 | `touch ~/outside-allowwrite-4362` | BLOCKED | 1 | `touch: cannot touch '/Users/technicalpickles/outside-allowwrite-4362': Operation not permitted` | sandbox-exec profile (home dir not on allow-list) |
+
+### Error-shape catalog
+
+Three distinct stderr shapes for write denies (all surface the same underlying
+`EPERM` from the kernel seatbelt, routed through different callers):
+
+1. **Tool-reported EPERM**: `touch: cannot touch 'X': Operation not permitted` /
+   `mkdir: cannot create directory 'X': Operation not permitted` — the failing tool
+   prefixes its own name and re-reports the POSIX error.
+2. **Shell-reported EPERM** (from shell redirects): `(eval):1: operation not permitted: X`
+   when a command like `echo test > .gitconfig` is used. No tool prefix; just shell eval
+   reporting back.
+3. **Git-reported EPERM**: `fatal: could not create leading directories of 'X/.git': Operation not permitted`
+   / `fatal: cannot copy 'X' to 'Y': Operation not permitted` / `fatal: could not write config file X: Operation not permitted`.
+   Git wraps the POSIX error in its own message.
+
+**There is NO `sandbox-exec:` or `seatbelt:` prefix on any error.** The kernel seatbelt
+denies the write with `EPERM` and nothing in the user-visible output identifies the
+enforcement layer. This is important for the sandbox-first plugin's error classifier:
+the only reliable signature is `Operation not permitted` combined with path heuristics,
+because there's no marker string telling you it was sandbox-exec as opposed to a regular
+Unix permission problem.
+
+## Hypothesis verdicts
+
+| # | Hypothesis | Verdict | Evidence |
+|---|---|---|---|
+| H1 | `.git/` writes are explicitly denied by Claude's sandbox profile | **REFUTED** | P4 succeeded; profile source confirms `BE_()` filters `.git` out of `cbq` |
+| H1' | `.git/` writes are not on the sandbox allow-list, so they deny by default | **REFUTED** | `.` is on the user's write allow-list, which includes everything under cwd including `.git/` — only the `tbq()` sub-denies carve pieces out |
+| H2 | `.vscode/settings.json` is blocked by macOS xattrs/Data Vault | **REFUTED** | `.vscode/` is blocked by `tbq()` in the Claude Code sandbox profile (explicit `(deny file-write* (subpath ".../.vscode"))`). `.git/` contents have no extended attributes (P10). This is plain sandbox-exec, not macOS rootless/Data Vault |
+| H3 | `git worktree add` fails on `.git/worktrees/<name>/` metadata write | **REFUTED** | P5 showed that path is writable, and P6 showed `git worktree add` actually succeeds |
+| H4 | Repo-relative writes (anything under `$cwd`) are allowed by default | **CONFIRMED, with caveats** | P2 and the many `.git/` subpath writes confirm this. Caveats: `.vscode/`, `.idea/`, `.claude/commands/`, `.claude/agents/`, and the `hQH` dotfiles (`.gitconfig, .mcp.json, .bashrc, …`) are hardcoded exceptions via `tbq()`. Plus user-configured `denyWithinAllow` entries like `.claude/settings.json` |
+| H5 | The Claude Code sandbox profile is a readable file on disk | **REFUTED** | Profile is generated inline by `$uq()` and passed via `sandbox-exec -p`, never written to a file |
+| H6 | `git clone`/`git worktree add` fail when placing destination inside the repo, because of writes to the source's `.git/` | **REFUTED (mechanism wrong)** | P6 showed worktree-add-inside SUCCEEDS. P8 showed clone-into-subdir fails, but the blocker is the **destination's** new `.git/hooks/` matching `**/.git/hooks/**` — not the source's `.git/`. The user's intuition that "hidden `.git/` writes are the issue" was right in spirit for clone, wrong about which `.git/` |
+| H7 | Task 50's claim that `git worktree add` fails on `.vscode/settings.json` creation was a misattribution | **CONFIRMED** (sort of) | P6 empirically demonstrates `git worktree add` works fine; it never attempts to write `.vscode/settings.json`. The original "worktree add blocked on `.vscode/settings.json`" observation must have come from a separate tool (editor-opening script, post-create hook) running after worktree creation, NOT from git worktree add itself |
+
+## What actually breaks (the real blocker list)
+
+For future reference, the operations that genuinely fail in a sandboxed Claude
+Code session and why:
+
+| Operation | Blocker | Exact path denied | Fixable how? |
+|---|---|---|---|
+| `git init` / `git config set` | `.git/config` deny | `/cwd/.git/config` via `tbq()` when `!allowGitConfig` | Per-session: pass `allowGitConfig=true` (not user-configurable via settings.json today). Per-command: `git -c user.x=y ...` (avoids writing to `.git/config`). Long-term: Claude Code needs to plumb this through `sandbox.allowGitConfig` in settings |
+| `git commit` with any `.git/hooks/*` | `.git/hooks/**` deny | `**/.git/hooks/**` via `tbq()` | Disable hooks (`git -c core.hooksPath=/dev/null commit ...`) or use `--no-verify` (which user global CLAUDE.md forbids absent explicit request) |
+| `git clone` anywhere | `**/.git/hooks/**` glob matches the cloned repo's template-seeded hooks dir | `DEST/.git/hooks/commit-msg.sample` etc. | Use `git clone --template=/dev/null` to skip hook templates, OR accept the failure and do `git init && git remote add && git fetch` dance |
+| Writing to editor config dirs | `.vscode/` and `.idea/` deny | `/cwd/.vscode`, `/cwd/.idea` via `tbq()` | Not user-fixable via settings.json. Have to operate outside the sandbox (Edit/Write tool uses a different layer anyway) |
+| Writing to most dotfiles in cwd | `hQH` deny list | `/cwd/.gitconfig`, `.bashrc`, `.mcp.json`, etc. via `tbq()` | Not user-fixable |
+| Creating files outside cwd | Not on `allowWrite` | Any path not under `.`, `$TMPDIR`, or the user's explicit `allowWrite` entries | Add the path to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json` |
+| Unix-socket IPC (e.g., git fsmonitor) | `allowUnixSockets`/`allowAllUnixSockets` not set | `fsmonitor--daemon.ipc` in `.git/` | Non-fatal for git; can be ignored. For others, set `allowUnixSockets` in settings |
+
+## Corrections to prior tasks (anti-gaslight fulfillment)
+
+The design doc's anti-gaslight provision says: "if any probe result conflicts with
+a task 34/50 annotation, the probe wins and the task gets annotated with the
+correction." Applying:
+
+- **Task 34** (`git worktree add` fails, "blocked on `.vscode/settings.json` creation",
+  "macOS-level protection"): wrong on all three counts. `git worktree add` SUCCEEDS in
+  the sandbox. `.vscode/settings.json` is blocked but by the Claude Code sandbox-exec
+  profile, not macOS. The worktree-add failure story needs a different origin — most
+  likely a post-create editor/tool invocation that nobody attributed correctly.
+- **Task 50** (cites task 34 for the `git worktree add` gap): the gap doesn't exist.
+  Whatever downstream work depends on this being "known broken" needs revisiting.
+- **PR #54 classifier fix** (was the error classifier updated for `.vscode/settings.json`?
+  need to check whether the error signature used is still accurate given the real
+  error shape): the error shape is plain POSIX `Operation not permitted` with no
+  sandbox-exec marker. Any signature looking for `sandbox-exec:` / `seatbelt:` /
+  `deny file-write-create` in stderr will miss every real case.
+
+## Follow-ups to file (out of scope for this session per design doc)
+
+These should become taskwarrior tasks:
+
+1. **Correct task 34's annotation** with the actual mechanism (`.vscode`/`.idea`/etc are
+   denied by `tbq()` hardcoded list in the Claude Code binary; `.git/` is not).
+2. **Reopen the "what actually fails in worktree add" investigation** — since `git worktree add` itself works, find the actual tool that was emitting the `.vscode/settings.json` error in the task 34 session and attribute it correctly.
+3. **Update `sandbox-first` error classifier** (`plugins/sandbox-first/src/sandbox_first/checker.py` `SANDBOX_ERROR_SIGNATURES`) with the three real error shapes from the "Error-shape catalog" section above: tool-prefixed EPERM, shell-eval EPERM, and git-wrapped EPERM. All three lack a `sandbox-exec:` marker.
+4. **Decide whether to expose `allowGitConfig` in `~/.claude/settings.json`** — right now this is a function parameter with no public knob, which means `.git/config` writes (required by many git workflows) are unconditionally blocked.
+5. **Decide whether to expose `allowUnixSockets` for git fsmonitor** — the `could not read IPC response` noise in P6 is harmless but ugly. Worth a flag.
+6. **Document `tbq()`'s hardcoded list as a known limitation** in the sandbox-first plugin README so users don't have to reverse-engineer it.
+
+Each of these will be filed as its own taskwarrior entry before closing this session.
+
+## Appendix: raw probe session
+
+Session ran against cwd `/private/tmp/sandbox-probe-repo` with an already-initialized
+`.git` (created before the session). All commands executed via Claude Code's Bash
+tool under default sandbox settings. User's `~/.claude/settings.json` provided the
+`allowOnly` / `denyWithinAllow` lists which were combined with `tbq()` to produce the
+effective deny list.
+
+## Phase 3 — Real-repo and workaround probes
+
+**Executed:** 2026-04-11 (same day as Phase 1/2, separate session)
+**Cwd for P12:** `/Users/technicalpickles/github.com/technicalpickles/pickled-claude-plugins`
+**Cwd for P13:** same (P13 uses absolute paths for source and destination)
+
+### P12 — real-repo `git worktree add`
+
+**Pre-probe state:**
+```
+$ git worktree list
+.../pickled-claude-plugins                                           7522223 [main]
+.../pickled-claude-plugins/.worktrees/sandbox-first-false-positives  ffcd52a [fix/sandbox-first-false-positives]
+```
+No `empirical-test-worktree` branch or worktree present.
+
+**Probe:**
+```
+$ git worktree add .worktrees/empirical-test-worktree -b empirical-test-worktree
+Preparing worktree (new branch 'empirical-test-worktree')
+HEAD is now at 7522223 docs(sandbox-first): add phase 3 probes P12/P13 to empirical test design
+exit=0
+```
+
+**Verification:**
+```
+$ git worktree list
+.../pickled-claude-plugins                                           7522223 [main]
+.../pickled-claude-plugins/.worktrees/empirical-test-worktree        7522223 [empirical-test-worktree]
+.../pickled-claude-plugins/.worktrees/sandbox-first-false-positives  ffcd52a [fix/sandbox-first-false-positives]
+```
+
+**Result:** **SUCCESS.** Exit code 0. Worktree created. Notably, **no** `error: could not read IPC response` noise this time, unlike P6 (which did emit that line in `/tmp/sandbox-probe-repo`). The absence of the fsmonitor IPC error is interesting but probably just means the fsmonitor daemon isn't configured/running for this repo path. It's not load-bearing to the result.
+
+**Cleanup (mandatory):**
+```
+$ git worktree remove .worktrees/empirical-test-worktree    # exit=0
+$ git branch -D empirical-test-worktree                      # Deleted branch empirical-test-worktree (was 7522223).
+$ git worktree list
+.../pickled-claude-plugins                                           7522223 [main]
+.../pickled-claude-plugins/.worktrees/sandbox-first-false-positives  ffcd52a [fix/sandbox-first-false-positives]
+```
+State restored to pre-probe.
+
+**Conclusion:** P12 empirically refutes any remaining "but maybe it's this repo specifically" defense of the task 34 claim. `git worktree add` works in the real repo under the real sandbox. The task 34 observation is **not reproducible** in its original context. As in Phase 2's P6, the operation that the task 34 session labeled as "git worktree add failure" must have been a downstream tool emitting a `.vscode/settings.json` error after the worktree already existed, not the worktree-add call itself. Task 63 can be closed; task 34's annotation is wrong.
+
+### P13 — `git clone --template=/dev/null`
+
+**Source repo:** `/tmp/sandbox-probe-repo` (from Phase 2, still present)
+
+**First run (contaminated source):**
+```
+$ mkdir -p /tmp/p13-clone-target   # exit=0
+$ git clone --template=/dev/null /tmp/sandbox-probe-repo /tmp/p13-clone-target/destination
+Cloning into '/tmp/p13-clone-target/destination'...
+warning: templates not found in /dev/null
+done.
+fatal: 'refs/remotes/origin/probe-ref' has neither a valid OID nor a target
+exit=128
+```
+
+The failure is **not** a sandbox issue. It's data contamination: Phase 2's P5b did
+`touch .git/refs/heads/probe-ref`, leaving a zero-byte ref file in the source repo.
+Any `git clone` of this source will fail on ref resolution, sandbox or not.
+
+**Crucially**, the clone got past `done.` — which is *far past* the template-seeding
+phase where P8 (vanilla `git clone`) died on `**/.git/hooks/**`. The `warning: templates
+not found in /dev/null` confirms git used the empty template dir, so it never tried to
+copy `commit-msg.sample` etc. into the destination `.git/hooks/`. The `**/.git/hooks/**`
+deny had nothing to match. Git's clone atomicity then rolled back the destination dir
+entirely when the ref step failed, so `ls /tmp/p13-clone-target/destination/` reported
+"No such file or directory" — not a sandbox block, just the rollback.
+
+**Cleanup of contaminated source** (removing Phase 2 artifacts so the probe can actually
+complete):
+```
+$ rm /tmp/sandbox-probe-repo/.git/refs/heads/probe-ref   # exit=0 (zero-byte file from P5b)
+$ rm -rf /tmp/sandbox-probe-repo/.git/refs/heads/probe   # exit=0 (empty dir from P5)
+$ ls -la /tmp/sandbox-probe-repo/.git/refs/heads/
+-rw-r--r-- 1 ... main           # real branch
+-rw-r--r-- 1 ... probe-inside   # real ref from P6 worktree
+-rw-r--r-- 1 ... probe-outside  # real ref from P7 (created before P7 failed)
+```
+
+**Second run (clean source):**
+```
+$ rm -rf /tmp/p13-clone-target && mkdir -p /tmp/p13-clone-target   # exit=0
+$ git clone --template=/dev/null /tmp/sandbox-probe-repo /tmp/p13-clone-target/destination
+Cloning into '/tmp/p13-clone-target/destination'...
+warning: templates not found in /dev/null
+done.
+exit=0
+```
+
+**Sanity check — destination hooks dir:**
+```
+$ ls -la /tmp/p13-clone-target/destination/.git/hooks/
+ls: cannot access '.../.git/hooks/': No such file or directory
+exit=2
+```
+
+**No `hooks/` directory at all.** That's the mechanism: git doesn't create
+`.git/hooks/` when the template source is empty, so the `**/.git/hooks/**` deny rule
+has nothing to match against. The clone completes.
+
+**Destination structure after clone:**
+```
+$ ls -la /tmp/p13-clone-target/destination/.git/
+-rw-r--r-- 289  config          # <- see "Puzzle" below
+-rw-r--r-- 21   HEAD
+-rw-r--r-- 65   index
+drwxr-xr-x ...  logs
+drwxr-xr-x ...  objects
+-rw-r--r-- 261  packed-refs
+drwxr-xr-x ...  refs
+# note: no hooks/ dir
+```
+
+**Cleanup:**
+```
+$ rm -rf /tmp/p13-clone-target   # exit=0
+```
+
+**Result:** **SUCCESS.** `--template=/dev/null` is a confirmed workaround for the
+`tbq()` `**/.git/hooks/**` deny that blocks vanilla `git clone` under the sandbox.
+Task 67's plugin README can document this.
+
+### Phase 3 puzzles (noted, not chased — probes are locked)
+
+1. **P13 second run wrote `.git/config` to the destination**, yet Phase 1's `tbq()`
+   reconstruction shows `**/.git/config` in the default-deny list and Phase 2's P4c
+   confirmed `touch .git/config` is blocked in a cwd-rooted probe. Possible
+   explanations (not investigated):
+   - The `**/.git/config` glob in sandbox-exec may be interpreted against the sandbox
+     profile's path normalization in a way that doesn't match `/tmp/p13-clone-target/destination/.git/config`
+     (e.g., glob is anchored to cwd or `$TMPDIR`).
+   - Git might be writing the config via a rename-from-temp pattern that the sandbox
+     scores differently than a direct `open(O_CREAT)`.
+   - `$TMPDIR` subpaths get a blanket write-allow from `$uq()` that could be overriding
+     the `tbq()` `.git/config` deny at the profile composition level.
+   - The Phase 1 `tbq()` reconstruction may be incomplete — there may be additional
+     filters excluding `$TMPDIR`-rooted paths from the `.git/config` deny specifically.
+   Worth filing as a follow-up but out of scope for this session.
+
+2. **P12 had no `fsmonitor--daemon.ipc` noise, P6 did.** Probably reflects that
+   `pickled-claude-plugins` doesn't have `core.fsmonitor` configured and the disposable
+   `/tmp/sandbox-probe-repo` inherited some default from user git config. Not load-bearing.
+
+### Phase 3 — updated hypothesis verdicts
+
+| # | Hypothesis | Phase 3 evidence |
+|---|---|---|
+| H6 | `git clone`/`git worktree add` fail when destination is inside repo due to source `.git/` writes | P12 further refutes for worktree-add in the real repo. P13 refines P8's mechanism: destination `.git/hooks/` is the real blocker for clone; source `.git/` is never an issue |
+| H7 | Task 50's `.vscode/settings.json` claim was a misattribution | P12 locks this in for the real-repo context — `git worktree add` emits zero output mentioning `.vscode/` |
+| **NEW** | `git clone --template=/dev/null` bypasses the `**/.git/hooks/**` deny | **CONFIRMED** by P13 |
+
+### Phase 3 conclusions for downstream tasks
+
+- **Task 63** (originally tracking the "git worktree add broken in sandbox" gap):
+  not reproducible. Closed as observation misread. The phase 1/2 conclusion carries
+  over to the real repo with no asterisks.
+- **Task 67** (sandbox-first README gap — document clone workarounds):
+  `git clone --template=/dev/null <source> <dest>` is the confirmed workaround.
+  Use it when cloning inside a sandboxed session. The cloned repo won't have sample
+  hooks but everything else works normally.
+- **Task 60** (this empirical test session): complete. All designed probes executed,
+  all results documented, no hypotheses left unexamined within scope.
+
+End of results.

--- a/docs/plans/2026-04-11-sandbox-empirical-test-results.md
+++ b/docs/plans/2026-04-11-sandbox-empirical-test-results.md
@@ -417,4 +417,163 @@ Task 67's plugin README can document this.
 - **Task 60** (this empirical test session): complete. All designed probes executed,
   all results documented, no hypotheses left unexamined within scope.
 
-End of results.
+End of Phase 3 results.
+
+## Phase 4 — Found data from session `0e6308b0`
+
+**Date:** 2026-04-11
+**Session JSONL:** `~/.claude/projects/-private-tmp-sandbox-clone-test/0e6308b0-aede-4048-882a-8ef6e894d93a.jsonl`
+**Cwd for entire session:** `/private/tmp/sandbox-clone-test`
+**Setup (run by user before starting Claude):**
+```
+mkdir -p /tmp/sandbox-clone-test
+cd /tmp/sandbox-clone-test
+git init
+touch readme.md && git add readme.md && git commit -m "init"
+claude
+```
+
+This is **found data** — the user ran a session for an unrelated practical task (cloning a repo inside `/tmp/sandbox-clone-test`) and the resulting tool calls happened to land on probe conditions that Phase 1/2/3 hadn't covered. Phase 4 reads the session JSONL and treats those events as additional probes. Found-data probes are weaker than designed probes because we don't control the conditions, but they're stronger than nothing and they cover gaps the designed probes left open.
+
+### The four events
+
+**Event 1 — `git clone` of `town-charter` (SSH):**
+```
+$ git clone git@github.com:technicalpickles/town-charter.git /private/tmp/sandbox-clone-test/town-charter
+Cloning into '/private/tmp/sandbox-clone-test/town-charter'...
+fatal: cannot copy '/usr/local/opt/git/share/git-core/templates/hooks/commit-msg.sample' to '/private/tmp/sandbox-clone-test/town-charter/.git/hooks/commit-msg.sample': Operation not permitted
+exit=128
+```
+**Verdict:** BLOCKED. Identical mechanism and error wording to Phase 2 P8 — `tbq()`'s `**/.git/hooks/**` glob deny. Third independent reproduction (P8, original 2026-04-09 sessions, this session).
+
+**Event 2 — `git worktree add ./.worktrees/test`:**
+```
+$ git worktree add -b test ./.worktrees/test
+Preparing worktree (new branch 'test')
+error: could not read IPC response
+HEAD is now at fbed6c8 init
+exit=0
+```
+Verified by `git worktree list`:
+```
+/private/tmp/sandbox-clone-test                  fbed6c8 [main]
+/private/tmp/sandbox-clone-test/.worktrees/test  fbed6c8 [test]
+```
+**Verdict:** SUCCEEDED. Same shape as P6 — non-fatal `IPC response` noise from blocked `fsmonitor--daemon.ipc` unix socket, then the worktree is created normally. Third independent reproduction of "worktree add works in sandbox" (P6 in `/tmp/sandbox-probe-repo`, P12 in real repo, this session in a fresh `/tmp` repo). The task 34 / task 50 multi-week claim is now disproven from three independent contexts.
+
+**Event 3 — `git clone --template=` (empty value):**
+
+First the user tried vanilla clone:
+```
+$ git clone git@github.com:technicalpickles/dotfiles.git /private/tmp/sandbox-clone-test/dotfiles
+Cloning into '/private/tmp/sandbox-clone-test/dotfiles'...
+fatal: cannot copy '/usr/local/opt/git/share/git-core/templates/hooks/commit-msg.sample' to '/private/tmp/sandbox-clone-test/dotfiles/.git/hooks/commit-msg.sample': Operation not permitted
+exit=128
+```
+(Yet another reproduction of P8.) Then the user retried with empty `--template=`:
+```
+$ git clone --template= git@github.com:technicalpickles/dotfiles.git /private/tmp/sandbox-clone-test/dotfiles
+Cloning into '/private/tmp/sandbox-clone-test/dotfiles'...
+error: could not write config file /private/tmp/sandbox-clone-test/dotfiles/.git/config: Operation not permitted
+fatal: could not set 'core.repositoryformatversion' to '0'
+exit=128
+```
+**Verdict:** Different blocker. `--template=` (empty) bypassed the hooks-template copy step (no hooks error), but then died on `.git/config` instead. **This proves `--template=` and `--template=/dev/null` are NOT equivalent for our purposes.** P13 used `--template=/dev/null` and succeeded with `.git/config` writing OK (in a non-/tmp cwd). This session's `--template=` (empty) failed on `.git/config` (in a `/tmp` cwd). The README workaround (#67) needs to specifically say `/dev/null`, not "any empty template."
+
+**Event 4 — Direct shell write to `.git/config`:**
+```
+$ pwd && mkdir -p /private/tmp/sandbox-clone-test/dotfiles-probe && echo "hello" > /private/tmp/sandbox-clone-test/dotfiles-probe/plain.txt && mkdir -p /private/tmp/sandbox-clone-test/dotfiles-probe/.git && echo "test" > /private/tmp/sandbox-clone-test/dotfiles-probe/.git/config
+/tmp/sandbox-clone-test
+(eval):1: operation not permitted: /private/tmp/sandbox-clone-test/dotfiles-probe/.git/config
+exit=1
+```
+**Verdict:** BLOCKED on the `.git/config` write specifically — note that the chained `mkdir`, `echo > plain.txt`, and `mkdir .git` all succeeded (cwd is on the user's allow-list, those are inside cwd, none of them match `tbq()`). The shell-eval EPERM shape (catalog item #2) is now confirmed in a real session, not just synthesized in our designed probes.
+
+### Phase 4 implications: the #68 puzzle is sharpened
+
+Combine events 3 and 4 with the existing `.git/config` datapoints:
+
+| Source | Cwd | Target path | Inside cwd? | Result |
+|---|---|---|---|---|
+| P4c | `/private/tmp/sandbox-probe-repo` | `./.git/config` → `<cwd>/.git/config` | Y, root | **BLOCKED** |
+| P13 | `<repo>/pickled-claude-plugins` | `/tmp/p13-clone-target/destination/.git/config` | N | **ALLOWED** |
+| Phase 4 event 3 | `/private/tmp/sandbox-clone-test` | `<cwd>/dotfiles/.git/config` | Y, subdir | **BLOCKED** |
+| Phase 4 event 4 | `/private/tmp/sandbox-clone-test` | `<cwd>/dotfiles-probe/.git/config` | Y, subdir | **BLOCKED** |
+
+**The pattern that fits all four:** `.git/config` writes are denied when the target is **inside cwd** (root or any subdirectory), allowed when **outside cwd**. The `/tmp` framing of #68's original write-up is a red herring — phase 4 has cwd inside `/tmp` AND target inside `/tmp`, and the deny still fires. What matters is the inside-vs-outside-cwd relationship, not the `/tmp` prefix.
+
+This reshapes the candidate explanations for #68:
+
+- **Mostly REFUTED:** "There's a `/tmp` blanket allow that overrides `tbq()`." Phase 4 events 3 and 4 fail on `/tmp` paths from a `/tmp` cwd. If a blanket `/tmp` allow existed, P4c, event 3, and event 4 should all have succeeded. They didn't.
+- **Still possible (sharpened):** The `tbq()` deny is recursively enforced under cwd but unbounded outside cwd. Mechanism candidates:
+  - sandbox-exec rule generation may emit `(deny file-write* (regex #"\.git/config$"))` scoped inside `(allow file-write* (subpath cwd))`. The deny only takes effect inside the allow region. Outside cwd, the path is allowed by some OTHER allow rule (e.g., user `allowWrite` or `$TMPDIR`) and the deny isn't paired with that allow.
+  - The `**/.git/config` glob in `tbq()` may be translated to a regex that only fires after a cwd-rooted match.
+  - The `tbq()` reconstruction may be missing a `(subpath cwd)` filter that scopes the deny.
+- **Still possible:** A second enforcement layer in the Claude Code runtime (separate from sandbox-exec) that checks "is this write target under cwd? If so, apply tbq() denies." This would explain the inside-vs-outside split independently of how sandbox-exec handles the rules. The 2026-04-09 "For security, Claude Code may only create or modify files in the allowed working directories" error string fits this layer's signature.
+
+The two candidates are not mutually exclusive — both could be true at once. Phase 5 below designs probes to disambiguate.
+
+### Phase 4 also gives us the third error shape in the wild
+
+The error-shape catalog originally listed three EPERM forms (tool-prefixed, shell-eval, git-wrapped). Until Phase 4, the catalog had:
+- Tool-prefixed: many examples (P1, P3, P3b, P3c, P3e, P3f, P4b, P4c, P11)
+- Shell-eval: synthesized only — no real session reproduction in Phase 1/2/3
+- Git-wrapped: P7 (`fatal: could not create leading directories`), P8 (`fatal: cannot copy ... templates`)
+
+Phase 4 fills the gaps:
+- **Shell-eval (event 4):** `(eval):1: operation not permitted: /private/tmp/sandbox-clone-test/dotfiles-probe/.git/config` — first real-session reproduction of the shell-eval form, against `.git/config`.
+- **Git-wrapped variant (event 3):** `error: could not write config file <path>: Operation not permitted` followed by `fatal: could not set 'core.repositoryformatversion' to '0'`. This is a NEW git-wrapped variant we hadn't seen before — git's error-then-fatal pair instead of a single `fatal:` line. The classifier work for #64 needs to handle both git error patterns.
+
+## Phase 5 — Designed probes for #68 (NOT YET EXECUTED)
+
+**Goal:** disambiguate "inside-cwd-recursive deny" from "second enforcement layer," and confirm that the inside-vs-outside-cwd pattern generalizes beyond `.git/config` to other `tbq()` rules.
+
+**Execution requirement:** Phase 5 must be run in a **fresh Claude session**, not in this synthesis session, for the same reason Phase 1/2/3 were each fresh — the sandbox profile is generated per-command at session start and we want a clean slate.
+
+**Setup (run before starting Claude, NOT in-session):**
+```
+rm -rf /tmp/p5-cwd-inside /tmp/p5-cwd-outside
+mkdir -p /tmp/p5-cwd-inside /tmp/p5-cwd-outside
+cd /tmp/p5-cwd-inside
+# do NOT git init - keep this as a plain dir to avoid contaminating the .git/ semantics
+claude
+```
+
+(The session will run with `cwd = /tmp/p5-cwd-inside`, equivalent to `/private/tmp/p5-cwd-inside` after `realpathSync`.)
+
+### Probe table
+
+All probes use absolute paths (not relative) to make the inside/outside-cwd analysis unambiguous. Cwd for the whole phase is `/tmp/p5-cwd-inside` ≡ `/private/tmp/p5-cwd-inside`.
+
+| # | Command | Hypothesis tested | Expected if "recursive deny under cwd" | Expected if "second runtime layer also matters" |
+|---|---|---|---|---|
+| P14 | `mkdir -p /private/tmp/p5-cwd-inside/.git && touch /private/tmp/p5-cwd-inside/.git/config` | Control: cwd-root `.git/config` (matches P4c) | BLOCK | BLOCK |
+| P15a | `mkdir -p /private/tmp/p5-cwd-inside/sub/.git && touch /private/tmp/p5-cwd-inside/sub/.git/config` | Subdir `.git/config` inside cwd (matches Phase 4 event 4) | BLOCK | BLOCK |
+| P15b | `mkdir -p /private/tmp/p5-cwd-inside/a/b/c/.git && touch /private/tmp/p5-cwd-inside/a/b/c/.git/config` | Deep subdir `.git/config` inside cwd | BLOCK | BLOCK |
+| P16 | `mkdir -p /private/tmp/p5-cwd-outside/.git && touch /private/tmp/p5-cwd-outside/.git/config` | `.git/config` OUTSIDE cwd, on a sibling `/tmp` path | ALLOW (deny is cwd-scoped) | ALLOW (path is outside cwd, runtime layer doesn't fire) |
+| P17 | `mkdir -p /private/tmp/p5-cwd-inside/sub/.git && touch /private/tmp/p5-cwd-inside/sub/.git/HEAD` | Control: subdir `.git/HEAD` (NOT in `tbq()`) inside cwd | ALLOW (HEAD is not in any deny) | ALLOW |
+| P18 | `mkdir -p /private/tmp/p5-cwd-inside/sub/.git/hooks && touch /private/tmp/p5-cwd-inside/sub/.git/hooks/test` | Subdir `.git/hooks/X` inside cwd (matches P8's destination semantics) | BLOCK | BLOCK |
+| P19 | `mkdir -p /private/tmp/p5-cwd-outside/.git/hooks && touch /private/tmp/p5-cwd-outside/.git/hooks/test` | `.git/hooks/X` OUTSIDE cwd | ALLOW (deny is cwd-scoped) | ALLOW |
+| P20 | `mkdir -p /private/tmp/p5-cwd-outside/.vscode && touch /private/tmp/p5-cwd-outside/.vscode/settings.json` | `.vscode/` OUTSIDE cwd | ALLOW (deny is cwd-scoped) | depends on layer scope |
+
+### What each result tells us
+
+- **P14 + P15a + P15b all BLOCK, P16 ALLOWS:** confirms the inside-vs-outside-cwd pattern for `.git/config`. Combined with P17 (subdir `.git/HEAD` allowed) this rules out "all `.git/` writes in subdirs are blocked" — only the `tbq()` paths are.
+- **P18 BLOCKS, P19 ALLOWS:** generalizes the inside-vs-outside pattern to `**/.git/hooks/**`. If P18 BLOCKS but P19 also BLOCKS, the deny is unbounded (not cwd-scoped) for hooks specifically — different rule generation than `.git/config`.
+- **P20 ALLOWS:** confirms `.vscode` is also cwd-scoped. If P20 BLOCKS, then the second enforcement layer probably exists and enforces dirname matches independent of cwd.
+- **Any P15* or P18 ALLOWS unexpectedly:** the inside-vs-outside hypothesis is wrong and we're back to the drawing board.
+
+### After Phase 5
+
+If Phase 5 results match the "deny is cwd-scoped" prediction across the board (all six expected outcomes), the explanation is in the sandbox-exec rule generation: `tbq()` denies are emitted as regex/subpath rules nested under or interleaved with the cwd allow, and the path is allowed by an unrelated allow rule (e.g., user `allowWrite`) outside cwd. This would mean the Phase 1 `tbq()` reverse-engineering captured the deny strings correctly but missed how `$uq()` composes them with the allow rules. Action items would be:
+
+1. Reverse-engineer `$uq()`'s emit step for `tbq()` rules — find where it actually formats them into `(deny ...)` sexprs.
+2. Update the `claude-code-sandbox-internals` memory with the corrected mechanism.
+3. Update the `tbq()` reconstruction in this doc with the missing scope info.
+4. Close task #68 with the correct explanation.
+
+If Phase 5 results show the inside/outside split holds for `.git/config` but NOT for `**/.git/hooks/**` or `.vscode/` (i.e., hooks/vscode are blocked everywhere, only config is cwd-scoped), the rule families are emitted differently and we need to account for that — possibly because the cwd-rooted absolute path version of tbq()'s rules (`path.resolve(cwd, ".git/config")`) is being treated differently from the glob version (`**/.git/config`).
+
+If Phase 5 contradicts the prediction (e.g., P16 BLOCKS too), the second enforcement layer is real and we need to grep the binary for the "allowed working directories" string and trace it back to the check that fires. That's a much bigger investigation but the results doc would update with whatever we find.
+
+End of Phase 5 design. Execute in a fresh session and append a Phase 5 results section after.

--- a/plugins/agent-meta/hooks/hooks.json
+++ b/plugins/agent-meta/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Inject session ID and transcript path into context when agent-meta skills are invoked",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/inject-session-context.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/agent-meta/hooks/inject-session-context.py
+++ b/plugins/agent-meta/hooks/inject-session-context.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+PostToolUse:Skill hook that injects the current session ID and transcript
+path into context when an agent-meta skill that needs them is invoked.
+
+Why: the `park` skill needs the Claude Code session ID to write a durable
+record of where this session lived. Previously it ran a Bash script that
+echoed $CLAUDE_SESSION_ID, but that env var is not reliably exported to
+Bash tool calls, so park often wrote "unknown" as the session.
+
+Hook payloads, on the other hand, always contain `session_id` and
+`transcript_path` as guaranteed top-level fields. By reading them here and
+emitting `hookSpecificOutput.additionalContext`, Claude sees the session
+details right after the Skill tool result, before it starts executing the
+skill's steps.
+
+This hook only injects context for skills that actually need it. Other
+Skill calls are silently ignored (no context pollution).
+"""
+import json
+import sys
+
+# Skills in the agent-meta plugin that benefit from knowing the session ID.
+# Keep this narrow: unparking a session doesn't need the current one, and
+# snapshot has its own flow.
+TARGET_SKILLS = {
+    "agent-meta:park",
+}
+
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    # Malformed stdin - fail silently so we never block a tool call.
+    sys.exit(0)
+
+tool_input = payload.get("tool_input") or {}
+skill_name = tool_input.get("skill", "")
+
+if skill_name not in TARGET_SKILLS:
+    sys.exit(0)
+
+session_id = payload.get("session_id", "")
+transcript_path = payload.get("transcript_path", "")
+
+if not session_id:
+    # Nothing useful to inject; let park fall back to its script.
+    sys.exit(0)
+
+lines = [f"Session ID: {session_id}"]
+if transcript_path:
+    lines.append(f"Transcript: {transcript_path}")
+
+output = {
+    "hookSpecificOutput": {
+        "hookEventName": "PostToolUse",
+        "additionalContext": "\n".join(lines),
+    }
+}
+print(json.dumps(output))
+sys.exit(0)

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -46,7 +46,9 @@ Ensure the directory exists. If using `.parkinglot/`, check it's gitignored.
 
 ## Before Writing
 
-1. Run [scripts/get-session-id.sh](scripts/get-session-id.sh) via Bash to get the current session ID. If empty, use "unknown".
+1. Get the current session ID:
+   - **Preferred:** Look for a `Session ID:` line in the PostToolUse hook context that this plugin injects when the `agent-meta:park` skill is invoked. If present, use that value. A `Transcript:` line may also be present with the path to the current conversation transcript.
+   - **Fallback:** If no injected context is visible (hook disabled, older install, etc.), run [scripts/get-session-id.sh](scripts/get-session-id.sh) via Bash. If that returns empty, use "unknown".
 2. Gather git branch, worktree path, and other context.
 
 ## Output Format


### PR DESCRIPTION
## Summary

- Adds a `PostToolUse:Skill` hook to the `agent-meta` plugin that fires when `agent-meta:park` is invoked
- Reads `session_id` and `transcript_path` from the guaranteed hook payload fields and injects them as `hookSpecificOutput.additionalContext`
- Updates `park` SKILL.md to prefer the injected context over the Bash script fallback

## Problem

`park` previously got the session ID by running a script that echoed `$CLAUDE_SESSION_ID`. That env var is not reliably exported to Bash tool calls — so parked files often recorded `"unknown"` as the session ID.

## Approach

Hook payloads always contain `session_id` and `transcript_path` as guaranteed top-level fields. A `PostToolUse:Skill` hook reads those from stdin after the skill tool call and emits them as `additionalContext`. Because this fires before Claude executes any of the skill's steps, the session ID is available in context when park runs.

Validated empirically with a hook probe: `hook_additional_context` is a first-class transcript attachment type, and the injected value was confirmed visible to Claude in the next turn.

The Bash script fallback is preserved for older installs or environments with hooks disabled.

## Test plan

- [ ] Reinstall `agent-meta` plugin and restart Claude Code
- [ ] Run `/park` and verify the parked file contains a real UUID session ID (not `"unknown"`)
- [ ] Run `/park` with hooks disabled (or `CLAUDE_SESSION_ID` unset) and verify fallback to script still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)