### PR TITLE
Add writing-for-scannability skill (writing-tools plugin)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,6 +95,11 @@
         "ref": "main"
       },
       "version": "0.1.0"
+    },
+    {
+      "name": "writing-tools",
+      "source": "./plugins/writing-tools",
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/writing-tools/.claude-plugin/plugin.json
+++ b/plugins/writing-tools/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "writing-tools",
+  "description": "Skills for structuring and formatting prose so it reads well",
+  "author": {
+    "name": "Josh Nichols",
+    "email": "josh@technicalpickles.com"
+  },
+  "repository": "https://github.com/technicalpickles/pickled-claude-plugins",
+  "license": "MIT"
+}

--- a/plugins/writing-tools/README.md
+++ b/plugins/writing-tools/README.md
@@ -1,0 +1,17 @@
+# writing-tools Plugin
+
+Skills for structuring and formatting prose so it reads well.
+
+## Installation
+
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
+```bash
+/plugin install writing-tools@pickled-claude-plugins
+```
+
+## Skills
+
+### writing-for-scannability
+
+Use when structuring prose so readers can skim it - drafting or restructuring READMEs, docs, PR or issue bodies, design docs, or any long-form text where a wall of prose hides the structure. Covers when to surface a buried list, how to keep list items parallel, how to front-load the load-bearing word for the F-pattern, and a sliding scale for how hard to lean on formatting per medium. Composes with prose-clarity and voice skills rather than replacing them.

--- a/plugins/writing-tools/README.md
+++ b/plugins/writing-tools/README.md
@@ -15,3 +15,35 @@ Requires the [pickled-claude-plugins marketplace](../../README.md#installation).
 ### writing-for-scannability
 
 Use when structuring prose so readers can skim it - drafting or restructuring READMEs, docs, PR or issue bodies, design docs, or any long-form text where a wall of prose hides the structure. Covers when to surface a buried list, how to keep list items parallel, how to front-load the load-bearing word for the F-pattern, and a sliding scale for how hard to lean on formatting per medium. Composes with prose-clarity and voice skills rather than replacing them.
+
+The full background, history, and worked examples live in the skill's [reference docs](skills/writing-for-scannability/references/).
+
+## Resources
+
+The skill is built on the scannable-writing research tradition. The sources it draws from:
+
+**How people read on screens**
+
+- Nielsen, [How Users Read on the Web](https://www.nngroup.com/articles/how-users-read-on-the-web/) (1997) - the founding finding that most readers scan rather than read.
+- Morkes & Nielsen, [Concise, SCANNABLE, and Objective](https://www.nngroup.com/articles/concise-scannable-and-objective-how-to-write-for-the-web/) (1997) - the Sun Microsystems usability study.
+- Nielsen, [F-Shaped Pattern of Reading](https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/) (2006) - the eye-tracking research behind front-loading.
+- Nielsen, [Website Reading: It (Sometimes) Does Happen](https://www.nngroup.com/articles/website-reading/) (2013) - the corrective on when reading does happen.
+- Krug, [Don't Make Me Think](https://en.wikipedia.org/wiki/Don't_Make_Me_Think) (2014 ed.) - satisficing and designing for scanning.
+
+**When to bullet, when not to**
+
+- Google, [Lists and Tables](https://developers.google.com/tech-writing/one/lists-and-tables) - the clearest practical rules, including parallelism.
+- Hurley, [Bullet point lists versus paragraphs](https://www.writingclearscience.com.au/bullet-point-lists-versus-paragraphs/) - the statement-plus-examples heuristic.
+- Seneca College, [Lists chapter](https://pressbooks.senecacollege.ca/technicalwriting/chapter/lists/) - the five list types.
+- UXmatters, [Scannability: Principle and Practice](https://www.uxmatters.com/mt/archives/2015/06/scannability-principle-and-practice.php) - when scannability is not the right move.
+- Gearing, [Bullet Points vs Prose](https://lukegearing.blot.im/bullet-points-vs-prose) - a counterpoint on when bullets lose meaning.
+
+**Parallel structure**
+
+- Perspectives on Medical Education, [The Power of Parallel Structure](https://pmc.ncbi.nlm.nih.gov/articles/PMC4673060/) - the cleanest summary of the grammar move.
+- Rabbit with a Red Pen, [Writing Parallel Structure](https://www.rabbitwitharedpen.com/blog/parallel-structure) - auditory heuristics for catching breaks.
+
+**The inverted pyramid (history)**
+
+- Wikipedia, [Inverted pyramid (journalism)](https://en.wikipedia.org/wiki/Inverted_pyramid_(journalism)) - the structural ancestor.
+- Scanlan, [Birth of the Inverted Pyramid](https://www.poynter.org/reporting-editing/2003/birth-of-the-inverted-pyramid-a-child-of-technology-commerce-and-history/) (Poynter) - the telegraph-era origin story.

--- a/plugins/writing-tools/docs/DESIGN.md
+++ b/plugins/writing-tools/docs/DESIGN.md
@@ -1,0 +1,74 @@
+# Design: writing-tools plugin / writing-for-scannability skill
+
+Date: 2026-05-29
+
+## Problem
+
+Prose-clarity guidance (Strunk-style concision) optimizes for tight prose. It happily leaves
+run-in lists inline (`create X, query Y, delete Z`) and produces walls of prose where the
+structure is buried. That's harder to skim. No skill covered the *structural* axis of writing:
+when to surface a buried list, how to front-load for scanning, and how hard to lean on
+formatting per medium.
+
+This plugin captures that as a reusable technique, grounded in the NN/g scannable-writing
+research, the inverted-pyramid tradition, parallel structure, the F-pattern, and a sliding
+scale across digital mediums.
+
+## Three-axis model
+
+Writing splits into complementary axes, invoked independently or together:
+
+- **Concision** (e.g. an elements-of-style / writing-clearly skill) - keeps prose tight. Tends
+  to keep lists inline.
+- **Scannability** (this skill) - structure and visual hierarchy. Decides *when* to promote a
+  buried list, how to front-load, how much to format per medium.
+- **Voice** (a personal writing-voice skill) - personality. Keeps the result human, not canned.
+
+Concision and scannability pull opposite directions on purpose: tight vs. skimmable. Voice
+referees the tone.
+
+## The bold-bullet reconciliation
+
+A voice skill's anti-AI-tells may flag "bold-first bullets" (`**term:** definition` on every
+bullet) as a canned LLM tell. This skill says bold-leading is *correct* for labeled lists. The
+resolution, stated in SKILL.md:
+
+- Bold-led bullets are right for genuine definition/labeled lists in scanning-reward mediums
+  (READMEs, docs, design docs, PR/issue bodies).
+- They are a tell when applied to plain item lists, used as the default shape for every list, or
+  leaned on in casual mediums (Slack, personal blog).
+- The sliding scale (reader-entry-diversity x durability) is the dial.
+
+This skill owns "how to build a good list"; voice owns "don't let it become a tic." Because the
+voice skill lives outside this repo (personal `~/.claude/skills`), the reconciliation is stated
+here and the voice skill is edited separately to point back at it.
+
+## Layout
+
+```
+plugins/writing-tools/
+  .claude-plugin/plugin.json   (no version; versions live in marketplace.json)
+  README.md
+  docs/DESIGN.md               (this file)
+  skills/writing-for-scannability/
+    SKILL.md
+    references/
+      scannable-writing-guide.md       (deep research, verbatim)
+      scannable-writing-cheatsheet.md  (one-pager, verbatim)
+```
+
+Added to `.claude-plugin/marketplace.json` as `writing-tools` at version `0.1.0`.
+
+## SKILL.md shape
+
+Operational, follows the skill-authoring conventions (description = triggers only, no workflow
+summary): overview + core principle, when to use / not, convert-to-list signals (table), when to
+leave prose alone, parallelism check, front-load / F-pattern, sliding-scale-by-medium table,
+voice reconciliation, common mistakes, pointers to the two reference files, the mantra.
+
+## Out of scope / follow-ups
+
+- Editing the personal writing-voice skill to soften the "bold-first bullets" tell and add a
+  cross-ref. That's a separate change outside this repo.
+- Future writing skills (e.g. a structure-only restructurer, headline writing) could join this
+  plugin later.

--- a/plugins/writing-tools/skills/writing-for-scannability/SKILL.md
+++ b/plugins/writing-tools/skills/writing-for-scannability/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: writing-for-scannability
+description: Use when structuring prose so readers can skim it - drafting or restructuring READMEs, docs, PR or issue bodies, design docs, RFCs, or any long-form text where a wall of prose hides the structure. Also use when explicitly asked to make something scannable or skimmable, convert prose to a list, surface a buried list, fix a wall of text, or decide whether bullets or prose fit. Strong signal: text with parallel sentence shapes, contrast markers ("that's distinct from", "versus"), bolded terms followed by colons, or an embedded "X, Y, and Z" series. Composes with prose-clarity skills (concision) and voice skills (personality) rather than replacing them. Skip for source code and for casual one-line replies where formatting reads as overkill.
+---
+
+# Writing for Scannability
+
+## Overview
+
+Most people scan before they read. The job is to format prose so a scanner gets the gist and a committed reader gets the depth, without writing two versions. This is the structural axis of writing: when to surface a buried list, how to front-load for the eye, and how hard to lean on formatting per medium.
+
+It is a different axis from concision (keeping prose tight) and from voice (keeping it human). Concision will happily leave a list buried inside a sentence; this skill decides when to pull it out. Voice keeps the result from reading like a corporate slide deck.
+
+**Core principle:** if the prose is doing list work, let it be a list. If the prose is doing argument work, leave it.
+
+## When to use
+
+Reach for this when:
+
+- A paragraph has parallel sentence shapes: *"X is A. Y is B."* or *"First... Second..."*
+- You hit a contrast marker: *"that's distinct from"*, *"as opposed to"*, *"versus"*, *"on the other hand"*
+- You have bolded terms each followed by a colon and a definition (a definition list hiding in prose)
+- Three or more parallel items pile up
+- A sentence carries an embedded series: *"create X, query Y, and delete Z"*
+- Someone hands you a wall of text and asks you to make it skimmable, or to restructure a README / PR body / design doc
+
+When NOT to use:
+
+- Source code or code comments
+- A casual one-line Slack reply or chat message where bullets would read as overkill
+- Personal-voice writing (a stylistic essay, an apology) where the unbroken prose IS the point
+
+## Convert prose to a list when the structure is already there
+
+Each signal below means a list is trying to escape the paragraph. The shape to reach for: a one-sentence lead-in, then bullets, each starting with its load-bearing term.
+
+| Signal | What it looks like |
+|--------|--------------------|
+| Parallel sentence shapes | *"X is A. Y is B."* repeated skeleton |
+| Contrast markers | *"that's distinct from"*, *"versus"*, *"whereas"* |
+| Bold term + colon | *"**Workflow**: how it runs. **Surface**: how it deploys."* |
+| Rule of three | three or more siblings in a row |
+| Embedded series | *"create X, query Y, and delete Z"* inside one sentence |
+
+## Leave prose alone when the connective tissue matters
+
+Bullets are lossy. They strip the words that say *why* items sit next to each other. Keep prose when:
+
+- **Connectives carry argument** - *counterintuitively*, *and as a result*, *but only when*. These do real work bullets can't show.
+- **The flow is causal or narrative** - *"we tried X, it failed because Y, so we pivoted to Z"* is a story, not a list.
+- **The items are two and short** - they ride the sentence's rhythm fine.
+- **The reader expects sustained reading** - long-form essays, persuasion, narrative.
+
+If you bullet a passage and the words *but*, *because*, *so*, *counterintuitively* fall on the floor, the relationships were the point. Put it back as prose.
+
+## Make every list item parallel
+
+Once items are bullets, they must share grammatical shape, or the list reads as broken even when the reader can't say why. Reading the items aloud surfaces the break fast.
+
+- **Same part of speech** - all nouns, all gerunds, or all infinitives. *running, swimming, cycling* (good) vs *running, to swim, cycling* (broken).
+- **Same tense and voice** - don't mix *reduces* with *improving*.
+- **Same opening shape** - if one bullet leads with a bolded term, all of them should.
+- **Roughly the same weight** - a one-word item shouldn't share a list with a three-sentence one.
+
+For steps where order matters, use a numbered list and start each item with an imperative verb: *Stop the server. Edit the config. Restart it.*
+
+## Front-load the load-bearing word
+
+Eye-tracking shows readers scan in an F: across the top, then down the left margin. So the leftmost word of every bullet, heading, and paragraph is the most-seen word on the page.
+
+- **Lead with the term, not the run-up.** *"Workflow methodology - how a coding agent runs through..."* beats *"How a coding agent runs through the stages is the workflow methodology..."*
+- **Bold the term, not the definition.** Bold marks the concept a scanner hunts for, not the supporting words around it.
+- **Don't over-bold.** If everything is emphasized, nothing is.
+- **One idea per paragraph.** A second concept buried in sentence three won't be seen by anyone scanning the first few words.
+
+## How hard to lean: the sliding scale
+
+Formatting (bold, headers, lists, explicit inverted-pyramid sections) costs the writer time and costs the reader some warmth. Heavily formatted prose reads corporate. Whether it's worth it scales with two things, not with medium alone:
+
+- **Reader-entry diversity** - how many modes hit this? Triage (5-second decision), browse (scrolling), deep-read (committed), reference (came back to find one thing)?
+- **Durability** - read once and gone, or returned to over time?
+
+High diversity x high durability = lean in hard. Low x low = dial it down.
+
+| Surface | How hard to lean | Why |
+|---------|------------------|-----|
+| Tweets | Universal rules only | One entry mode (scroll); no formatting affordances. Front-load harder, there's no slack. |
+| Slack / chat | Light | Ephemeral but searched. Front-load the first word (*"Blocker:"*, *"FYI:"*). Headers feel like a memo. |
+| PR / inline review comments | Dialed down | Conversational. One clear *"blocker because X, suggest Y"* beats three bulleted sections. |
+| GitHub issues | Heavy | Multi-audience: triager wants 5-second triage, assignee wants detail. Descriptive title, TL;DR, sections. |
+| PR descriptions | Heavy | Reviewer orients before diving into the diff. Problem in one line, approach in a paragraph, then deeper sections. |
+| READMEs | Heavy | Ten seconds to decide if the repo is relevant. Title, one-line what, install, minimal example, links. |
+| Design docs / RFCs / ADRs | Highest | Durable, multi-mode, read months apart. Headers carry navigation; TL;DR up top; then prose can have all the connective tissue it needs. |
+
+What's **universal** (every surface, no dialing): front-load the load-bearing word, don't bury the conclusion, keep list items parallel.
+
+## Reconciling with voice skills
+
+Voice guidance often flags "bold-first bullets" (every bullet `**term:** definition`) as a canned, AI-generated tell. That's not a contradiction with this skill, it's a boundary:
+
+- Bold-led bullets are **right** when the list is genuinely a definition/labeled list AND the medium rewards scanning (READMEs, docs, design docs, issue/PR bodies).
+- They become a **tell** when applied to a plain non-definition list, used as the reflexive shape for *every* list, or leaned on hard in casual mediums (Slack, a personal-voice blog) where they read corporate.
+
+This skill owns *how to build a good list*. Voice owns *don't let it become a monotonous tic*. The sliding scale above is the dial that decides which.
+
+## Common mistakes
+
+- **Bullet-bombing** - a page of nothing but bullets is a wall too. Mix bullets into prose.
+- **Single-item lists** - a list of one isn't a list. Make it a sentence.
+- **Mixed grammatical forms** - audible the moment you read the list aloud.
+- **Over-bolding** - bold the load-bearing term, let supporting words support.
+- **Burying the lede** - conclusion first. Resist the academic build-up.
+- **Lists over ~8 items** - regroup into sub-lists or rethink. Emphasizing everything emphasizes nothing.
+
+## Going deeper
+
+- [references/scannable-writing-cheatsheet.md](references/scannable-writing-cheatsheet.md) - the one-page version: signals, the parallelism check, the F-pattern, a worked before/after, citations.
+- [references/scannable-writing-guide.md](references/scannable-writing-guide.md) - the full treatment: the empirical case (NN/g, F-pattern, satisficing), the inverted-pyramid history, five conversion patterns with before/afters, anti-patterns, and a reading list with inline citations. Read this when you want the *why* behind a rule or a richer set of examples.
+
+## The mantra
+
+If the prose is doing list work, let it be a list. If it's doing argument work, leave it. Front-load the load-bearing word. Make every bullet parallel. Bold the term, not the definition. Conclude first, explain second.

--- a/plugins/writing-tools/skills/writing-for-scannability/references/scannable-writing-cheatsheet.md
+++ b/plugins/writing-tools/skills/writing-for-scannability/references/scannable-writing-cheatsheet.md
@@ -1,0 +1,75 @@
+# Scannable Writing Cheat Sheet
+
+**Core premise:** Roughly 79% of readers scan, only 16% read word-by-word. Format prose so scanners get the gist and readers get the depth - without writing two versions.
+
+---
+
+## When to convert prose into a list
+
+Each signal below means a list is trying to escape the paragraph:
+
+- **Parallel sentence shapes** - "X is A. Y is B." or "First... Second... Also..."
+- **Contrast markers** - "that's distinct from", "as opposed to", "versus"
+- **Bold terms followed by colons** - you've already written a definition list in prose
+- **Three or more parallel items** - rule of three; almost always wants to be a list
+- **Embedded series in a sentence** - "create X, query Y, and delete Z"
+
+**The shape to reach for:** a one-sentence lead-in, then bullets, each starting with the load-bearing term.
+
+## When to leave prose alone
+
+Bullets strip connective tissue. Keep prose when:
+
+- **The connectives carry argument** - *counterintuitively*, *as a result*, *but only when*
+- **The flow is causal or narrative** - not enumerated
+- **The items are two and short** - naturally part of the sentence's rhythm
+- **The audience expects sustained reading** - long-form articles, narratives, persuasion
+
+**Rule of thumb:** if the prose is doing list work, let it be a list. If the prose is doing argument work, leave it.
+
+## The parallelism check
+
+Once you've decided on a list, every item must share the same grammatical shape:
+
+- **Same part of speech** - all nouns, all gerunds, or all infinitives
+- **Same tense and voice** - don't mix *reduces* with *improving*
+- **Roughly the same weight** - one-word items shouldn't share a list with full sentences
+- **Same opening shape** - *how an agent X*, *how an agent Y* (not *how an agent X*, *the way Y works*)
+
+Bad: *I like running, to swim, and cycling.*
+Good: *I like running, swimming, and cycling.*
+
+## What to emphasize (the F-pattern)
+
+Eye-tracking shows readers scan in an F: across the top, then down the left margin. So:
+
+- **Front-load the load-bearing word** in every bullet, heading, and paragraph
+- **Bold the term, not the definition** - *Workflow methodology - how a coding agent runs through...*
+- **Don't over-bold** - if everything is emphasized, nothing is
+- **Use one-idea-per-paragraph** - readers who skip past the first few words won't see the rest
+
+## Before / after
+
+**Before** (one wall of prose, structure buried):
+
+> Agent orchestration is overloaded. The working hypothesis is they mean workflow methodology: how a coding agent runs through Understand, Plan, Execute, Deliver, and Monitor+React. That's distinct from surface: how an agent gets invoked, deployed, chained, or run in parallel.
+
+**After** (labeled list, structure surfaced):
+
+> "Agent orchestration" is overloaded. Engineers usually mean one of two things:
+> - **Workflow methodology** - how a coding agent runs through Understand, Plan, Execute, Deliver, and Monitor+React.
+> - **Surface** - how an agent gets invoked, deployed, chained, or run in parallel.
+
+**Signals that fired:** parallel sentence shapes, a *"that's distinct from"* contrast marker, and bolded terms followed by colons.
+
+---
+
+### Further reading
+
+- Nielsen, [How Users Read on the Web](https://www.nngroup.com/articles/how-users-read-on-the-web/) - the foundational 79% / 16% finding
+- Morkes & Nielsen, [Concise, SCANNABLE, Objective](https://www.nngroup.com/articles/concise-scannable-and-objective-how-to-write-for-the-web/) - the 124% usability study
+- Google Tech Writing, [Lists and Tables](https://developers.google.com/tech-writing/one/lists-and-tables) - the clearest practical rules; parallelism requirements
+- Hurley, [Bullet point lists versus paragraphs](https://www.writingclearscience.com.au/bullet-point-lists-versus-paragraphs/) - statement-plus-examples heuristic
+- *Perspectives on Medical Education*, [The Power of Parallel Structure](https://pmc.ncbi.nlm.nih.gov/articles/PMC4673060/) - the grammar move underneath the bullets
+- Nielsen Norman, [F-Shaped Pattern of Reading](https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/) - what to front-load and why
+- Gearing, [Bullet Points vs Prose](https://lukegearing.blot.im/bullet-points-vs-prose) - useful counterpoint on when bullets *lose* meaning

--- a/plugins/writing-tools/skills/writing-for-scannability/references/scannable-writing-guide.md
+++ b/plugins/writing-tools/skills/writing-for-scannability/references/scannable-writing-guide.md
@@ -1,0 +1,188 @@
+# The Art of Scannable Writing
+
+A practical guide to formatting prose so readers can both skim and read deeply - drawn from thirty years of usability research, the journalism tradition that came before it, and the grammar move that quietly does most of the work.
+
+## Why this matters (the empirical case)
+
+The foundational claim is that people don't read web pages - they scan them. The headline finding comes from a 1997 study by John Morkes and Jakob Nielsen at the Nielsen Norman Group, which found that [79% of test users always scanned any new page they came across, and only 16% read word-by-word](https://www.nngroup.com/articles/how-users-read-on-the-web/). The same study found that rewriting Sun Microsystems' web pages to be [concise, scannable, and objective improved measured usability by 124%](https://www.nngroup.com/articles/concise-scannable-and-objective-how-to-write-for-the-web/) - far more than any single intervention alone.
+
+Subsequent research confirmed and tightened the picture. [2006 eye-tracking research](https://www.nngroup.com/articles/website-reading/) showed readers scanning pages in an F-shape: across the top, then a partial second line, then down the left margin. [2008 research quantified that users have time to read at most 28% of the words on an average page view](https://www.nngroup.com/articles/website-reading/). And in 2020, NN/g published a [400-page synthesis of three large eye-tracking studies spanning 13 years and over 500 participants](https://www.parentcenterhub.org/web-reading/) which concluded: the more things change, the more they stay the same. People still scan.
+
+Two cognitive principles converge to produce this behavior. The first is what Herbert Simon called **satisficing** - taking the first reasonable option rather than the optimal one - popularized for web design by [Steve Krug's *Don't Make Me Think*](https://en.wikipedia.org/wiki/Don't_Make_Me_Think). Readers don't optimize their reading; they hunt for "good enough" matches to what they came looking for and move on. The second is cognitive load: screen reading is [roughly 25% slower than paper](https://www.nngroup.com/articles/be-succinct-writing-for-the-web/), so readers compensate by reading less.
+
+The practical implication isn't "write shorter." It's: **format so the scanner gets the gist and the reader gets the depth, without writing two versions.**
+
+## A short history of the idea
+
+The pattern of front-loading important information is older than the web. The **inverted pyramid** - leading with the most essential facts, then descending in importance - emerged in American journalism in [the mid-19th century alongside the spread of the telegraph](https://en.wikipedia.org/wiki/Inverted_pyramid_(journalism)). One persuasive origin story traces its first clear use to [Secretary of War Edwin Stanton's April 15, 1865 telegram announcing Lincoln's assassination](https://www.poynter.org/reporting-editing/2003/birth-of-the-inverted-pyramid-a-child-of-technology-commerce-and-history/), which newspapers printed almost verbatim. Telegraphy made the structure necessary: transmission was expensive and unreliable, so the most important facts had to come first in case the wire was cut mid-message. The structure outlived the telegraph because it solves a deeper problem - it lets readers stop at any point and still walk away with the gist.
+
+The web inherited this directly. Nielsen's 1997 guidelines are essentially the inverted pyramid plus visual chunking: [highlighted keywords, meaningful sub-headings, bulleted lists, one idea per paragraph, conclusion first, half the word count of print](https://www.nngroup.com/articles/how-users-read-on-the-web/). Krug's 2000 book *Don't Make Me Think* added the user-side framing - readers don't read, they [scan, satisfice, and muddle through](https://en.wikipedia.org/wiki/Don't_Make_Me_Think) - and the matching design directive: design for scanning, not reading. The technical writing community then formalized the patterns into [explicit rules](https://developers.google.com/tech-writing/one/lists-and-tables): when to use a numbered list, when to bullet, how to keep items parallel.
+
+So the modern guidance is the convergence of three traditions: journalism's inverted pyramid, usability research, and technical communication practice. They all point in the same direction.
+
+## The core techniques
+
+### 1. Convert prose to a list when the structure is already there
+
+The first move is recognizing **latent structure** - prose that has list-shape hidden inside paragraph form. Each of these signals means a list is trying to escape:
+
+- **Parallel sentence shapes** - *"X is A. Y is B."* Each sentence has the same skeleton, signaling the items are siblings.
+- **Contrast markers** - *"that's distinct from"*, *"as opposed to"*, *"versus"*, *"on the other hand"*. These are arrows pointing at a contrast that bullets display better than prose.
+- **Bold terms followed by colons** - you've already written a definition list in prose. Marina Hurley calls these [statement-plus-examples paragraphs](https://www.writingclearscience.com.au/bullet-point-lists-versus-paragraphs/) and notes they convert almost mechanically.
+- **Three or more parallel items** - the rule of three. Two parallel items can stay in prose (*"she came, she saw, she conquered"* doesn't want bullets). Three or more usually do.
+- **Embedded series** - Google's tech-writing guide calls these [run-in lists](https://developers.google.com/tech-writing/one/lists-and-tables): *"the API enables callers to create X, query Y, and delete Z"*. Generally promote them to real lists.
+
+### 2. Keep prose when the connective tissue matters
+
+Bullets are lossy. They strip out the words that explain *why* items are next to each other. Keep prose when:
+
+- **Connectives carry argument** - *counterintuitively*, *and as a result*, *but only when*. These do real work that bullets can't represent.
+- **The flow is causal or narrative** - *"we tried X, which failed because Y, so we pivoted to Z"* is a story, not a list.
+- **The audience expects sustained reading** - long-form essays, narratives, persuasion. [UXmatters notes that increasing scannability isn't always the right move and can hurt long-form journalism](https://www.uxmatters.com/mt/archives/2015/06/scannability-principle-and-practice.php).
+- **The items are two and short** - naturally part of a sentence's rhythm.
+
+Luke Gearing's ["Bullet Points vs Prose"](https://lukegearing.blot.im/bullet-points-vs-prose) is a useful corrective: he rewrites his own bulleted text into prose and demonstrates how the bullets had been hiding voice and connective meaning.
+
+**Rule of thumb:** if the prose is doing list work, let it be a list. If the prose is doing argument work, leave it.
+
+### 3. Use parallel structure
+
+Once items are bullets, they must be **parallel** - same grammatical form. This is the grammar move underneath the visual one, and it's where most lists fall apart. The [*Perspectives on Medical Education* guide](https://pmc.ncbi.nlm.nih.gov/articles/PMC4673060/) gives the cleanest summary: each idea in a series should be written in a similar grammatical and stylistic form.
+
+What "parallel" actually means in practice:
+
+- **Same part of speech** - all nouns, all gerunds, all infinitives. *I like running, swimming, and cycling* (parallel) vs *I like running, to swim, and cycling* (mixed).
+- **Same tense and voice** - don't mix *reduces* (active present) with *improving* (gerund).
+- **Same opening shape** - when one bullet leads with a bolded term, every bullet should lead with a bolded term.
+- **Roughly the same weight** - one-word items shouldn't share a list with multi-sentence items.
+
+[Google's guide enforces this strictly](https://developers.google.com/tech-writing/one/lists-and-tables): items must be parallel in grammar, logical category, capitalization, and punctuation. Numbered lists in particular should [start with imperative verbs](https://developers.google.com/tech-writing/one/lists-and-tables): *Stop the server. Edit the config. Restart it.*
+
+The check is auditory as much as logical. [Faulty parallelism sounds wrong even when you can't articulate why](https://www.rabbitwitharedpen.com/blog/parallel-structure). Reading bullets out loud surfaces the breaks fast.
+
+### 4. Front-load the load-bearing word
+
+[Eye-tracking research shows readers scan in an F](https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/) - across the top of the page, then a shorter horizontal pass, then down the left margin. The implication for writing is that **the leftmost word of every bullet, heading, and paragraph is the most-seen word on the page**.
+
+Practical applications:
+
+- **Lead with the term, not the explanation** - *Workflow methodology - how a coding agent runs through...* rather than *How a coding agent runs through the stages is the workflow methodology...*
+- **Bold the term, not the definition** - bolding is for the load-bearing concept the scanner needs to find the right item, not the supporting text around it.
+- **Don't over-bold** - if everything is emphasized, nothing is. NN/g's research treats highlighted keywords [as one technique among several, not the whole strategy](https://www.nngroup.com/articles/how-users-read-on-the-web/).
+- **One idea per paragraph** - Nielsen specifically warns that [users will skip over any additional ideas if they're not caught by the first few words](https://www.nngroup.com/articles/how-users-read-on-the-web/). Don't bury a second concept in sentence three.
+
+### 5. Apply the inverted pyramid at every level
+
+The journalism move scales. The same "most important first, then descending detail" structure should apply to:
+
+- **The page** - conclusion in the opening paragraph; details follow.
+- **The section** - topic sentence first; elaboration follows.
+- **The paragraph** - main point in sentence one.
+- **The bullet** - load-bearing term first; the rest after.
+
+## A gallery of conversions
+
+Different patterns, different conversions. Here are five common shapes worth recognizing on sight.
+
+### Pattern 1: Labeled list (definitions in prose)
+
+The shape your original example took - two parallel terms each followed by a definition.
+
+> **Before:** Agent orchestration is overloaded. Engineers usually mean workflow methodology: how a coding agent runs through Understand, Plan, Execute, Deliver, and Monitor+React. That's distinct from surface: how an agent gets invoked, deployed, chained, or run in parallel.
+
+> **After:** "Agent orchestration" is overloaded. Engineers usually mean one of two things:
+> - **Workflow methodology** - how a coding agent runs through Understand, Plan, Execute, Deliver, and Monitor+React.
+> - **Surface** - how an agent gets invoked, deployed, chained, or run in parallel.
+
+Signals that fired: two parallel bolded terms with colons, *"that's distinct from"* contrast marker, two definitions with identical *"how an agent X"* structure.
+
+### Pattern 2: Embedded series (list hiding in a sentence)
+
+The "verb a, verb b, and verb c" shape inside a sentence. From [Google's tech-writing guide](https://developers.google.com/tech-writing/one/lists-and-tables):
+
+> **Before:** The API enables callers to create llamas, query alpacas, delete vicunas, and track dromedaries.
+
+> **After:** The API enables callers to:
+> - Create llamas
+> - Query alpacas
+> - Delete vicunas
+> - Track dromedaries
+
+Four parallel verb-noun pairs in a sentence almost always wants to be a list. Each item shorter? Maybe leave inline. Four or more parallel verbs? Promote.
+
+### Pattern 3: Steps (sequence matters)
+
+> **Before:** To reconfigure the server, you first stop it, then edit the configuration file, and finally restart it.
+
+> **After:** To reconfigure the server:
+> 1. Stop the server.
+> 2. Edit the configuration file.
+> 3. Restart the server.
+
+Numbered, not bulleted, because order matters. Each step is an imperative verb, matching Google's rule.
+
+### Pattern 4: Contrast (A vs B)
+
+> **Before:** While synchronous APIs block the caller until completion, asynchronous APIs return immediately and notify the caller via a callback or event.
+
+> **After:** The two API styles differ in how they hand control back to the caller:
+> - **Synchronous** - blocks the caller until the operation completes.
+> - **Asynchronous** - returns immediately and notifies the caller via a callback or event.
+
+The original *"while X, Y"* construction signals contrast. Bullets render the contrast visually.
+
+### Pattern 5: The negative example (when NOT to convert)
+
+> **Original (prose, correct as-is):** We initially tried a centralized gateway, but it became a bottleneck under load and, counterintuitively, made debugging harder because traces had to traverse it. So we moved to a peer-to-peer model.
+
+> **Bad conversion to bullets:**
+> - Initially tried centralized gateway
+> - Became a bottleneck under load
+> - Made debugging harder
+> - Moved to peer-to-peer model
+
+The bullet version loses *but*, *and*, *counterintuitively*, *because*, *so*. The relationships between items were the entire point. Leave it as prose.
+
+## Anti-patterns to avoid
+
+- **Bullet-bombing.** Pages of nothing but bullets become a wall just like prose does. [Bullets should be sprinkled into prose, not replace it](https://web.mit.edu/juggler/www/ocw/ocw_lectures/class01/lecture_lists.htm) - a mix of the two works best.
+- **Single-item lists.** A list of one isn't a list. Either find more items or write it as a sentence.
+- **Mixed grammatical forms within a list.** Audible immediately when read aloud.
+- **Over-bolding.** [If everything is emphasized, nothing is.](https://www.nngroup.com/articles/how-users-read-on-the-web/) Bold the load-bearing term; let the supporting words be supporting words.
+- **Clever sub-headings.** Nielsen specifically warns against [clever-rather-than-clear sub-headings](https://www.nngroup.com/articles/how-users-read-on-the-web/) - they fail readers scanning for keywords.
+- **Burying the lede.** The inverted pyramid says: conclusion first. Resist the academic-essay impulse to build up to it.
+- **Lists over 8 items.** [Technical writing guides converge on a 2-to-8 range](https://pressbooks.senecacollege.ca/technicalwriting/chapter/lists/). Past that, regroup into sub-lists or rethink the structure - emphasizing everything emphasizes nothing.
+
+## A mantra
+
+If the prose is doing list work, let it be a list. If the prose is doing argument work, leave it. Front-load the load-bearing word. Make every bullet parallel. Bold the term, not the definition. Conclude first; explain second.
+
+---
+
+## Further reading
+
+**Foundational research**
+
+- Nielsen, [How Users Read on the Web](https://www.nngroup.com/articles/how-users-read-on-the-web/) (1997) - the founding 79/16 study.
+- Morkes & Nielsen, [Concise, SCANNABLE, and Objective: How to Write for the Web](https://www.nngroup.com/articles/concise-scannable-and-objective-how-to-write-for-the-web/) (1997) - the Sun Microsystems usability study, the 124% improvement finding.
+- Nielsen, [F-Shaped Pattern of Reading on the Web](https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/) (2006) - the original eye-tracking research.
+- Nielsen, [Website Reading: It (Sometimes) Does Happen](https://www.nngroup.com/articles/website-reading/) (2013) - the 28% finding and a useful corrective.
+- Krug, [*Don't Make Me Think* (Revisited)](https://en.wikipedia.org/wiki/Don't_Make_Me_Think) (2014 ed.) - satisficing, scanning, billboard design.
+
+**Practical guides**
+
+- Google, [Lists and Tables](https://developers.google.com/tech-writing/one/lists-and-tables) - the clearest rule-set, with parallelism requirements.
+- Hurley, [Bullet point lists versus paragraphs](https://www.writingclearscience.com.au/bullet-point-lists-versus-paragraphs/) - the statement-plus-examples heuristic.
+- Seneca College, [Lists chapter, *Technical Writing Essentials*](https://pressbooks.senecacollege.ca/technicalwriting/chapter/lists/) - the five list types (bullet, numbered, in-sentence, labeled, nested).
+- UXmatters, [Scannability: Principle and Practice](https://www.uxmatters.com/mt/archives/2015/06/scannability-principle-and-practice.php) - when scannability is and isn't the right move.
+
+**The grammar move underneath**
+
+- *Perspectives on Medical Education*, [The Power of Parallel Structure](https://pmc.ncbi.nlm.nih.gov/articles/PMC4673060/) - short, practical, the cleanest summary.
+- Rabbit with a Red Pen, [Writing Parallel Structure](https://www.rabbitwitharedpen.com/blog/parallel-structure) - auditory heuristics and the four areas to check.
+
+**Counterpoints and historical context**
+
+- Gearing, [Bullet Points vs Prose](https://lukegearing.blot.im/bullet-points-vs-prose) - a writer rewriting his own bullets into prose.
+- Wikipedia, [Inverted pyramid (journalism)](https://en.wikipedia.org/wiki/Inverted_pyramid_(journalism)) - the structural ancestor.
+- Scanlan, [Birth of the Inverted Pyramid](https://www.poynter.org/reporting-editing/2003/birth-of-the-inverted-pyramid-a-child-of-technology-commerce-and-history/) (Poynter) - the Lincoln-telegram origin story and the telegraph context.


### PR DESCRIPTION
## Summary

New `writing-tools` plugin with one skill, `writing-for-scannability`. It covers the structural axis of writing, the part `elements-of-style` and voice skills leave alone: when to pull a buried list out of a wall of prose, how to front-load for the way people actually scan (the F-pattern), and how hard to lean on formatting depending on where the text is going. A tweet and a design doc want very different treatment.

- Came out of a research session on the NN/g scannable-writing tradition, the inverted pyramid, parallel structure, and the F-pattern. The full writeup ships as reference docs alongside the operational SKILL.md.
- Reconciles a real conflict: "bold-led bullets are good for scanning" versus "bold-first bullets are an AI tell." Bold-leading is right for genuine definition lists in docs, a tell when it's reflexive or used in casual chat. A sliding scale (reader-entry diversity by durability) is the dial.
- Composes with concision and voice skills instead of replacing them.

## Test plan

Handed fresh agents a buried-structure README paragraph and a casual Slack reply, with and without the skill, and never mentioned lists. With the skill, both runs surfaced the buried list in the doc and left the Slack reply as prose. Without it, both left the doc's structure buried. Does what it says.
