### PR TITLE
Bump cq plugin to 0.2.0 for subagent schema docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -74,7 +74,7 @@
         "path": "claude-plugin",
         "ref": "main"
       },
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "name": "taskwarrior",


### PR DESCRIPTION
## Summary

- Bumps the `cq` plugin to 0.2.0 so installed copies pull cq's updated skill docs.
- cq's `main` now indexes subagent transcripts ([technicalpickles/cq#5](https://github.com/technicalpickles/cq/pull/5)): the row-level views gained `is_sidechain` / `agent_id` / `agent_type` / `workflow_id`, and `sessions` added `subagent_count`. The plugin sources from cq's main via `git-subdir`, but the marketplace caches by version, so already-installed copies keep the stale `SKILL.md` schema docs until the version moves.

## Test plan

- Reinstall the plugin and confirm the cached `SKILL.md` View Schemas section lists the new tag columns and `subagent_count`.
