### PR TITLE
feat(cq): add cq skill plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,6 +60,16 @@
       "name": "buildkite",
       "source": "./plugins/buildkite",
       "version": "1.0.0"
+    },
+    {
+      "name": "cq",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/technicalpickles/cq.git",
+        "path": "claude-plugin",
+        "ref": "main"
+      },
+      "version": "0.1.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds cq to the marketplace as a `git-subdir` source pointing at
  `github.com/technicalpickles/cq` under `claude-plugin/`
- Initial version `0.1.0`, `ref: main` (unpinned; tag-based releases
  deferred)

## Test plan
- [ ] version-check CI passes (minor bump already applied)
- [ ] After merge: `claude plugin install cq@pickled-claude-plugins` in a
  fresh session surfaces the cq skill
- [ ] Existing local skill at `~/pickleton/.claude/skills/cq/` gets
  removed in a follow-up

Closes gt-ehbc.

Depends on technicalpickles/cq#2 being merged before the `ref: main` source resolves to a real `claude-plugin/` subdir.