### PR TITLE
Bump cq plugin to 0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
         "path": "claude-plugin",
         "ref": "main"
       },
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     {
       "name": "taskwarrior",


### PR DESCRIPTION
Mirrors the cq plugin version bump (0.3.0 -> 0.3.1) into the marketplace entry.

cq#9 fixes a wrong claim in the cq skill (SKILL.md said `--since` works on `cq sql`, which it doesn't) and bumps plugin.json to 0.3.1. This keeps the marketplace entry in sync so consumers pick up the corrected skill.

The cq entry is a git-subdir source pinned to `ref: main`, so this lands once cq#9 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)