### PR TITLE
feat(petri-dish): add petri-dish skill plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -85,6 +85,16 @@
       "name": "github-actions",
       "source": "./plugins/github-actions",
       "version": "0.1.1"
+    },
+    {
+      "name": "petri-dish",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/technicalpickles/petri-dish.git",
+        "path": "claude-plugin",
+        "ref": "main"
+      },
+      "version": "0.1.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the `petri-dish` plugin to the marketplace, sourced from [github.com/technicalpickles/petri-dish](https://github.com/technicalpickles/petri-dish) via `git-subdir` at `claude-plugin/`. Mirrors the cq pattern (PR #63). Initial version 0.1.0, tracking `ref: main` until we adopt tag-based releases.

The plugin teaches Claude Code how to author petri-dish cultures (Claude Code experiments): schema, prompt anatomy, baseline cells, multi-run discipline, and the brittle bits to watch for. Source PR: [technicalpickles/petri-dish#1](https://github.com/technicalpickles/petri-dish/pull/1) (merged).

## Test plan

- [ ] CI passes (version-check is a no-op for new external plugins)
- [ ] After merge: `claude plugin install petri-dish@pickled-claude-plugins` succeeds
- [ ] `/plugin list` shows petri-dish enabled
- [ ] Skill description triggers on culture-authoring phrasings ("write a petri-dish culture", "A/B variant of X", "baseline cell for Y")
- [ ] SKILL.md can read `references/authoring-cultures.md` from its local install path

Refs: gt-o3gj

🤖 Generated with [Claude Code](https://claude.com/claude-code)