### PR TITLE
fix(sandbox-first): recognize macOS Mach port denial as sandbox-shaped

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "sandbox-first",
       "source": "./plugins/sandbox-first",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "name": "buildkite",

--- a/plugins/sandbox-first/skills/sandbox-first/SKILL.md
+++ b/plugins/sandbox-first/skills/sandbox-first/SKILL.md
@@ -19,6 +19,14 @@ Before retrying with `dangerouslyDisableSandbox`:
    - "Operation not permitted" (filesystem write outside allowed paths)
    - "Connection refused" or network timeouts (host not in allowedHosts)
    - "Permission denied" on paths outside the project
+   - **macOS Mach port / XPC denial** — crash containing `bootstrap_check_in`
+     and "Permission denied (1100)". The surface error looks like an
+     application crash (e.g. Chromium `Check failed: kr == KERN_SUCCESS`),
+     but the root cause is seatbelt denying `mach-register`/`mach-lookup`
+     for a service. Seen with Playwright launching headless Chromium, and
+     applies to other multi-process macOS tools (Electron, Puppeteer, etc.).
+     Sandbox config cannot grant Mach port access, so this genuinely
+     requires `dangerouslyDisableSandbox`.
 3. **Suggest a config fix.** Tell the user what to add to `~/.claude/settings.json`:
    - Network: add host to `sandbox.network.allowedHosts`
    - Filesystem: add path to `sandbox.filesystem.allowWrite`

--- a/plugins/sandbox-first/src/sandbox_first/checker.py
+++ b/plugins/sandbox-first/src/sandbox_first/checker.py
@@ -44,6 +44,16 @@ FAILURE_CONTEXT = (
 #     "No such file or directory" without any EPERM. Matching "no such file or directory"
 #     would catch real ENOENT errors (missing files, bad paths) as false positives, so
 #     this case requires transcript-level context to detect safely.
+#
+# macOS Mach port / XPC denials:
+#   bootstrap_check_in is the launchd API multi-process macOS apps call to register
+#   a service with the bootstrap server. When seatbelt denies this, the process
+#   crashes with a message like:
+#     Check failed: kr == KERN_SUCCESS. bootstrap_check_in
+#     org.chromium.Chromium.MachPortRendezvousServer.<pid>: Permission denied (1100)
+#   Observed when Playwright launches headless Chromium inside Claude Code's bash
+#   sandbox. The same signature covers other multi-process macOS tools (Electron,
+#   Puppeteer, etc.). bootstrap_check_in is distinctive enough to match on alone.
 SANDBOX_ERROR_SIGNATURES = (
     "operation not permitted",
     "sandbox-exec",
@@ -53,6 +63,7 @@ SANDBOX_ERROR_SIGNATURES = (
     "couldn't resolve host",
     "network is unreachable",
     "failed to connect",
+    "bootstrap_check_in",
 )
 
 

--- a/plugins/sandbox-first/tests/test_checker.py
+++ b/plugins/sandbox-first/tests/test_checker.py
@@ -216,6 +216,11 @@ class TestCheckPostToolUseFailure:
                 "git clone /src /tmp/outside/dest",
                 "error: could not write config file /tmp/outside/dest/.git/config: Operation not permitted\nfatal: could not set 'core.repositoryformatversion' to '0'",
             ),
+            (
+                "macos-mach-port-chromium",
+                "python -c 'from playwright.sync_api import sync_playwright; ...'",
+                "[0413/203015.123456:FATAL:mach_port_rendezvous.cc(159)] Check failed: kr == KERN_SUCCESS. bootstrap_check_in org.chromium.Chromium.MachPortRendezvousServer.12345: Permission denied (1100)",
+            ),
         ],
     )
     def test_sandbox_shaped_errors_return_context(self, case, command, error):


### PR DESCRIPTION
## Summary

- Adds `bootstrap_check_in` to the sandbox-failure signature list so the `PostToolUseFailure` hook surfaces sandbox context when Playwright (or any multi-process macOS tool) crashes during Mach port registration
- Updates the `sandbox-first` skill to describe the signature and note that this case genuinely needs `dangerouslyDisableSandbox` (sandbox config can't grant Mach port access)
- Addresses task `22f5107f`

## Failure signature this catches

```
Check failed: kr == KERN_SUCCESS. bootstrap_check_in
org.chromium.Chromium.MachPortRendezvousServer.<pid>: Permission denied (1100)
```

The surface error looks like an application crash, but the root cause is seatbelt denying the launchd `bootstrap_check_in` call that Chromium's multi-process architecture needs. `bootstrap_check_in` is a distinctive launchd API name — safe to match on alone, generalizes to other multi-process macOS tools (Electron, Puppeteer).

## End-to-end verification: unsuccessful

Attempted to reproduce the failure with four Playwright variants from inside Claude Code's sandboxed Bash:

1. `p.chromium.launch()` + bare — **succeeded**
2. `launch()` + `new_page()` + data URL — **succeeded**
3. Full `build-pvc-pdf.py` pattern (`file://`, `device_scale_factor=3.125`, element screenshot) — **succeeded**
4. `launch(headless=False)` (full Chromium, not headless_shell) — **succeeded**

Cannot currently force the Mach port denial. Possible reasons: sandbox config or macOS TCC state drifted since the original failure; original attribution may be off (the task references `shoot.py` which doesn't exist — the closest file `shoot.sh` uses `f3d`, not Chromium).

The signature addition is still correct on its own: `bootstrap_check_in` is a real macOS launchd API that sandboxes can deny, and the parametrized test in `test_checker.py` validates that the detection logic handles the exact error string from the task annotation. Merging this doesn't introduce risk — at worst it's dormant code. Followup task to audit the original failure's true source before declaring task `22f5107f` resolved.

## Test plan

- [x] `uv run pytest` in `plugins/sandbox-first` — 41/41 pass, including new `macos-mach-port-chromium` parametrized case
- [ ] (deferred to followup) Confirm the signature fires on a real Chromium Mach port crash — requires reproducing the original failure first

🤖 Generated with [Claude Code](https://claude.com/claude-code)