### PR TITLE
fix(actually-lsp): stop dropping TypeScript on real-world projects

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "actually-lsp",
       "source": "./plugins/actually-lsp",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "name": "working-in-monorepos",

--- a/plugins/actually-lsp/hooks/session-start.sh
+++ b/plugins/actually-lsp/hooks/session-start.sh
@@ -106,7 +106,12 @@ while IFS='|' read -r ecosystem marker_path; do
       # Persist state
       now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
       mtime=$(stat -c %Y "$marker_path" 2>/dev/null || stat -f %m "$marker_path" 2>/dev/null || echo 0)
-      plugin_hash=$(get_plugin_list | sha256sum | head -c 8)
+      # Slice in bash rather than `| head -c 8`: piping into a truncating
+      # reader is the same antipattern that broke detect.sh under pipefail.
+      # sha256sum's output is small enough that it's safe in practice today,
+      # but there's no reason to keep the fragile shape.
+      plugin_hash=$(get_plugin_list | sha256sum)
+      plugin_hash="${plugin_hash:0:8}"
       write_state "$ecosystem" "$state" false "$now" "$mtime" "$plugin_hash" null
       break
     fi

--- a/plugins/actually-lsp/lib/detect.sh
+++ b/plugins/actually-lsp/lib/detect.sh
@@ -19,8 +19,13 @@ detect_ecosystems() {
 
     # TypeScript-specific check: package.json without any .ts/.tsx files in
     # the tree is not a TypeScript project (it's plain JavaScript).
+    #
+    # `-print -quit` stops find after the first match. Don't pipe to
+    # `head -1`: under pipefail, the SIGPIPE find receives once its output
+    # exceeds the OS pipe buffer (~64KB, hit by any project with
+    # node_modules) flips the existence check and silently drops TypeScript.
     if [[ "$ecosystem" == "typescript" ]]; then
-      if ! find "$project_dir" -maxdepth 4 -type f \( -name "*.ts" -o -name "*.tsx" \) 2>/dev/null | head -1 | grep -q .; then
+      if [[ -z "$(find "$project_dir" -maxdepth 4 -type f \( -name "*.ts" -o -name "*.tsx" \) -print -quit 2>/dev/null)" ]]; then
         continue
       fi
     fi

--- a/plugins/actually-lsp/tests/test_detect.py
+++ b/plugins/actually-lsp/tests/test_detect.py
@@ -9,8 +9,14 @@ DETECT_SH = PLUGIN_ROOT / "lib" / "detect.sh"
 
 
 def run_detect(project_dir):
-    """Source ecosystems.sh and detect.sh, run detect_ecosystems, return stdout."""
+    """Source ecosystems.sh and detect.sh, run detect_ecosystems, return stdout.
+
+    Runs under `set -eo pipefail` to match hooks/session-start.sh semantics, so
+    pipeline-related bugs surface at the unit layer instead of only in
+    end-to-end hook tests.
+    """
     script = (
+        f"set -eo pipefail; "
         f"source {PLUGIN_ROOT}/lib/ecosystems.sh && "
         f"source {DETECT_SH} && "
         f"detect_ecosystems '{project_dir}'"
@@ -41,6 +47,39 @@ def test_detect_finds_typescript(tmp_path):
     lines = output.split("\n")
     ts_lines = [l for l in lines if l.startswith("typescript|")]
     assert len(ts_lines) == 1
+
+
+def _seed_large_ts_tree(root):
+    """Seed a fixture whose .ts paths overflow the OS pipe buffer (~64KB).
+
+    The regression here only fires once `find`'s accumulated output exceeds
+    the pipe buffer, so the second write blocks → SIGPIPE once `head -1`
+    closes its read end. We need:
+    - .ts files within `find -maxdepth 4` (counted from root)
+    - enough total output bytes to exceed the buffer (~64KB)
+    """
+    (root / "package.json").write_text("{}")
+    for d in range(50):
+        sub = root / f"dir{d}"
+        sub.mkdir()
+        for i in range(50):
+            (sub / f"file_with_a_reasonably_long_name_{i}.ts").write_text("")
+
+
+def test_detect_finds_typescript_in_large_tree(tmp_path):
+    """Regression: a large .ts tree under pipefail tripped SIGPIPE.
+
+    The old `find ... | head -1 | grep -q .` pattern caused `find` to receive
+    SIGPIPE once `head` closed its pipe, which under `set -eo pipefail`
+    flipped the existence check to false and silently dropped TypeScript
+    detection in any real-world project (monorepos, anything with node_modules).
+    """
+    _seed_large_ts_tree(tmp_path)
+    output, rc = run_detect(tmp_path)
+    assert rc == 0, f"detect_ecosystems exited {rc}; output={output!r}"
+    assert any(l.startswith("typescript|") for l in output.split("\n")), (
+        f"typescript was dropped; output was {output!r}"
+    )
 
 
 def test_detect_skips_typescript_without_ts_files(tmp_path):

--- a/plugins/actually-lsp/tests/test_session_start.py
+++ b/plugins/actually-lsp/tests/test_session_start.py
@@ -62,6 +62,25 @@ def test_hook_nudges_when_no_lsp_plugin(tmp_path):
     assert "/actually-lsp:doctor" in stdout
 
 
+def test_hook_nudges_for_typescript_in_large_tree(tmp_path):
+    """Regression: real-world TS projects have enough .ts files for `find`'s
+    output to exceed the pipe buffer. Once that happens, the old
+    `find ... | head -1` pattern receives SIGPIPE under pipefail, and the
+    hook silently drops TypeScript detection.
+    """
+    (tmp_path / "package.json").write_text("{}")
+    for d in range(50):
+        sub = tmp_path / f"dir{d}"
+        sub.mkdir()
+        for i in range(50):
+            (sub / f"file_with_a_reasonably_long_name_{i}.ts").write_text("")
+    stdout, _, rc = run_hook(tmp_path, plugin_list_output='[]')
+    assert rc == 0
+    assert "typescript-lsp@claude-plugins-official" in stdout, (
+        f"typescript nudge missing from hook stdout: {stdout!r}"
+    )
+
+
 def test_hook_emits_activation_context_when_ready(tmp_path):
     """TypeScript project with LSP plugin + node_modules: emit activation context."""
     (tmp_path / "package.json").write_text("{}")


### PR DESCRIPTION
## What

`actually-lsp@0.2.0`'s SessionStart hook silently dropped TypeScript detection on any real-world TS project — bktide, the typescript-lsp plugin repo, anything with `node_modules`. The plugin appeared to work; nothing was emitted.

## Root cause

`lib/detect.sh:23` used:

```bash
if \! find "$project_dir" -maxdepth 4 -type f \( -name "*.ts" -o -name "*.tsx" \) 2>/dev/null | head -1 | grep -q .; then
  continue
fi
```

The hook runs under `set -eo pipefail`. Once `find`'s accumulated output exceeds the OS pipe buffer (~64KB — easy to hit when `node_modules` is in the tree), `head -1` closes its read end after the first match, `find`'s next write gets SIGPIPE, and pipefail propagates that non-zero status. The `\! ... | ... | ...` flips it to true, the `if` body fires, and TypeScript is silently dropped.

## Fix

Use `find -print -quit` and check the captured string for emptiness:

```bash
if [[ -z "$(find "$project_dir" -maxdepth 4 -type f \( -name "*.ts" -o -name "*.tsx" \) -print -quit 2>/dev/null)" ]]; then
  continue
fi
```

`-quit` tells find to stop walking after the action fires, so there's no pipe and no SIGPIPE. Also a perf win on large monorepos — find exits on the first `.ts` it sees instead of walking the whole maxdepth-4 subtree.

## Why the existing tests didn't catch it

Two reasons:

1. `test_detect.py:run_detect` ran the inner script with `bash -c "..."` and **no `set -eo pipefail`**, so the pipefail-dependent bug was invisible at the unit layer.
2. `test_session_start.py` *did* go through the real hook (which sets pipefail), but the TypeScript fixtures only created **one** `.ts` file — `find` finishes naturally before SIGPIPE can fire. The bug needs `find`'s output to exceed the pipe buffer before `head` closes.

## Tests added

- `test_detect_finds_typescript_in_large_tree` — fixture with 50 dirs × 50 files (~190KB of find output) at depth 2, within `find -maxdepth 4`.
- `test_hook_nudges_for_typescript_in_large_tree` — same fixture, end-to-end through the SessionStart hook.
- `run_detect` now sets `set -eo pipefail` to match hook semantics so any future pipe-misuse in `detect.sh` fails at the unit layer.

Both new tests fail against unfixed `detect.sh`, pass with the fix. All 32 tests pass.

## Bonus: kill the same antipattern in `plugin_hash`

`hooks/session-start.sh:109` had `get_plugin_list | sha256sum | head -c 8` — same shape as the bug, just on a different command. It happens to be safe in practice because `sha256sum`'s output is small enough to fit in the pipe buffer atomically before `head` closes, but there's no reason to keep the fragile pattern. Replaced with a bash parameter-expansion slice.

## Other languages

Rust (`Cargo.toml`) and Ruby (`Gemfile`) use direct `-f marker` checks — no pipe truncation. Their `env_check` commands (`cargo metadata --no-deps`, `bundle check`) run inside `(cd ... && eval ...) >/dev/null 2>&1` with no pipes. Not affected.

## Version

Patch bump to `0.2.1`.