### PR TITLE
fix(git): use heredoc pattern in commit skill, note -F vs -t

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "git",
       "source": "./plugins/git",
-      "version": "2.2.0"
+      "version": "2.2.1"
     },
     {
       "name": "ci-cd-tools",

--- a/plugins/git/skills/commit/SKILL.md
+++ b/plugins/git/skills/commit/SKILL.md
@@ -15,7 +15,18 @@ IF adding files that look like they are agent configuration, or adding planning 
 
 ## git commit
 
-PREFER writing out a commit message to the `scratch/` directory, and save it to a name reflecting what is being commited. Then use use `git commit -t scratch/path-to-message.txt`
+Use a heredoc for the message, matching Claude Code's built-in pattern:
+
+```
+git commit -m "$(cat <<'EOF'
+Commit subject
+
+Body paragraph.
+EOF
+)"
+```
+
+For very long commit bodies, write to the `scratch/` directory with the Write tool first and use `git commit -F scratch/path-to-message.txt`. (Note: `-F` reads the file as the message. `-t` loads it as a template to edit, which doesn't work with non-interactive commits.)
 
 ### signing
 


### PR DESCRIPTION
## Summary
- The commit skill recommended `git commit -t scratch/path-to-message.txt`. `-t` loads the file as a *template* to edit interactively, which doesn't work for non-interactive agent commits. `-F` is the flag that reads the file as the message.
- Replaced with the heredoc pattern from Claude Code's built-in system prompt. Scratch-file approach kept as a fallback for very long commit bodies, now correctly using `-F`.
- Bumps `git` plugin to `2.2.1` (patch).

## Test plan
- [ ] CI (version-check) passes
- [ ] Skill reads cleanly and matches Claude Code's built-in guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)