### PR TITLE
feat(agent-meta): inject session ID via PostToolUse hook on park

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "1.3.0"
+      "version": "1.4.0"
     },
     {
       "name": "sandbox-first",

--- a/plugins/agent-meta/hooks/hooks.json
+++ b/plugins/agent-meta/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Inject session ID and transcript path into context when agent-meta skills are invoked",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/inject-session-context.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/agent-meta/hooks/inject-session-context.py
+++ b/plugins/agent-meta/hooks/inject-session-context.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+PostToolUse:Skill hook that injects the current session ID and transcript
+path into context when an agent-meta skill that needs them is invoked.
+
+Why: the `park` skill needs the Claude Code session ID to write a durable
+record of where this session lived. Previously it ran a Bash script that
+echoed $CLAUDE_SESSION_ID, but that env var is not reliably exported to
+Bash tool calls, so park often wrote "unknown" as the session.
+
+Hook payloads, on the other hand, always contain `session_id` and
+`transcript_path` as guaranteed top-level fields. By reading them here and
+emitting `hookSpecificOutput.additionalContext`, Claude sees the session
+details right after the Skill tool result, before it starts executing the
+skill's steps.
+
+This hook only injects context for skills that actually need it. Other
+Skill calls are silently ignored (no context pollution).
+"""
+import json
+import sys
+
+# Skills in the agent-meta plugin that benefit from knowing the session ID.
+# Keep this narrow: unparking a session doesn't need the current one, and
+# snapshot has its own flow.
+TARGET_SKILLS = {
+    "agent-meta:park",
+}
+
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    # Malformed stdin - fail silently so we never block a tool call.
+    sys.exit(0)
+
+tool_input = payload.get("tool_input") or {}
+skill_name = tool_input.get("skill", "")
+
+if skill_name not in TARGET_SKILLS:
+    sys.exit(0)
+
+session_id = payload.get("session_id", "")
+transcript_path = payload.get("transcript_path", "")
+
+if not session_id:
+    # Nothing useful to inject; let park fall back to its script.
+    sys.exit(0)
+
+lines = [f"Session ID: {session_id}"]
+if transcript_path:
+    lines.append(f"Transcript: {transcript_path}")
+
+output = {
+    "hookSpecificOutput": {
+        "hookEventName": "PostToolUse",
+        "additionalContext": "\n".join(lines),
+    }
+}
+print(json.dumps(output))
+sys.exit(0)

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -46,7 +46,9 @@ Ensure the directory exists. If using `.parkinglot/`, check it's gitignored.
 
 ## Before Writing
 
-1. Run [scripts/get-session-id.sh](scripts/get-session-id.sh) via Bash to get the current session ID. If empty, use "unknown".
+1. Get the current session ID:
+   - **Preferred:** Look for a `Session ID:` line in the PostToolUse hook context that this plugin injects when the `agent-meta:park` skill is invoked. If present, use that value. A `Transcript:` line may also be present with the path to the current conversation transcript.
+   - **Fallback:** If no injected context is visible (hook disabled, older install, etc.), run [scripts/get-session-id.sh](scripts/get-session-id.sh) via Bash. If that returns empty, use "unknown".
 2. Gather git branch, worktree path, and other context.
 
 ## Output Format


### PR DESCRIPTION
## Summary

- Adds a `PostToolUse:Skill` hook to the `agent-meta` plugin that fires when `agent-meta:park` is invoked
- Reads `session_id` and `transcript_path` from the guaranteed hook payload fields and injects them as `hookSpecificOutput.additionalContext`
- Updates `park` SKILL.md to prefer the injected context over the Bash script fallback

## Problem

`park` previously got the session ID by running a script that echoed `$CLAUDE_SESSION_ID`. That env var is not reliably exported to Bash tool calls — so parked files often recorded `"unknown"` as the session ID.

## Approach

Hook payloads always contain `session_id` and `transcript_path` as guaranteed top-level fields. A `PostToolUse:Skill` hook reads those from stdin after the skill tool call and emits them as `additionalContext`. Because this fires before Claude executes any of the skill's steps, the session ID is available in context when park runs.

Validated empirically with a hook probe: `hook_additional_context` is a first-class transcript attachment type, and the injected value was confirmed visible to Claude in the next turn.

The Bash script fallback is preserved for older installs or environments with hooks disabled.

## Test plan

- [ ] Reinstall `agent-meta` plugin and restart Claude Code
- [ ] Run `/park` and verify the parked file contains a real UUID session ID (not `"unknown"`)
- [ ] Run `/park` with hooks disabled and verify fallback to script still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)