### PR TITLE
feat(ci-cd-tools): extract fixing-ci skill from /fix-ci command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
     {
       "name": "ci-cd-tools",
       "source": "./plugins/ci-cd-tools",
-      "version": "1.1.2"
+      "version": "1.2.0"
     },
     {
       "name": "dev-tools",

--- a/plugins/ci-cd-tools/README.md
+++ b/plugins/ci-cd-tools/README.md
@@ -2,22 +2,30 @@
 
 CI/CD pipeline tools and integrations for debugging build failures.
 
+## Skills
+
+### fixing-ci
+
+The iterative-fix loop. Drives verify-locally → push → check → iterate for a failing Buildkite build until it's green or you've hit the iteration cap. Investigation is delegated to `buildkite:investigating-builds`.
+
+Activates on intent like "fix CI", "make CI green", "iterate on this build". See `skills/fixing-ci/SKILL.md` for the input contract and full loop.
+
 ## Commands
 
 ### /fix-ci
 
-Start an iterative CI fix session to systematically investigate and fix CI failures through a structured workflow. Analyzes build failures, applies fixes, verifies locally, and tracks progress until builds pass. Uses the `buildkite:investigating-builds` skill for build investigation.
+Start an iterative CI fix session. Resolves the input interactively (build URL / PR / branch / cwd), optionally creates a tracking document, then runs the `fixing-ci` skill.
 
 **Usage:**
 ```
 /fix-ci [buildkite-url]
 ```
 
-If no URL is provided, infers the build from the current branch.
+If no URL is provided, infers from the current branch's open PR.
 
 ## Note
 
-Buildkite skills have moved to the `buildkite` plugin. Install it for build investigation and pipeline development capabilities.
+Buildkite skills (investigating builds, developing pipelines) live in the `buildkite` plugin. Install it for build investigation and pipeline development capabilities — `fixing-ci` depends on `buildkite:investigating-builds` for the investigation step.
 
 ## Installation
 

--- a/plugins/ci-cd-tools/commands/fix-ci.md
+++ b/plugins/ci-cd-tools/commands/fix-ci.md
@@ -1,59 +1,34 @@
 ---
-description: Start an iterative CI fix session - investigate failures, apply fixes, and track progress until green
+description: Start an iterative CI fix session — resolve the input (build / PR / branch / cwd), then run the `fixing-ci` skill loop until CI is green or you've hit the iteration cap.
 ---
 
 # Fix CI Failures
 
-Start an iterative CI debugging session. Systematically investigate and fix CI failures through a structured loop: investigate → fix → verify locally → push → check → iterate.
-
-This command orchestrates the debugging loop. For all Buildkite interaction (fetching builds, reading logs, monitoring), use the `investigating-builds` skill workflows and tool hierarchy.
+Iteratively fix a failing Buildkite CI run. This command resolves what to fix, then loads the `ci-cd-tools:fixing-ci` skill to drive the loop (verify locally → push → check → iterate).
 
 ## Arguments
 
-- **URL** (optional): Buildkite build URL to start investigating
-- If no URL provided, infer from current branch
+- **URL** (optional): Buildkite build URL to start with
+- If no URL provided, infer from current branch / open PR
 
-## Step 1: Determine the Build
+## Step 1: Resolve the Input
 
-### If URL provided:
+Determine the build to fix using this priority order:
 
-Use the `investigating-builds` skill's "Investigating a Build from URL" workflow — `bktide snapshot` parses any Buildkite URL automatically.
+1. **URL argument** provided → use it directly. The `bktide snapshot` tool parses any Buildkite URL.
+2. **No URL, current git branch has an open PR** → resolve via `gh pr view --json number,headRefName`, then find the latest failing build for that branch using the `buildkite:investigating-builds` skill's "Checking Current Branch/PR Status" workflow.
+3. **No URL, current branch but no PR** → ask the user for either the build URL or the PR number.
+4. **Detached HEAD or no clear branch** → ask the user.
 
-### If no URL provided:
+Once resolved, you have one of: `build_url`, `pr` number, or `branch` name.
 
-1. Get the current git branch:
-   ```bash
-   git branch --show-current
-   ```
-
-2. Identify the pipeline:
-   - Repository name often matches pipeline slug
-   - Check `.buildkite/pipeline.yml` for pipeline hints
-
-3. Use the skill's "Checking Current Branch/PR Status" workflow to find the latest build for this branch.
-
-4. If no pipeline can be determined, ask the user for the Buildkite URL.
-
-## Step 2: Capture Initial State
-
-Record the starting point:
-
-- **Branch name**: Current git branch
-- **PR number**: If applicable (`gh pr view --json number`)
-- **Build number**: The failing build
-- **Failure count**: Number of failed jobs
-
-Announce to the user:
-
-> "Starting CI fix session for branch `<branch>` (Build #<number>). I see <N> failed jobs. Let me investigate."
-
-### Optional: Create Tracking Document
+## Step 2: Optional Tracking Document
 
 For complex or multi-day debugging sessions, offer to create a tracking document:
 
 > "Would you like me to create a tracking document for this CI fix session? Useful for multi-day debugging or handoff."
 
-If yes, create `docs/plans/ci-fix-<branch-slug>.md`:
+If yes, create `docs/plans/ci-fix-<branch-slug>.md` with this template:
 
 ```markdown
 # CI Fix Workflow: <branch-name>
@@ -73,7 +48,7 @@ If yes, create `docs/plans/ci-fix-<branch-slug>.md`:
 **Failures:** <count> (<pattern description>)
 
 **Root cause:**
-<1-2 sentences explaining why this failed>
+<1-2 sentences>
 
 **Fix:**
 <Code changes or commands>
@@ -99,190 +74,10 @@ If yes, create `docs/plans/ci-fix-<branch-slug>.md`:
 - [ ] <remaining items if session ends before green>
 ```
 
-## Step 3: Check Branch Freshness
+If no, skip and proceed.
 
-**IMPORTANT**: Before diving into failures, check if the branch is up to date with main.
+## Step 3: Run the Fix Loop
 
-1. Check if branch is behind main:
-   ```bash
-   git fetch origin main
-   git rev-list --count HEAD..origin/main
-   ```
+Use the `ci-cd-tools:fixing-ci` skill, passing the resolved input from Step 1. The skill drives the loop: branch-freshness check → delegate investigation → categorize → verify locally → push → monitor → iterate (max 3 iterations).
 
-2. If behind by more than 0 commits:
-   > "Your branch is <N> commits behind main. Recommend merging main first to rule out stale code issues."
-
-   Ask user if they want to:
-   - Merge main now (handle conflicts if needed)
-   - Skip and investigate current failures
-   - The failures might already be fixed in main
-
-## Step 4: Investigate Failures
-
-Use the `investigating-builds` skill to investigate. The skill's tool hierarchy applies: `bktide snapshot` first, then other bktide commands, then MCP tools as fallback.
-
-After gathering build data, identify failure patterns:
-- Test failures (RSpec, Jest, pytest, etc.)
-- Build/compilation errors
-- Linting/type checking errors
-- Infrastructure issues (Docker, dependencies)
-
-## Step 5: Categorize and Plan Fixes
-
-Group failures by type and plan the fix approach:
-
-| Category | Signs | Typical Fix |
-|----------|-------|-------------|
-| **Stale branch** | Tests pass on main | Merge main, resolve conflicts |
-| **Gemfile.lock issues** | Checksum errors, missing gems | Regenerate from main |
-| **Test failures** | RSpec/Jest failures with stack traces | Fix the test or code |
-| **Type errors** | Sorbet/TypeScript errors | Fix type annotations |
-| **Lint errors** | Rubocop/ESLint failures | Auto-fix or manual fix |
-| **Flaky tests** | Passes locally, fails in CI | Investigate timing/isolation |
-
-For each failure category, outline:
-1. What needs to be fixed
-2. Files likely involved
-3. How to verify locally before pushing
-
-## Step 6: Pre-Push Verification
-
-**Before pushing any fix**, verify locally:
-
-### For Ruby/Rails projects:
-```bash
-bin/rspec <spec_files>
-bin/srb tc <modified_files>      # if using Sorbet
-lefthook run pre-commit          # or: pre-commit run --files <modified_files>
-```
-
-### For JavaScript/TypeScript projects:
-```bash
-npm test -- <test_files>         # or: yarn test <test_files>
-npx tsc --noEmit                 # if using TypeScript
-npm run lint
-```
-
-### General:
-```bash
-# Run whatever CI runs locally if possible
-# Check the failed job's command in the logs
-```
-
-## Step 7: Push and Monitor
-
-After local verification passes:
-
-1. **Commit the fix** with a descriptive message referencing the build:
-   ```
-   Fix <failure type> from build #<number>
-
-   <brief description of what was wrong and how it was fixed>
-   ```
-
-2. **Push the changes**:
-   ```bash
-   git push
-   ```
-
-3. **Monitor the new build** using the `investigating-builds` skill's "Post-Push Monitoring" workflow.
-
-4. **Report status** when build completes:
-   - If passed: Summarize what was fixed
-   - If failed: Go to Step 8
-
-## Step 8: Iterate if Still Failing
-
-If the new build still has failures:
-
-1. **Compare with previous build**:
-   - Same failures? Fix didn't work
-   - Different failures? Progress, but new issues
-   - Fewer failures? Partial progress
-
-2. **Document the iteration**:
-   > "Build #<new> still failing with <N> failures (was <M>). <same/different> failure pattern."
-
-3. **Return to Step 4** with the new build number
-
-4. **Track iterations** — after 3+ iterations, consider:
-   - Is there a deeper architectural issue?
-   - Should we get another pair of eyes?
-   - Is the branch too diverged from main?
-
-## Step 9: Session Summary
-
-When CI finally passes (or session ends), summarize:
-
-```markdown
-## CI Fix Session Summary
-
-**Branch:** <branch-name>
-**Started:** Build #<first-build> (<N> failures)
-**Ended:** Build #<final-build> (passed / still failing)
-**Iterations:** <count>
-
-### Fixes Applied
-1. <Fix 1 description>
-2. <Fix 2 description>
-
-### Patterns Encountered
-- <Pattern 1 and how it was resolved>
-
-### Lessons Learned
-- <Any insights for future debugging>
-```
-
-## Common Fix Patterns
-
-### Gemfile.lock Checksum Issues
-
-**Symptom:** `Your lockfile has an empty CHECKSUMS entry for "<gem>"`
-
-**Fix:**
-```bash
-rm Gemfile.lock
-git checkout origin/main -- Gemfile.lock
-bundle lock
-bundle install  # verify
-git add Gemfile.lock
-git commit -m "Regenerate Gemfile.lock with proper checksums"
-```
-
-### Merge Conflicts Blocking Push
-
-**Fix:**
-```bash
-git stash push -m "WIP changes"
-git fetch origin main
-git merge origin/main --no-edit
-# Resolve conflicts
-git add <conflicted-files>
-git commit
-git stash pop
-# Resolve any conflicts from stash
-```
-
-### Test Matcher/Helper Changes Breaking Tests
-
-**Diagnosis:** Compare with main to see what changed:
-```bash
-git diff origin/main -- spec/support/
-git diff origin/main -- test/helpers/
-```
-
-**Fix:** Often need to restore original behavior for non-target tests while adding new behavior for new tests.
-
-### Year Boundary Test Failures
-
-**Symptom:** Tests involving dates fail around new year
-
-**Fix:** Look for hardcoded years or date assumptions in tests.
-
-## Guidelines
-
-- **Always verify locally** before pushing — saves CI cycles
-- **One fix at a time** when possible — easier to identify what worked
-- **Document as you go** — helps if session spans multiple days
-- **Know when to stop** — sometimes fresh eyes or a different approach is needed
-- **Check main first** — the issue might already be fixed there
+When the skill returns (CI green, iteration cap hit, or classified as flake/infra/unknown), surface the session summary to the user.

--- a/plugins/ci-cd-tools/skills/fixing-ci/SKILL.md
+++ b/plugins/ci-cd-tools/skills/fixing-ci/SKILL.md
@@ -45,7 +45,7 @@ Record the starting point:
 - **Branch name**: Current git branch
 - **PR number**: If applicable (`gh pr view --json number`)
 - **Build number**: The failing build (from input contract)
-- **Failure count**: Number of failed jobs (from investigation skill)
+- **Failure count**: Number of failed jobs (from a bktide snapshot of the build)
 
 Announce:
 
@@ -101,7 +101,8 @@ If the failure is `flake` or `infra` (CI runner/queue/dependencies), **stop**. S
 ```bash
 bin/rspec <spec_files>
 bin/srb tc <modified_files>      # if using Sorbet
-lefthook run pre-commit          # or: pre-commit run --files <modified_files>
+lefthook run pre-commit          # if using lefthook
+pre-commit run --files <modified_files>  # if using pre-commit framework
 ```
 
 ### JavaScript/TypeScript projects

--- a/plugins/ci-cd-tools/skills/fixing-ci/SKILL.md
+++ b/plugins/ci-cd-tools/skills/fixing-ci/SKILL.md
@@ -37,3 +37,135 @@ If the caller provides one of the above, use it directly. Otherwise:
 
 1. **From cwd**: read the current git branch (`git branch --show-current`), look for an open PR (`gh pr view --json number,headRefName`), find its latest failing build via the `buildkite:investigating-builds` skill's "Checking Current Branch/PR Status" workflow.
 2. **If cwd doesn't resolve cleanly** (no branch, no open PR, no failing build): the caller (slash-command wrapper or workflow agent) is responsible for either asking the user or failing with a clear message. This skill assumes resolution is done before its loop starts.
+
+## Step 1: Capture Initial State
+
+Record the starting point:
+
+- **Branch name**: Current git branch
+- **PR number**: If applicable (`gh pr view --json number`)
+- **Build number**: The failing build (from input contract)
+- **Failure count**: Number of failed jobs (from investigation skill)
+
+Announce:
+
+> "Starting CI fix session for branch `<branch>` (Build #<number>). I see <N> failed jobs. Let me investigate."
+
+## Step 2: Check Branch Freshness
+
+Before diving into failures, check if the branch is up to date with main.
+
+1. Check if behind main:
+   ```bash
+   git fetch origin main
+   git rev-list --count HEAD..origin/main
+   ```
+
+2. If behind by more than 0 commits, the failures might already be fixed in main. Decide:
+   - Merge main now (handle conflicts)
+   - Skip and investigate current failures
+
+In **autonomous mode** (e.g. invoked from a workflow agent), default to merging main if behind. The slash-command wrapper asks the user.
+
+## Step 3: Investigate (Delegated)
+
+Use the `buildkite:investigating-builds` skill to investigate the failing build. The skill's tool hierarchy applies: `bktide snapshot` first, then other bktide commands, then MCP tools as fallback.
+
+After investigation, you should have:
+- The failing job(s) and their logs
+- A pattern category (test failure, lint, type error, lockfile, stale branch, infra, flake)
+- Files likely involved
+
+## Step 4: Categorize and Plan Fixes
+
+Group failures by type:
+
+| Category | Signs | Typical Fix |
+|----------|-------|-------------|
+| **Stale branch** | Tests pass on main | Merge main, resolve conflicts |
+| **Gemfile.lock issues** | Checksum errors, missing gems | Regenerate from main (see references/common-fix-patterns.md) |
+| **Test failures** | RSpec/Jest failures with stack traces | Fix the test or code |
+| **Type errors** | Sorbet/TypeScript errors | Fix type annotations |
+| **Lint errors** | Rubocop/ESLint failures | Auto-fix or manual fix |
+| **Flaky tests** | Passes locally, fails in CI | Investigate timing/isolation; do NOT fix-and-push, surface as flake |
+
+For each category, plan: what to fix, files involved, how to verify locally.
+
+If the failure is `flake` or `infra` (CI runner/queue/dependencies), **stop**. Surface and exit. Don't push fixes for problems we don't understand.
+
+## Step 5: Pre-Push Verification
+
+**Always verify locally before pushing.** Saves CI cycles, catches misfires.
+
+### Ruby/Rails projects
+```bash
+bin/rspec <spec_files>
+bin/srb tc <modified_files>      # if using Sorbet
+lefthook run pre-commit          # or: pre-commit run --files <modified_files>
+```
+
+### JavaScript/TypeScript projects
+```bash
+npm test -- <test_files>         # or: yarn test <test_files>
+npx tsc --noEmit                 # if using TypeScript
+npm run lint
+```
+
+### General
+Run whatever the failing CI step ran. Check the failed job's command in the logs.
+
+## Step 6: Push and Monitor
+
+After local verification passes:
+
+1. **Commit** with a message referencing the build:
+   ```
+   Fix <failure type> from build #<number>
+
+   <brief description of what was wrong and how it was fixed>
+   ```
+
+2. **Push**:
+   ```bash
+   git push
+   ```
+
+3. **Monitor the new build** using the `buildkite:investigating-builds` skill's "Post-Push Monitoring" workflow.
+
+4. On completion: pass → summarize and exit. Fail → go to Step 7.
+
+## Step 7: Iterate if Still Failing
+
+Compare with the previous build:
+- Same failures → fix didn't work
+- Different failures → progress, but new issues
+- Fewer failures → partial progress
+
+**Iteration cap: 3.** After 3 iterations without going green, **step back**. Don't keep trying. Exit with a summary covering:
+- What was tried
+- What's still failing
+- A guess at why progress stalled (deeper architectural issue, branch too diverged, etc.)
+
+Three iterations is a heuristic, not a hard rule — if iterations 1 and 2 made clear progress on different failures and iteration 3 is on the last remaining issue, one more attempt is reasonable. If the same failure persists across all three, stop.
+
+## Step 8: Session Summary
+
+When CI passes (or session ends), summarize:
+
+- **Branch**: `<branch>`
+- **Started**: Build #<first> (<N> failures)
+- **Ended**: Build #<final> (passed / still failing)
+- **Iterations**: <count>
+- **Fixes applied**: brief list
+- **Patterns encountered** and how each was resolved
+
+## Common Fix Patterns
+
+Detailed patterns for recurring issues (Gemfile.lock checksum, merge conflicts, year-boundary, test-helper changes) live in [references/common-fix-patterns.md](references/common-fix-patterns.md).
+
+## Guidelines
+
+- **Always verify locally** before pushing — saves CI cycles
+- **One fix at a time** when possible — easier to identify what worked
+- **Know when to stop** — sometimes fresh eyes are needed (3-iteration cap)
+- **Check main first** — the issue might already be fixed there

--- a/plugins/ci-cd-tools/skills/fixing-ci/SKILL.md
+++ b/plugins/ci-cd-tools/skills/fixing-ci/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: fixing-ci
+description: Use when CI is failing on a branch, PR, or specific Buildkite build and the user wants to iteratively fix it through verify-locally → push → check → iterate. Strong signals: "fix CI", "make CI green", "CI is failing", "tests are failing in Buildkite", "iterate on this build", a Buildkite build URL paired with intent to push fixes, a PR with a red check the user wants to make green, or repeat-push debugging. Covers verify-fix-locally workflows (rspec, jest, lint, type checking before pushing), iteration tracking across multiple builds, and knowing when to step back after N failed attempts. Do NOT use for first-time investigation of a build (use `buildkite:investigating-builds` for "why did this fail" without a fix-and-push intent). Do NOT use for authoring pipeline YAML or adding pipeline steps (use `buildkite:developing-pipelines`). Do NOT use for GitHub Actions debugging or non-Buildkite CI. This skill drives the fix loop; investigation is delegated to `buildkite:investigating-builds`.
+---
+
+# Fixing CI
+
+## Overview
+
+This skill drives an iterative CI fix session: investigate the failure (via the Buildkite investigation skill), apply a fix, verify it locally, push, watch the new build, and iterate until green or until you've hit the iteration cap and need to step back.
+
+The scope is the **fix loop only** — investigation is delegated to `buildkite:investigating-builds`, which already covers `bktide snapshot`, log reading, and failure-pattern recognition.
+
+## When to Use
+
+- You have a failing CI build and want to push fixes until it goes green
+- You want to verify changes locally before each push (saves CI cycles)
+- You're iterating on fixes across multiple builds and need to know when to step back
+
+## When NOT to Use
+
+- First-time "why did this fail" investigation with no fix-and-push intent → use `buildkite:investigating-builds` directly
+- Authoring or modifying pipeline YAML → use `buildkite:developing-pipelines`
+- GitHub Actions, CircleCI, or non-Buildkite CI
+
+## Input Contract
+
+The skill needs to know what to fix. Any one of these inputs is sufficient:
+
+- **`build_url`** — A Buildkite build URL (e.g. `https://buildkite.com/org/pipeline/builds/123`)
+- **`pr`** — A GitHub PR number (resolves to its latest failing build for that branch)
+- **`branch`** — A git branch name (resolves to its open PR's latest failing build)
+
+### Resolving inputs
+
+If the caller provides one of the above, use it directly. Otherwise:
+
+1. **From cwd**: read the current git branch (`git branch --show-current`), look for an open PR (`gh pr view --json number,headRefName`), find its latest failing build via the `buildkite:investigating-builds` skill's "Checking Current Branch/PR Status" workflow.
+2. **If cwd doesn't resolve cleanly** (no branch, no open PR, no failing build): the caller (slash-command wrapper or workflow agent) is responsible for either asking the user or failing with a clear message. This skill assumes resolution is done before its loop starts.

--- a/plugins/ci-cd-tools/skills/fixing-ci/evals/README.md
+++ b/plugins/ci-cd-tools/skills/fixing-ci/evals/README.md
@@ -1,0 +1,38 @@
+# fixing-ci eval artifacts
+
+These files support tuning the skill description. The description determines whether Claude invokes the skill for a given user query.
+
+## Files
+
+- `eval_set.json` — 16 queries with `should_trigger` labels.
+  - **Positives** (10): real fix-loop intents (fix CI, make green, iterate on a build, "still red after my push", lockfile/lint/type fixes paired with push intent).
+  - **Negatives** (6) cover near-miss categories:
+    - **First-time investigation without fix intent** ("why did this fail") — should route to `buildkite:investigating-builds`
+    - **Cross-build analytics** (pass/fail summaries) — should route to `buildkite:investigating-builds`
+    - **Pipeline YAML authoring** — should route to `buildkite:developing-pipelines`
+    - **Non-Buildkite CI** (GitHub Actions)
+    - **PR review** — different domain
+    - **Meta-work on the skill itself**
+
+## Why the description matters
+
+The trigger description distinguishes "I want to fix CI" from "I want to understand CI." Both involve build URLs and failure analysis, but the fix-loop adds verify-locally and iterate-and-push behaviors. The description leads with concrete trigger phrases ("fix CI", "make CI green", "iterate") and explicitly carves out the investigation-only case as a should-NOT.
+
+## Re-running the eval
+
+From the skill-creator plugin (requires `ANTHROPIC_API_KEY` or a `claude -p` patch — see the buildkite/investigating-builds eval README):
+
+```bash
+cd ~/.claude/plugins/cache/claude-plugins-official/skill-creator/*/skills/skill-creator
+
+uv run --with anthropic --with 'httpx[socks]' -- python3 -m scripts.run_loop \
+  --eval-set <repo>/plugins/ci-cd-tools/skills/fixing-ci/evals/eval_set.json \
+  --skill-path <repo>/plugins/ci-cd-tools/skills/fixing-ci \
+  --model claude-opus-4-7 \
+  --max-iterations 5 \
+  --verbose
+```
+
+## Caveat
+
+As noted in the buildkite/investigating-builds eval README, the formal eval is a floor (catches obvious false triggers), not a ceiling. Real validation is using the skill in a normal session.

--- a/plugins/ci-cd-tools/skills/fixing-ci/evals/eval_set.json
+++ b/plugins/ci-cd-tools/skills/fixing-ci/evals/eval_set.json
@@ -1,0 +1,66 @@
+[
+  {
+    "query": "fix CI on this branch — it's failing with a few rspec errors and i want to push fixes until it goes green",
+    "should_trigger": true
+  },
+  {
+    "query": "make CI green for PR #196",
+    "should_trigger": true
+  },
+  {
+    "query": "iterate on https://buildkite.com/gusto/pinwheel/builds/481 — i think there's a real test failure to fix",
+    "should_trigger": true
+  },
+  {
+    "query": "this build has been red for 3 pushes, can you help me figure out what to fix",
+    "should_trigger": true
+  },
+  {
+    "query": "rubocop is failing in CI, fix it and push",
+    "should_trigger": true
+  },
+  {
+    "query": "i pushed a fix and CI is still red, take a look and try again",
+    "should_trigger": true
+  },
+  {
+    "query": "Gemfile.lock checksum errors in CI again, regenerate and push",
+    "should_trigger": true
+  },
+  {
+    "query": "the typescript build is failing, can you fix the type errors and push",
+    "should_trigger": true
+  },
+  {
+    "query": "verify the rspec changes pass locally then push them so CI goes green",
+    "should_trigger": true
+  },
+  {
+    "query": "loop on this until CI is green: https://buildkite.com/gusto/pinwheel/builds/481",
+    "should_trigger": true
+  },
+  {
+    "query": "why did this build fail https://buildkite.com/gusto/pinwheel/builds/481",
+    "should_trigger": false
+  },
+  {
+    "query": "summarize pass/fail rates across the last 20 builds on main",
+    "should_trigger": false
+  },
+  {
+    "query": "add a deploy step to .buildkite/pipeline.yml",
+    "should_trigger": false
+  },
+  {
+    "query": "GitHub Actions workflow is failing, can you fix it",
+    "should_trigger": false
+  },
+  {
+    "query": "review this PR and tell me if the test changes look right",
+    "should_trigger": false
+  },
+  {
+    "query": "edit the SKILL.md for fixing-ci to clarify the iteration cap",
+    "should_trigger": false
+  }
+]

--- a/plugins/ci-cd-tools/skills/fixing-ci/references/common-fix-patterns.md
+++ b/plugins/ci-cd-tools/skills/fixing-ci/references/common-fix-patterns.md
@@ -1,0 +1,47 @@
+# Common Fix Patterns
+
+Detailed patterns for recurring CI failures. The `fixing-ci` SKILL.md links here for progressive disclosure — load this only when you've classified the failure into one of these categories.
+
+## Gemfile.lock Checksum Issues
+
+**Symptom:** `Your lockfile has an empty CHECKSUMS entry for "<gem>"`
+
+**Fix:**
+```bash
+rm Gemfile.lock
+git checkout origin/main -- Gemfile.lock
+bundle lock
+bundle install  # verify
+git add Gemfile.lock
+git commit -m "Regenerate Gemfile.lock with proper checksums"
+```
+
+## Merge Conflicts Blocking Push
+
+**Fix:**
+```bash
+git stash push -m "WIP changes"
+git fetch origin main
+git merge origin/main --no-edit
+# Resolve conflicts
+git add <conflicted-files>
+git commit
+git stash pop
+# Resolve any conflicts from stash
+```
+
+## Test Matcher/Helper Changes Breaking Tests
+
+**Diagnosis:** Compare with main:
+```bash
+git diff origin/main -- spec/support/
+git diff origin/main -- test/helpers/
+```
+
+**Fix:** Often need to restore original behavior for non-target tests while adding new behavior for new tests.
+
+## Year Boundary Test Failures
+
+**Symptom:** Tests involving dates fail around new year
+
+**Fix:** Look for hardcoded years or date assumptions in tests.


### PR DESCRIPTION
## Summary

- Extracts the iterative-fix loop from `/ci-cd-tools:fix-ci` into a new `fixing-ci` skill
- Slash command becomes a thin wrapper that resolves input and delegates to the skill (290 → 83 lines)
- Investigation is delegated to `buildkite:investigating-builds` (no duplication)
- Common fix patterns moved to `references/common-fix-patterns.md` for progressive disclosure
- Added eval set (`evals/eval_set.json`) for trigger-description tuning

This unblocks an upcoming `watch-pr` PocketFlow workflow that loads the same skill non-interactively to run autonomous fix attempts when CI fails on a watched PR.

Skill is named `fixing-ci` (gerund) rather than `fix-ci` to avoid the slash-command/skill name-collision that breaks SKILL.md injection.

Bumps ci-cd-tools 1.1.2 → 1.2.0 (minor: new public surface area).

## Test plan

- [ ] Reinstall plugin locally and restart Claude Code
- [ ] Run `/fix-ci` in a repo with failing CI; confirm input resolution + skill delegation
- [ ] Run `/fix-ci https://buildkite.com/...` with explicit URL; confirm skill receives it
- [ ] In a fresh session, ask "what does the fixing-ci skill cover?"; confirm Skill tool invokes \`ci-cd-tools:fixing-ci\`
- [ ] \`./scripts/validate-plugin-versions.sh\` passes (note: pre-existing \`cq\` plugin error in main is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)