### PR TITLE
fix(tool-routing): Python 3.9 compat for discovery.py

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "tool-routing",
       "source": "./plugins/tool-routing",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     {
       "name": "stay-on-target",

--- a/plugins/tool-routing/src/tool_routing/discovery.py
+++ b/plugins/tool-routing/src/tool_routing/discovery.py
@@ -1,5 +1,7 @@
 """Manifest-driven route discovery using Claude CLI."""
 
+from __future__ import annotations
+
 import json
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Summary
- `discovery.py` uses `str | None` union type syntax (Python 3.10+), but uv created the venv with Python 3.9.6
- This caused a `TypeError` on every `PreToolUse:Bash` hook invocation
- Fix: add `from __future__ import annotations` to make type hints lazy strings at runtime
- Bump tool-routing 1.2.0 -> 1.2.1

## Test plan
- [x] Verified `tool-routing check` exits 0 with Python 3.9 venv after fix
- [x] Confirmed no other files in tool-routing use 3.10+ syntax without the future import

🤖 Generated with [Claude Code](https://claude.com/claude-code)