### PR TITLE
Fix validator's remote-plugin handling and CLAUDE.md scope rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,17 +130,21 @@ chore: update deps               # → no bump
 
 Scope must match `[a-z0-9-]+` (lowercase letters, numbers, hyphens only).
 
+**`feat`, `fix`, and `perf` REQUIRE a scope** (they change a specific plugin). The scope is a plugin name, or `repo` for repo-wide changes. `chore`, `ci`, `docs`, `style`, `test`, `refactor`, `build`, and `revert` may omit the scope. Enforced by `scripts/check-commit-scope.sh`.
+
 **Valid scopes:**
 - `feat(git): ...` - single plugin name
 - `fix(ci-cd-tools): ...` - plugin with hyphens
-- `fix: ...` - no scope (for cross-cutting changes)
+- `feat(repo): ...` - repo-wide change that isn't plugin-specific (tooling, CI, scripts)
+- `docs: ...` / `chore: ...` - no scope (non-functional types may omit it)
 
 **Invalid scopes:**
+- `fix: ...` - bare `feat`/`fix`/`perf` without a scope is rejected (use `fix(repo): ...`)
 - `fix(ci-cd-tools,dev-tools): ...` - commas not allowed
 - `fix(CI-CD): ...` - uppercase not allowed
 
 For changes touching multiple plugins, either:
-1. Use no scope: `fix: use markdown links in skills`
+1. Use the `repo` scope: `fix(repo): use markdown links in skills`
 2. Make separate commits per plugin
 
 **Bump versions in your PR.** Run `./scripts/bump-version.sh --auto` to apply the bumps that conventional commits imply, then commit the result as `chore(plugin): bump version to X.Y.Z`. The Version Check workflow blocks merge until pending bumps are applied.

--- a/scripts/validate-plugin-versions.sh
+++ b/scripts/validate-plugin-versions.sh
@@ -4,7 +4,8 @@
 #
 # Rules:
 # 1. plugin.json files must NOT contain "version" field (marketplace.json is source of truth)
-# 2. All plugins in marketplace.json must have a corresponding plugin.json
+# 2. All LOCAL plugins in marketplace.json must have a corresponding plugin.json
+#    (remote plugins with an object source live in another repo and are skipped)
 # 3. All plugin directories must have a plugin.json file
 # 4. All plugins with plugin.json must be registered in marketplace.json
 #
@@ -46,21 +47,23 @@ if [[ $errors -eq 0 ]]; then
 fi
 echo
 
-# Check 2: All plugins in marketplace.json have corresponding plugin.json
-echo "Checking marketplace.json plugins have plugin.json files..."
+# Check 2: All LOCAL plugins in marketplace.json have a corresponding plugin.json.
+# Remote plugins (source is an object: git-subdir/github/url/npm) live in another
+# repo, so they have no local plugin.json here and are skipped.
+echo "Checking local marketplace.json plugins have plugin.json files..."
 if [[ -f "$MARKETPLACE_JSON" ]]; then
-    marketplace_plugins=$(jq -r '.plugins[].name' "$MARKETPLACE_JSON" 2>/dev/null || echo "")
-    for plugin in $marketplace_plugins; do
+    local_plugins=$(jq -r '.plugins[] | select(.source | type == "string") | .name' "$MARKETPLACE_JSON" 2>/dev/null || echo "")
+    for plugin in $local_plugins; do
         plugin_json_path="$PLUGINS_DIR/$plugin/.claude-plugin/plugin.json"
         if [[ ! -f "$plugin_json_path" ]]; then
-            echo "  ERROR: Plugin '$plugin' in marketplace.json but no plugin.json at:"
+            echo "  ERROR: Local plugin '$plugin' in marketplace.json but no plugin.json at:"
             echo "         $plugin_json_path"
             errors=$((errors + 1))
         fi
     done
 
     if [[ $errors -eq 0 ]]; then
-        echo "  OK: All marketplace plugins have plugin.json files"
+        echo "  OK: All local marketplace plugins have plugin.json files"
     fi
 else
     echo "  WARNING: marketplace.json not found at $MARKETPLACE_JSON"


### PR DESCRIPTION
Two small cleanups that surfaced while doing #94.

## Summary

- `validate-plugin-versions.sh` was reporting remote git-subdir plugins (`cq`, `petri-dish`) as errors because it expected a local `plugin.json` for every marketplace entry. Those plugins live in their own repos, so the check now only applies to local (string-source) plugins. The script passes again as a pre-commit hook.
- CLAUDE.md's commit-scope rules contradicted the checker that enforces them: it listed bare `fix:` as valid for cross-cutting changes, but `check-commit-scope.sh` requires `feat`/`fix`/`perf` to carry a scope (`repo` for repo-wide work). This is what tripped #94. The doc now matches enforcement.

## Test plan

- `./scripts/validate-plugin-versions.sh` → PASSED (no more cq/petri-dish errors)
- `./scripts/check-commit-scope.sh` accepts `fix(repo): ...`, rejects bare `fix: ...`
