### PR TITLE
feat(actually-lsp): probe ready ecosystems with documentSymbol

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "actually-lsp",
       "source": "./plugins/actually-lsp",
-      "version": "0.5.0"
+      "version": "0.6.0"
     },
     {
       "name": "working-in-monorepos",

--- a/plugins/actually-lsp/skills/actually-lsp-doctor/SKILL.md
+++ b/plugins/actually-lsp/skills/actually-lsp-doctor/SKILL.md
@@ -39,6 +39,38 @@ For each ecosystem in `no-lsp-plugin`, `server-not-runnable`, or `error`:
 
 **`error`**: surface the cached `last_error` from the state file. Ask the user how to proceed.
 
-## Step 4: Re-detect and report
+## Step 4: Re-detect
 
-Re-run detection (same as Step 1's "if missing" path). Update the project state file. Output a final per-ecosystem status line.
+Re-run detection (same as Step 1's "if missing" path) and compute the new state per ecosystem. Hold the result in memory; don't write the state file yet. Step 5 may downgrade `ready` ecosystems before persistence.
+
+## Step 5: Probe ready ecosystems via LSP
+
+The goal is to ground a `ready` verdict in an actual LSP response, not just env state. Env can say "server should run" while the server fails to answer queries (not indexed yet, wrong workspace root, crashed).
+
+For each ecosystem whose computed state is `ready`:
+
+1. **Ensure the `LSP` tool is loaded.** If it isn't available in this session, call `ToolSearch` with query `select:LSP`. If `ToolSearch` returns no match, skip the probe for *every* ecosystem and note "LSP tool unavailable in session" in the report. Do not downgrade any state. This is an environment issue, not an ecosystem failure.
+
+2. **Find a sample source file** under `$PROJECT_DIR`:
+   - rust: `find "$PROJECT_DIR" -maxdepth 4 -type f -name '*.rs' -print -quit`
+   - typescript: `find "$PROJECT_DIR" -maxdepth 4 -type f \( -name '*.ts' -o -name '*.tsx' \) -print -quit`
+   - ruby: `find "$PROJECT_DIR" -maxdepth 4 -type f -name '*.rb' -print -quit`
+
+   If no file is found, skip the probe for this ecosystem and note "no sample file" in the report. Do not downgrade.
+
+3. **Call `LSP documentSymbol`** against the sample file at `line: 1, character: 1`.
+
+4. **On error or non-array response:** downgrade the ecosystem to `error` and set `last_error` to the stringified LSP response (or a short summary if the response is large). Env said the server should be runnable, so a probe failure is a real LSP failure worth surfacing on the next SessionStart.
+
+5. **On success:** count the symbols in the response array. State stays `ready`. The count is for the report only; nothing extra goes into the state file.
+
+## Step 6: Write state and final report
+
+Write the (possibly probe-updated) per-ecosystem state to `.claude/actually-lsp.json` using `write_state` from `lib/state.sh`. Output one status line per ecosystem:
+
+- `ready` with successful probe: `<ecosystem>: ready (LSP: N symbols)`
+- `ready` with skipped probe: `<ecosystem>: ready (LSP: skipped, <reason>)`
+- `error` from probe failure: `<ecosystem>: error (LSP probe failed: <summary>)`
+- Other states: `<ecosystem>: <state>` plus the recovery hint from Step 2
+
+Keep tone terse. No celebration messaging.

--- a/plugins/actually-lsp/tests/test_plugin_structure.py
+++ b/plugins/actually-lsp/tests/test_plugin_structure.py
@@ -79,6 +79,23 @@ class TestSkills:
         assert "name: actually-lsp-doctor" in content
         assert "description:" in content
 
+    def test_doctor_skill_probes_lsp_when_ready(self):
+        """The doctor must verify a `ready` verdict by calling the LSP tool.
+
+        Env-only readiness checks (plugin installed + server binary
+        runnable) miss the case where the server is up but not actually
+        answering queries (not indexed yet, wrong workspace root,
+        crashed). The probe closes that gap.
+        """
+        path = PLUGIN_ROOT / "skills" / "actually-lsp-doctor" / "SKILL.md"
+        content = path.read_text()
+        assert "documentSymbol" in content, (
+            "Doctor SKILL.md must call LSP `documentSymbol` to verify ready ecosystems"
+        )
+        assert "ToolSearch" in content, (
+            "Doctor SKILL.md must instruct loading the deferred LSP tool via ToolSearch"
+        )
+
     def test_ignore_skill_exists(self):
         path = PLUGIN_ROOT / "skills" / "actually-lsp-ignore" / "SKILL.md"
         assert path.exists(), f"Missing skill at {path}"


### PR DESCRIPTION
## Summary

- The doctor's `ready` verdict was env-only (plugin installed, server binary runnable). That misses the server-is-up-but-not-answering case: not indexed yet, wrong workspace root, crashed. A `documentSymbol` probe per ready ecosystem grounds the verdict in an actual LSP response.
- Probe failure downgrades the ecosystem to `error` with `last_error`, so the SessionStart hook surfaces it next time around. Missing LSP tool or no sample file just notes the skip and leaves state alone.

## Test plan

- `cd plugins/actually-lsp && uv run pytest` (36 tests, including the new `test_doctor_skill_probes_lsp_when_ready` regression guard).
- Manual: run `/actually-lsp-doctor` in a known-good Ruby/TS/Rust project and confirm the final status line includes `(LSP: N symbols)`.

## Follow-up work

- Behavioral coverage of the probe itself still needs a `skill-creator:run_eval`-style prompt set against a fixture project. The structural test only guards SKILL.md from regressing on `documentSymbol` / `ToolSearch` mentions.
