### PR TITLE
Bump cq plugin to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
         "path": "claude-plugin",
         "ref": "main"
       },
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     {
       "name": "taskwarrior",


### PR DESCRIPTION
## Summary

Bumps the `cq` marketplace entry to 0.3.0 to surface the skill update from [technicalpickles/cq#6](https://github.com/technicalpickles/cq/pull/6) (merged), which added timestamp-as-string, sandbox-cache, and stderr-piping gotchas to the cq skill.

cq is a `git-subdir` plugin pinned to `ref: main`, so its content already tracks upstream. This version bump is the signal consumers use to pick up the update.
