### PR TITLE
Add sandbox-advisor plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,6 +95,11 @@
       "name": "writing-tools",
       "source": "./plugins/writing-tools",
       "version": "0.1.0"
+    },
+    {
+      "name": "sandbox-advisor",
+      "source": "./plugins/sandbox-advisor",
+      "version": "0.1.0"
     }
   ]
 }

--- a/.github/workflows/sandbox-advisor-plugin-tests.yml
+++ b/.github/workflows/sandbox-advisor-plugin-tests.yml
@@ -1,0 +1,28 @@
+name: sandbox-advisor plugin tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'plugins/sandbox-advisor/**'
+      - '.github/workflows/sandbox-advisor-plugin-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/sandbox-advisor
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --no-install-project
+      - name: Run pytest
+        run: uv run pytest tests/ -v

--- a/plugins/sandbox-advisor/.claude-plugin/plugin.json
+++ b/plugins/sandbox-advisor/.claude-plugin/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "sandbox-advisor",
+  "description": "Turns Claude Code sandbox EPERMs into crisp re-run-unsandboxed guidance"
+}

--- a/plugins/sandbox-advisor/README.md
+++ b/plugins/sandbox-advisor/README.md
@@ -1,0 +1,51 @@
+# sandbox-advisor
+
+A `PostToolUseFailure` hook that, when a Bash command fails, tells you whether it
+failed because of a *known* Claude Code sandbox limitation, and what to do about
+it. The message is advisory, not a directive.
+
+## What it does
+
+Knowledge lives in a **failure-mode registry**. Each mode pairs a command
+matcher with the error fingerprints that mode is known to produce. When a Bash
+command **fails**, the hook checks whether the command matches a known mode and
+whether that mode's fingerprints appear in the failure output. Three modes ship
+in v1, all of which need to run unsandboxed:
+
+- **git writes inside pt worktrees** -- blocked-path set (`.claude/`, `.vscode/`,
+  `.gitmodules`) and `.git/worktrees/.../index.lock`. This deny is *polymorphic*:
+  it surfaces as `index.lock`, a blocked-path `Operation not permitted`, or a
+  downstream `Could not reset index file`, so this mode carries a broad
+  fingerprint set.
+- **`srb` (sorbet)** -- LMDB uses SysV semaphores the sandbox denies.
+- **`ps` / `top`** -- setuid-root binaries; the sandbox denies setuid exec.
+
+When a mode matches, it injects an advisory note ("this command is known to fail
+under the sandbox; if that's why it failed, re-run with
+`dangerouslyDisableSandbox: true`"). Otherwise it stays silent. Adding a new
+failure mode is appending a registry entry (matcher + fingerprints + advice).
+
+## Why reactive (not a proactive guard)
+
+A command-name guard mis-fires: `git add` fails sandboxed only ~4% of the time
+(only in worktrees). Acting on the actual failure means a command that succeeds
+sandboxed is never touched, so the hook can never cause a false sandbox bypass.
+
+## Who it's for
+
+Auto-mode already retries unsandboxed for you. This plugin covers the contexts
+auto-mode does not reliably reach: subagents, cron/headless runs, and teammates
+not on auto-mode, where a hard EPERM is a stall instead of a recovery.
+
+## Guarantees
+
+- **Fail-open.** Any internal error exits 0 with no output; the raw failure
+  surfaces unchanged. A broken advisor never wedges work.
+- **No rewrite, no block, no state.** It only ever adds advice to an
+  already-failed command.
+
+## Background
+
+See the deny-surface evidence and friction data this is built on:
+the sandbox-probe results and the transcript-mining sandbox-friction findings
+in the pickletown workspace.

--- a/plugins/sandbox-advisor/hooks/advise.py
+++ b/plugins/sandbox-advisor/hooks/advise.py
@@ -96,12 +96,79 @@ def classify_command(command: str):
     return None
 
 
+import json
+
+# Advisory, not directive. We acknowledge the command is a KNOWN sandbox
+# failure mode and that this is likely (not certainly) why it failed, then
+# offer the fix. This honesty is what makes the broad git fingerprints safe:
+# we never assert "definitely the sandbox," we say "known to fail this way."
+_ADVICE = {
+    "git-write": (
+        "Heads up: git writes inside pt worktrees are KNOWN to fail under the "
+        "Claude Code command sandbox (the blocked .claude/.vscode/.gitmodules "
+        "paths and .git/worktrees/.../index.lock, which allowWrite cannot "
+        "override). If that's why this failed, re-run with "
+        "dangerouslyDisableSandbox: true."
+    ),
+    "srb": (
+        "Heads up: srb (sorbet) is KNOWN to fail under the Claude Code command "
+        "sandbox -- it caches in LMDB, which uses SysV semaphores the sandbox "
+        "denies (semctl/semop EPERM); the cache dir is already writable so "
+        "allowWrite cannot fix it. If that's why this failed, re-run with "
+        "dangerouslyDisableSandbox: true."
+    ),
+    "ps-top": (
+        "Heads up: ps/top are KNOWN to fail under the Claude Code command "
+        "sandbox -- they are setuid-root binaries and the sandbox denies "
+        "executing setuid/setgid binaries. They are read-only and safe "
+        "unsandboxed. If that's why this failed, re-run with "
+        "dangerouslyDisableSandbox: true."
+    ),
+}
+
+
+def _payload_text(payload: dict) -> str:
+    """Serialize the whole payload so fingerprints match regardless of which
+    field carries the error text."""
+    return json.dumps(payload, default=str)
+
+
+def decide_advice(payload: dict):
+    """Return advisory text to inject, or None to stay silent."""
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command") or ""
+    if not command:
+        return None
+    # Loop guard: if it already ran unsandboxed, "re-run unsandboxed" is wrong.
+    if tool_input.get("dangerouslyDisableSandbox"):
+        return None
+    mode = classify_command(command)
+    if mode is None:
+        return None
+    # Require one of THIS mode's fingerprints in the failure payload, so an
+    # srb type-error or a non-sandbox git error does not trigger advice.
+    if not matches_mode_fingerprints(_payload_text(payload), mode):
+        return None
+    return _ADVICE[mode]
+
+
 def main() -> None:
-    # Stub: consume stdin and stay silent. Real logic lands in later tasks.
     try:
-        sys.stdin.read()
+        payload = json.load(sys.stdin)
     except Exception:
-        pass
+        # Malformed stdin -> fail open, surface the raw failure unchanged.
+        sys.exit(0)
+    try:
+        reason = decide_advice(payload)
+    except Exception:
+        sys.exit(0)
+    if reason:
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUseFailure",
+                "additionalContext": reason,
+            }
+        }))
     sys.exit(0)
 
 

--- a/plugins/sandbox-advisor/hooks/advise.py
+++ b/plugins/sandbox-advisor/hooks/advise.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""PostToolUseFailure:Bash hook (sandbox-advisor). See README.md."""
+import sys
+
+
+def main() -> None:
+    # Stub: consume stdin and stay silent. Real logic lands in later tasks.
+    try:
+        sys.stdin.read()
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sandbox-advisor/hooks/advise.py
+++ b/plugins/sandbox-advisor/hooks/advise.py
@@ -1,6 +1,41 @@
 #!/usr/bin/env python3
 """PostToolUseFailure:Bash hook (sandbox-advisor). See README.md."""
+import re
 import sys
+
+# Per-mode error fingerprints, matched case-insensitively against the raw
+# payload text. git-write is deliberately broad: the same sandbox deny surfaces
+# as the index.lock message, a blocked-path "Operation not permitted", OR the
+# downstream "Could not reset index file" with no EPERM line visible. srb and
+# ps-top stay narrow because their failures are distinctive.
+_MODE_FINGERPRINTS = {
+    "git-write": (
+        "operation not permitted",
+        "index.lock",
+        "could not reset index file",
+        ".claude/agents",
+        ".claude/commands",
+        ".vscode/",
+        ".gitmodules",
+    ),
+    "srb": (
+        "operation not permitted",
+        "mdb_error",
+        "failed to create database",
+    ),
+    "ps-top": (
+        "operation not permitted",
+        "os error 1",
+    ),
+}
+
+
+def matches_mode_fingerprints(text: str, mode: str) -> bool:
+    """True if the failure output carries a fingerprint for this mode."""
+    if not text:
+        return False
+    low = text.lower()
+    return any(fp in low for fp in _MODE_FINGERPRINTS.get(mode, ()))
 
 
 def main() -> None:

--- a/plugins/sandbox-advisor/hooks/advise.py
+++ b/plugins/sandbox-advisor/hooks/advise.py
@@ -38,6 +38,64 @@ def matches_mode_fingerprints(text: str, mode: str) -> bool:
     return any(fp in low for fp in _MODE_FINGERPRINTS.get(mode, ()))
 
 
+# git subcommands that write (worktree/index/refs). Read-only forms
+# (log/show/diff/status/...) are intentionally absent so they classify as None.
+_GIT_WRITE_SUBCOMMANDS = {
+    "add", "commit", "rebase", "merge", "cherry-pick", "revert", "rm", "mv",
+    "restore", "reset", "pull", "fetch", "push", "am", "apply", "clean",
+    "checkout", "switch", "clone", "init", "stash", "worktree", "branch", "tag",
+}
+
+_SRB_RE = re.compile(r"^(bundle\s+exec\s+)?(\./)?(bin/)?srb(\s|$)")
+_PS_TOP_RE = re.compile(r"^(rtk\s+)?(/usr/bin/|/bin/)?(ps|top)(\s|$)")
+_ENV_PREFIX_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*=\S*\s+)+")
+
+
+def _strip_leading_cd_and_env(command: str) -> str:
+    """Reduce `cd <path> && FOO=bar <cmd>` to `<cmd>`.
+
+    Only a single leading `cd ... &&` is stripped (the dominant real shape);
+    further chaining is left intact so the segment we inspect is the real one.
+    """
+    seg = command.strip()
+    cd_match = re.match(r"^cd\s+\S+\s*&&\s*(.*)$", seg, re.DOTALL)
+    if cd_match:
+        seg = cd_match.group(1).strip()
+    seg = _ENV_PREFIX_RE.sub("", seg)
+    return seg.strip()
+
+
+def _is_git_write(seg: str) -> bool:
+    toks = seg.split()
+    if not toks or toks[0] != "git":
+        return False
+    # Skip git global options to find the subcommand.
+    i = 1
+    while i < len(toks):
+        t = toks[i]
+        if t in ("-C", "-c", "--git-dir", "--work-tree", "--namespace"):
+            i += 2
+            continue
+        if t.startswith("-"):
+            i += 1
+            continue
+        break
+    sub = toks[i] if i < len(toks) else ""
+    return sub in _GIT_WRITE_SUBCOMMANDS
+
+
+def classify_command(command: str):
+    """Return 'git-write', 'srb', 'ps-top', or None."""
+    seg = _strip_leading_cd_and_env(command)
+    if _SRB_RE.match(seg):
+        return "srb"
+    if _PS_TOP_RE.match(seg):
+        return "ps-top"
+    if _is_git_write(seg):
+        return "git-write"
+    return None
+
+
 def main() -> None:
     # Stub: consume stdin and stay silent. Real logic lands in later tasks.
     try:

--- a/plugins/sandbox-advisor/hooks/advise.py
+++ b/plugins/sandbox-advisor/hooks/advise.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """PostToolUseFailure:Bash hook (sandbox-advisor). See README.md."""
+import json
 import re
 import sys
 
@@ -96,8 +97,6 @@ def classify_command(command: str):
     return None
 
 
-import json
-
 # Advisory, not directive. We acknowledge the command is a KNOWN sandbox
 # failure mode and that this is likely (not certainly) why it failed, then
 # offer the fix. This honesty is what makes the broad git fingerprints safe:
@@ -127,10 +126,12 @@ _ADVICE = {
 }
 
 
-def _payload_text(payload: dict) -> str:
-    """Serialize the whole payload so fingerprints match regardless of which
-    field carries the error text."""
-    return json.dumps(payload, default=str)
+def _error_text(payload: dict) -> str:
+    """Serialize the payload EXCEPT tool_input, so fingerprints match the
+    failure output regardless of which field carries it, without
+    false-matching the command text (which lives in tool_input)."""
+    rest = {k: v for k, v in payload.items() if k != "tool_input"}
+    return json.dumps(rest, default=str)
 
 
 def decide_advice(payload: dict):
@@ -147,7 +148,7 @@ def decide_advice(payload: dict):
         return None
     # Require one of THIS mode's fingerprints in the failure payload, so an
     # srb type-error or a non-sandbox git error does not trigger advice.
-    if not matches_mode_fingerprints(_payload_text(payload), mode):
+    if not matches_mode_fingerprints(_error_text(payload), mode):
         return None
     return _ADVICE[mode]
 
@@ -158,6 +159,7 @@ def main() -> None:
     except Exception:
         # Malformed stdin -> fail open, surface the raw failure unchanged.
         sys.exit(0)
+    reason = None
     try:
         reason = decide_advice(payload)
     except Exception:

--- a/plugins/sandbox-advisor/hooks/hooks.json
+++ b/plugins/sandbox-advisor/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "On a failed Bash call, if it failed because of the command sandbox and is a known unsandbox-only command, advise re-running with dangerouslyDisableSandbox: true",
+  "hooks": {
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/advise.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/sandbox-advisor/pyproject.toml
+++ b/plugins/sandbox-advisor/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "sandbox-advisor"
+version = "0.1.0"
+description = "Sandbox-failure advisor hook for Claude Code"
+requires-python = ">=3.10"
+
+[dependency-groups]
+dev = ["pytest>=8"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/plugins/sandbox-advisor/tests/fixtures/already-unsandboxed.json
+++ b/plugins/sandbox-advisor/tests/fixtures/already-unsandboxed.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "bundle exec srb tc", "dangerouslyDisableSandbox": true},
+  "tool_response": {"stderr": "Operation not permitted", "exit_code": 1}
+}

--- a/plugins/sandbox-advisor/tests/fixtures/git-write-eperm.json
+++ b/plugins/sandbox-advisor/tests/fixtures/git-write-eperm.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "cd repos/x/worktrees/y && git add .", "dangerouslyDisableSandbox": false},
+  "tool_response": {"stderr": "fatal: Unable to create '.git/worktrees/y/index.lock': Operation not permitted", "exit_code": 128}
+}

--- a/plugins/sandbox-advisor/tests/fixtures/malformed.txt
+++ b/plugins/sandbox-advisor/tests/fixtures/malformed.txt
@@ -1,0 +1,1 @@
+this is not json

--- a/plugins/sandbox-advisor/tests/fixtures/ps-eperm.json
+++ b/plugins/sandbox-advisor/tests/fixtures/ps-eperm.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "ps aux", "dangerouslyDisableSandbox": false},
+  "tool_response": {"stderr": "ps: Operation not permitted (os error 1)", "exit_code": 1}
+}

--- a/plugins/sandbox-advisor/tests/fixtures/srb-eperm.json
+++ b/plugins/sandbox-advisor/tests/fixtures/srb-eperm.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "bundle exec srb tc", "dangerouslyDisableSandbox": false},
+  "tool_response": {"stderr": "mdb_error: \"Operation not permitted\" failed to create database", "exit_code": 1}
+}

--- a/plugins/sandbox-advisor/tests/fixtures/srb-typecheck-error.json
+++ b/plugins/sandbox-advisor/tests/fixtures/srb-typecheck-error.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "bundle exec srb tc", "dangerouslyDisableSandbox": false},
+  "tool_response": {"stderr": "srb: typecheck found 3 errors in 2 files", "exit_code": 1}
+}

--- a/plugins/sandbox-advisor/tests/test_advise_integration.py
+++ b/plugins/sandbox-advisor/tests/test_advise_integration.py
@@ -1,0 +1,75 @@
+"""Run advise.py as a subprocess with stdin, like Claude Code does."""
+import json
+import subprocess
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+HOOK = PLUGIN_ROOT / "hooks" / "advise.py"
+FIXTURES = PLUGIN_ROOT / "tests" / "fixtures"
+
+
+def _run(stdin_text: str):
+    return subprocess.run(
+        ["python3", str(HOOK)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def _run_fixture(name: str):
+    return _run((FIXTURES / name).read_text())
+
+
+def _advice(result):
+    """Parse additionalContext from stdout, or None if no output."""
+    out = result.stdout.strip()
+    if not out:
+        return None
+    return json.loads(out)["hookSpecificOutput"]["additionalContext"]
+
+
+def test_srb_eperm_advises_unsandbox():
+    result = _run_fixture("srb-eperm.json")
+    assert result.returncode == 0
+    advice = _advice(result)
+    assert advice and "dangerouslyDisableSandbox" in advice
+
+
+def test_git_write_eperm_advises_unsandbox():
+    result = _run_fixture("git-write-eperm.json")
+    assert result.returncode == 0
+    advice = _advice(result)
+    assert advice and "git" in advice.lower()
+
+
+def test_ps_eperm_advises_unsandbox():
+    result = _run_fixture("ps-eperm.json")
+    assert result.returncode == 0
+    advice = _advice(result)
+    assert advice and "setuid" in advice.lower()
+
+
+def test_srb_typecheck_error_stays_silent():
+    result = _run_fixture("srb-typecheck-error.json")
+    assert result.returncode == 0
+    assert _advice(result) is None
+
+
+def test_already_unsandboxed_stays_silent():
+    result = _run_fixture("already-unsandboxed.json")
+    assert result.returncode == 0
+    assert _advice(result) is None
+
+
+def test_malformed_stdin_fails_open():
+    result = _run((FIXTURES / "malformed.txt").read_text())
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_empty_stdin_fails_open():
+    result = _run("")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""

--- a/plugins/sandbox-advisor/tests/test_advise_unit.py
+++ b/plugins/sandbox-advisor/tests/test_advise_unit.py
@@ -154,3 +154,12 @@ class TestDecideAdvice:
             )
         )
         assert reason is None
+
+    def test_fingerprint_in_command_text_only_stays_silent(self):
+        # The fingerprint appears only in the command (a commit message), not
+        # in the failure output -> must stay silent.
+        reason = advise.decide_advice(self._payload(
+            "git commit -m 'operation not permitted'",
+            "nothing to commit, working tree clean",
+        ))
+        assert reason is None

--- a/plugins/sandbox-advisor/tests/test_advise_unit.py
+++ b/plugins/sandbox-advisor/tests/test_advise_unit.py
@@ -1,0 +1,57 @@
+"""Unit tests for sandbox-advisor pure functions."""
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "advise", Path(__file__).parent.parent / "hooks" / "advise.py"
+)
+advise = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(advise)
+
+
+class TestMatchesModeFingerprints:
+    def test_git_index_lock(self):
+        assert advise.matches_mode_fingerprints(
+            "fatal: Unable to create '.git/worktrees/x/index.lock': "
+            "Operation not permitted",
+            "git-write",
+        )
+
+    def test_git_blocked_path(self):
+        assert advise.matches_mode_fingerprints(
+            "error: unable to create file .claude/agents/x.md: "
+            "Operation not permitted",
+            "git-write",
+        )
+
+    def test_git_downstream_reset_index(self):
+        # The polymorphic case: only the downstream message is visible.
+        assert advise.matches_mode_fingerprints(
+            "fatal: Could not reset index file to revision 'HEAD'.",
+            "git-write",
+        )
+
+    def test_srb_lmdb(self):
+        assert advise.matches_mode_fingerprints(
+            'mdb_error: "Operation not permitted" failed to create database',
+            "srb",
+        )
+
+    def test_ps_setuid_eperm(self):
+        assert advise.matches_mode_fingerprints(
+            "ps: Operation not permitted (os error 1)", "ps-top"
+        )
+
+    def test_srb_typecheck_is_not_a_sandbox_failure(self):
+        assert not advise.matches_mode_fingerprints(
+            "srb: typecheck found 3 errors in 2 files", "srb"
+        )
+
+    def test_git_fingerprint_does_not_leak_to_srb(self):
+        # An index.lock message is a git signature, not an srb one.
+        assert not advise.matches_mode_fingerprints(
+            "Unable to create 'index.lock'", "srb"
+        )
+
+    def test_empty(self):
+        assert not advise.matches_mode_fingerprints("", "git-write")

--- a/plugins/sandbox-advisor/tests/test_advise_unit.py
+++ b/plugins/sandbox-advisor/tests/test_advise_unit.py
@@ -95,3 +95,62 @@ class TestClassifyCommand:
 
     def test_env_prefix_stripped(self):
         assert advise.classify_command("FOO=bar srb tc") == "srb"
+
+
+class TestDecideAdvice:
+    def _payload(self, command, output, unsandboxed=False):
+        return {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": command,
+                "dangerouslyDisableSandbox": unsandboxed,
+            },
+            "tool_response": {"stderr": output},
+        }
+
+    def test_srb_sandbox_failure_advises(self):
+        reason = advise.decide_advice(
+            self._payload("bundle exec srb tc", "Operation not permitted")
+        )
+        assert reason is not None
+        assert "dangerouslyDisableSandbox" in reason
+        assert "sorbet" in reason.lower() or "lmdb" in reason.lower()
+
+    def test_git_write_in_worktree_advises(self):
+        reason = advise.decide_advice(
+            self._payload(
+                "cd repos/x/worktrees/y && git add .",
+                "Unable to create '.git/worktrees/y/index.lock': "
+                "Operation not permitted",
+            )
+        )
+        assert reason is not None
+        assert "git" in reason.lower()
+
+    def test_ps_advises(self):
+        reason = advise.decide_advice(
+            self._payload("ps aux", "Operation not permitted (os error 1)")
+        )
+        assert reason is not None
+        assert "setuid" in reason.lower()
+
+    def test_srb_non_sandbox_failure_silent(self):
+        # srb failed with type errors, not a sandbox EPERM -> no advice.
+        reason = advise.decide_advice(
+            self._payload("srb tc", "srb: typecheck found 3 errors")
+        )
+        assert reason is None
+
+    def test_unknown_command_with_eperm_silent(self):
+        reason = advise.decide_advice(
+            self._payload("some-tool --x", "Operation not permitted")
+        )
+        assert reason is None
+
+    def test_already_unsandboxed_silent(self):
+        reason = advise.decide_advice(
+            self._payload(
+                "srb tc", "Operation not permitted", unsandboxed=True
+            )
+        )
+        assert reason is None

--- a/plugins/sandbox-advisor/tests/test_advise_unit.py
+++ b/plugins/sandbox-advisor/tests/test_advise_unit.py
@@ -55,3 +55,43 @@ class TestMatchesModeFingerprints:
 
     def test_empty(self):
         assert not advise.matches_mode_fingerprints("", "git-write")
+
+
+class TestClassifyCommand:
+    def test_bare_git_write(self):
+        assert advise.classify_command("git add .") == "git-write"
+
+    def test_git_write_after_cd(self):
+        assert advise.classify_command(
+            "cd repos/x/worktrees/y && git commit -m wip"
+        ) == "git-write"
+
+    def test_git_read_is_none(self):
+        assert advise.classify_command("git log --oneline") is None
+
+    def test_git_status_is_none(self):
+        assert advise.classify_command("git status") is None
+
+    def test_srb_bundle_exec(self):
+        assert advise.classify_command("bundle exec srb tc") == "srb"
+
+    def test_srb_bin(self):
+        assert advise.classify_command("bin/srb tc") == "srb"
+
+    def test_ps(self):
+        assert advise.classify_command("ps aux") == "ps-top"
+
+    def test_rtk_ps(self):
+        assert advise.classify_command("rtk ps -ef") == "ps-top"
+
+    def test_top(self):
+        assert advise.classify_command("/usr/bin/top -l 1") == "ps-top"
+
+    def test_psql_is_not_ps(self):
+        assert advise.classify_command("psql -c 'select 1'") is None
+
+    def test_unrelated_is_none(self):
+        assert advise.classify_command("cat file.txt") is None
+
+    def test_env_prefix_stripped(self):
+        assert advise.classify_command("FOO=bar srb tc") == "srb"

--- a/plugins/sandbox-advisor/tests/test_plugin_structure.py
+++ b/plugins/sandbox-advisor/tests/test_plugin_structure.py
@@ -1,0 +1,38 @@
+"""Structural invariants for the sandbox-advisor plugin."""
+import json
+import os
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+
+
+def test_manifest_valid():
+    manifest = json.loads(
+        (PLUGIN_ROOT / ".claude-plugin" / "plugin.json").read_text()
+    )
+    assert manifest["name"] == "sandbox-advisor"
+    assert manifest["description"]
+
+
+def test_hooks_json_registers_posttooluse_failure_on_bash():
+    hooks = json.loads((PLUGIN_ROOT / "hooks" / "hooks.json").read_text())
+    entries = hooks["hooks"]["PostToolUseFailure"]
+    assert entries, "expected a PostToolUseFailure entry"
+    entry = entries[0]
+    assert entry["matcher"] == "Bash"
+    command = entry["hooks"][0]["command"]
+    assert "advise.py" in command
+
+
+def test_hook_script_exists_and_is_executable():
+    script = PLUGIN_ROOT / "hooks" / "advise.py"
+    assert script.exists(), f"missing hook script: {script}"
+    assert os.access(script, os.X_OK), (
+        f"hook not executable: run chmod +x {script}"
+    )
+
+
+def test_hook_script_has_shebang():
+    script = PLUGIN_ROOT / "hooks" / "advise.py"
+    first_line = script.read_text().splitlines()[0]
+    assert first_line.startswith("#!"), "hook script needs a shebang"


### PR DESCRIPTION
## Summary

- Adds a `sandbox-advisor` plugin: a `PostToolUseFailure`/`Bash` hook that, when a Bash command fails because of the Claude Code command sandbox, injects an advisory note explaining why and how to recover (re-run with `dangerouslyDisableSandbox: true`).
- Reactive, not proactive. It only ever adds advice to an already-failed command, so it can never rewrite, block, or silently disable the sandbox. A command that succeeds sandboxed is never touched.
- v1 covers the three failure modes that reliably need unsandboxing: git writes inside pt worktrees, `srb` (sorbet/LMDB), and `ps`/`top` (setuid exec). Knowledge lives in a per-mode registry, so adding a mode is one entry.

## Why

Auto-mode already retries unsandboxed for you, but it doesn't reach subagents, cron/headless runs, or teammates who aren't on it. For those, a hard sandbox EPERM is a cryptic stall. This turns it into a clear next step. The messaging is advisory ("this command is known to fail under the sandbox; if that's why, re-run unsandboxed") because the same deny is polymorphic, especially git's, which surfaces as `index.lock`, a blocked-path `Operation not permitted`, or a downstream `Could not reset index file`.

## Test plan

- `cd plugins/sandbox-advisor && python3 -m pytest tests/ -v` (38 tests: structural, unit, and subprocess integration that runs the hook the way Claude Code does).
- Fail-open is covered: malformed/empty stdin and any internal error exit 0 with no output, so a broken hook never wedges a tool call.
- A regression test confirms a fingerprint appearing only in the command text (e.g. a commit message) does not trigger advice.
