### PR TITLE
fix(actually-lsp): drop nudge references to unshipped commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "actually-lsp",
       "source": "./plugins/actually-lsp",
-      "version": "0.2.1"
+      "version": "0.2.2"
     },
     {
       "name": "working-in-monorepos",

--- a/plugins/actually-lsp/hooks/session-start.sh
+++ b/plugins/actually-lsp/hooks/session-start.sh
@@ -75,17 +75,16 @@ emit_for_state() {
       ;;
     no-lsp-plugin)
       echo "[actually-lsp] Detected $ecosystem. Recommended LSP plugin: $recommended_plugin."
-      echo "Run \`/actually-lsp:doctor\` to set up, or \`/actually-lsp:skip $ecosystem\` to dismiss."
+      echo "Install with: /plugin install $recommended_plugin"
       ;;
     server-not-runnable)
-      echo "[actually-lsp] $ecosystem LSP plugin installed but env not ready."
-      echo "Run \`/actually-lsp:doctor\` to fix."
+      echo "[actually-lsp] $ecosystem LSP plugin installed but env not ready (server binary missing or env check failed)."
       ;;
     ready)
       cat "$PLUGIN_ROOT/activation/$ecosystem.md"
       ;;
     error)
-      echo "[actually-lsp] Detection failed for $ecosystem. Run \`/actually-lsp:doctor $ecosystem\` for details."
+      echo "[actually-lsp] Detection failed for $ecosystem."
       ;;
   esac
 }

--- a/plugins/actually-lsp/tests/test_session_start.py
+++ b/plugins/actually-lsp/tests/test_session_start.py
@@ -59,7 +59,17 @@ def test_hook_nudges_when_no_lsp_plugin(tmp_path):
     stdout, stderr, rc = run_hook(tmp_path, plugin_list_output='[]')
     assert rc == 0
     assert "typescript-lsp@claude-plugins-official" in stdout
-    assert "/actually-lsp:doctor" in stdout
+    assert "/plugin install typescript-lsp@claude-plugins-official" in stdout
+
+
+def test_hook_does_not_reference_unshipped_commands(tmp_path):
+    """Nudges must not reference /actually-lsp:doctor or :skip until 0.5 ships them."""
+    (tmp_path / "package.json").write_text("{}")
+    (tmp_path / "src.ts").write_text("export const x = 1;")
+    stdout, _, rc = run_hook(tmp_path, plugin_list_output='[]')
+    assert rc == 0
+    assert "/actually-lsp:doctor" not in stdout
+    assert "/actually-lsp:skip" not in stdout
 
 
 def test_hook_nudges_for_typescript_in_large_tree(tmp_path):

--- a/plugins/actually-lsp/uv.lock
+++ b/plugins/actually-lsp/uv.lock
@@ -1,0 +1,75 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "actually-lsp-tests"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", specifier = ">=8.0.0" }]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]


### PR DESCRIPTION
## Summary

The 0.2.1 SessionStart hook tells users to run `/actually-lsp:doctor` and `/actually-lsp:skip`, but those commands aren't shipped yet (the README has them as "Coming in 0.5"). So new users hit the nudge, try the suggestion, and get nothing.

Quick fix: drop the broken suggestions from the nudge text.

- `no-lsp-plugin`: replace `Run /actually-lsp:doctor ...` with a concrete `/plugin install <recommended>` line (actionable today).
- `server-not-runnable`: drop the `Run /actually-lsp:doctor` follow-up; the "env not ready" status line stays.
- `error`: drop the `Run /actually-lsp:doctor` follow-up.
- New regression test asserts no nudge text references the unshipped commands.

When the doctor/skip commands ship in 0.5, the nudges can grow back into pointing at them.

## Test plan

- [x] `uv run --directory plugins/actually-lsp pytest tests/test_session_start.py -v` (10 passed)
- [x] `./scripts/bump-version.sh --auto` bumped 0.2.1 → 0.2.2 (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)