### PR TITLE
feat(git): add push skill for failure-output diagnosis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "git",
       "source": "./plugins/git",
-      "version": "3.1.0"
+      "version": "3.2.0"
     },
     {
       "name": "ci-cd-tools",

--- a/plugins/git/skills/push/SKILL.md
+++ b/plugins/git/skills/push/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: push
+description: Use when pushing changes to git, especially when a push fails - covers reading mixed SSH/hook output, debugging SSH without dropping core.sshCommand, and the background-push retry trap
+---
+
+# Git Push
+
+Preferences for `git push`, especially diagnosing failures.
+
+## Reading push failure output
+
+When `git push` exits non-zero, output mixes three layers:
+
+- SSH/transport (key offered, accepted)
+- Hook driver header (lefthook, husky, pre-commit, etc.)
+- Hook output (test/lint/coverage walls)
+
+Identify the failed layer before debugging:
+
+- `lefthook` or `hook: pre-push` → pre-push hook failed; transport was fine
+- `Permission denied (publickey)` → SSH auth refused
+- `! [rejected]` / `non-fast-forward` → push needs rebase
+
+A wall of test or coverage output is NOT an SSH problem. The hook ran tests, the tests failed, the push was blocked.
+
+## pre-push hook failures
+
+Same rules as `pre-commit failures` in the commit skill: analyze the failures, autofix when possible, ask the user when unclear. Do NOT skip with `--no-verify` without explicit confirmation.
+
+## Debugging SSH
+
+Before adding `-v` to debug an SSH issue, check whether `core.sshCommand` is configured:
+
+```
+git config --get core.sshCommand
+```
+
+If it returns nothing, `GIT_SSH_COMMAND="ssh -v" git push origin <branch>` is fine.
+
+If it returns *anything* (custom IdentityFile, IdentityAgent, deploy-key flags, etc.), DO NOT use `GIT_SSH_COMMAND="ssh -v"`. It REPLACES `core.sshCommand` entirely, dropping every flag. Output will look like the wrong keys are being offered, because they are, but only because you removed the constraint.
+
+Append `-v` to the existing command instead:
+
+```
+GIT_SSH_COMMAND="$(git config core.sshCommand) -v" git push origin <branch>
+```
+
+## Background push gotcha
+
+If you started a push with `run_in_background` and then ran a foreground retry (e.g., because the first looked stuck), the background push may have already succeeded. Before re-investigating "why is push failing":
+
+1. `git -C <worktree> log --oneline origin/<branch>..HEAD`. Empty output means the push went through.
+2. Verify retry's cwd: `pwd` and `git rev-parse --show-toplevel`.
+3. `gh pr view <pr>` to see if the commit landed.
+
+Don't escalate to "SSH might be broken" before confirming the push didn't already complete.

--- a/plugins/git/skills/push/SKILL.md
+++ b/plugins/git/skills/push/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: push
-description: Use when pushing changes to git, especially when a push fails - covers reading mixed SSH/hook output, debugging SSH without dropping core.sshCommand, and the background-push retry trap
+description: Use when running git push or diagnosing why a push failed. Especially when output mixes SSH transport with hook output (lefthook, husky, pre-commit), errors include "Permission denied (publickey)" or "rejected/non-fast-forward", a pre-push hook fails, or about to debug SSH with `-v`.
 ---
 
 # Git Push


### PR DESCRIPTION
## Summary

- Adds a `push` skill alongside `commit` in the git plugin
- Teaches agents to identify which layer of `git push` output failed (SSH transport, hook driver, hook output) before debugging
- Documents the `GIT_SSH_COMMAND="ssh -v"` trap: it replaces `core.sshCommand` entirely, so any `-i`/`IdentitiesOnly`/`IdentityAgent` flags configured in `~/.gitconfig.d/` get dropped silently. Recipe: `GIT_SSH_COMMAND="$(git config core.sshCommand) -v"` to append `-v` to the existing command
- Documents the background-push retry trap: a backgrounded push that succeeded after the agent gave up and started a foreground retry can look like a different failure
- Bumps git plugin 3.1.0 to 3.2.0

## Motivation

A real session (working on Gusto/switchboard) misclassified a failed push as an "intermittent SSH issue" when in fact pre-push lefthook tests had failed and SSH was fine. The agent then debugged with `GIT_SSH_COMMAND="ssh -v"` which dropped the agent-key constraint, made the wrong-key offering look like real auth failure, and compounded the misdiagnosis. This skill captures the patterns that would have caught it.

The hook-output match strings (`lefthook`, `hook: pre-push`) are lefthook-specific. Husky and pre-commit have different output shapes; can extend if a real miss surfaces.

## Test plan

- [ ] Reinstall plugin locally, restart Claude Code
- [ ] Confirm skill appears in available skills list as `git:push`
- [ ] Check version-check CI passes (3.1.0 -> 3.2.0 matches the `feat(git):` bump rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)