### PR TITLE
refactor: remove slash-command wrappers that share names with skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "git",
       "source": "./plugins/git",
-      "version": "2.2.0"
+      "version": "3.0.0"
     },
     {
       "name": "ci-cd-tools",
@@ -49,7 +49,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "1.4.0"
+      "version": "2.0.0"
     },
     {
       "name": "sandbox-first",

--- a/plugins/agent-meta/README.md
+++ b/plugins/agent-meta/README.md
@@ -6,13 +6,15 @@ Meta-development tools for agentic workflows.
 
 Working with AI coding agents generates valuable artifacts beyond code: session patterns, failure modes, decision trails. This plugin helps capture and learn from that meta-layer.
 
-## Commands
+## Skills
 
-| Command | Description |
-|---------|-------------|
-| `/park` | Save current work context for later resumption |
-| `/unpark` | Resume work from a parked handoff |
-| `/snapshot` | Capture current session state (inline or `--save`) |
+| Skill | Description |
+|-------|-------------|
+| `agent-meta:park` | Save current work context for later resumption |
+| `agent-meta:unpark` | Resume work from a parked handoff |
+| `agent-meta:snapshot` | Capture current session state (inline or with save) |
+
+Invoke by asking naturally ("park this session", "unpark docs/handoffs/foo.md") or with the fully qualified slash form (`/agent-meta:park`).
 
 ## Scripts
 

--- a/plugins/agent-meta/commands/park.md
+++ b/plugins/agent-meta/commands/park.md
@@ -1,6 +1,0 @@
----
-name: park
-description: Save current work context for later resumption
----
-
-Use the `agent-meta:park` skill to save this work session.

--- a/plugins/agent-meta/commands/snapshot.md
+++ b/plugins/agent-meta/commands/snapshot.md
@@ -1,8 +1,0 @@
----
-name: snapshot
-description: Capture current session state without stopping
----
-
-Use the `agent-meta:snapshot` skill to summarize the current session.
-
-Pass `--save` to write the snapshot to the parking lot location.

--- a/plugins/agent-meta/commands/unpark.md
+++ b/plugins/agent-meta/commands/unpark.md
@@ -1,6 +1,0 @@
----
-name: unpark
-description: Resume work from a parked handoff
----
-
-Use the `agent-meta:unpark` skill to resume from a saved work session.

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -94,8 +94,8 @@ Report:
 ```
 Parked to `[path]`.
 
-To resume in a new session:
-/unpark [path]
+To resume in a new session, ask Claude:
+> unpark [path]
 ```
 
-The `/unpark [path]` command should be copy-pasteable so the user can easily resume.
+The resume prompt should be copy-pasteable so the user can easily paste it into a new session.

--- a/plugins/agent-meta/skills/snapshot/SKILL.md
+++ b/plugins/agent-meta/skills/snapshot/SKILL.md
@@ -72,10 +72,10 @@ Format when saved:
 
 Report: "Snapshot saved to `[path]`"
 
-## Difference from /park
+## Difference from park
 
-| Aspect | /snapshot | /park |
-|--------|-----------|-------|
+| Aspect | snapshot | park |
+|--------|----------|------|
 | Intent | Review progress | Stop work for later |
 | Output | Inline (default) | Always file |
 | Resume prompt | No | Yes |

--- a/plugins/agent-meta/skills/unpark/SKILL.md
+++ b/plugins/agent-meta/skills/unpark/SKILL.md
@@ -75,7 +75,7 @@ Options:
 (C) Continue anyway - I understand the context has changed
 ```
 
-If option A: Update the handoff file with current findings, then recommend running `/unpark` again.
+If option A: Update the handoff file with current findings, then recommend unparking again.
 
 ## Session Chains
 

--- a/plugins/git/commands/checkout.md
+++ b/plugins/git/commands/checkout.md
@@ -1,6 +1,0 @@
----
-name: checkout
-description: Check out a PR or branch into an isolated worktree
----
-
-Use the `git:checkout` skill to set up a worktree.

--- a/plugins/git/commands/commit.md
+++ b/plugins/git/commands/commit.md
@@ -1,6 +1,0 @@
----
-name: commit
-description: Commit changes with best practices for staging, messages, and hooks
----
-
-Use the `git:commit` skill to commit changes.

--- a/plugins/git/commands/inbox.md
+++ b/plugins/git/commands/inbox.md
@@ -1,6 +1,0 @@
----
-name: inbox
-description: Check what PRs are waiting for your review
----
-
-Use the `git:inbox` skill to show PRs awaiting review.

--- a/plugins/git/commands/pull-request.md
+++ b/plugins/git/commands/pull-request.md
@@ -1,6 +1,0 @@
----
-name: pull-request
-description: Create, update, or comment on GitHub pull requests
----
-
-Use the `git:pull-request` skill to work with PRs.

--- a/plugins/git/commands/triage.md
+++ b/plugins/git/commands/triage.md
@@ -1,6 +1,0 @@
----
-name: triage
-description: Review git state across worktrees, stashes, and branches
----
-
-Use the `git:triage` skill to inventory work in progress.

--- a/plugins/git/commands/update.md
+++ b/plugins/git/commands/update.md
@@ -1,6 +1,0 @@
----
-name: update
-description: Update your branch with upstream changes - fetches, merges, and resolves conflicts
----
-
-Use the `git:update` skill to sync your branch with upstream.


### PR DESCRIPTION
## Summary

Removes thin-wrapper slash commands from `agent-meta` and `git` plugins that share names with skills in the same plugin. These collisions suppress SKILL.md content injection after the Skill tool call, forcing the model to grep/read the skill file manually or hallucinate a path.

Investigation and data in bean `gt-w3eu`:

- 100% failure rate on affected skills (154/154 `park` calls, 38/38 `unpark`, 13/13 `git:commit`, etc.)
- Working skills (`dev-tools:designing-clis`, `superpowers:brainstorming`, `elements-of-style:writing-clearly-and-concisely`) all avoid name collisions
- Side-by-side session transcripts confirm the injection mechanism is the differentiator
- Superpowers sidesteps this by naming the slash command `brainstorm` while the skill is `brainstorming`

Skills remain invokable via fully-qualified slash form (`/agent-meta:park`, `/git:commit`) or natural language through keyword triggers on descriptions. Thin slash wrappers were a legacy pattern from when skills weren't directly slash-callable.

## Changes

- **agent-meta**: delete `commands/{park,unpark,snapshot}.md`; update README skills table and self-references in 3 SKILL.md files
- **git**: delete `commands/{checkout,commit,inbox,pull-request,triage,update}.md` (no README/SKILL updates needed, already used `git:name` form)

## Breaking changes

- `/park`, `/unpark`, `/snapshot`, `/commit`, `/checkout`, `/inbox`, `/pull-request`, `/triage`, `/update` no longer resolve as bare slash commands
- Users should type the fully-qualified form (`/agent-meta:park`, `/git:commit`) or ask naturally ("park this session", "commit these changes")

## Test plan

- [ ] Reinstall `agent-meta` and `git` plugins locally (`/plugin uninstall` + `/plugin install`)
- [ ] Restart Claude Code
- [ ] Invoke `/agent-meta:park` — confirm SKILL.md content is injected (user message starts with "Base directory for this skill: ...")
- [ ] Invoke `/git:commit` — confirm same
- [ ] Ask "park this session" in natural language — confirm skill triggers
- [ ] Confirm bare `/park` no longer resolves (expected behavior)

Refs: gt-w3eu

🤖 Generated with [Claude Code](https://claude.com/claude-code)