### PR TITLE
Park commits the handoff it writes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "2.1.0"
+      "version": "2.2.0"
     },
     {
       "name": "buildkite",

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: park
 description: Save current work context for later resumption
-allowed-tools: Bash(scripts/get-session-id.sh)
+allowed-tools: Bash(scripts/get-session-id.sh), Bash(scripts/commit-handoff.sh:*)
 ---
 
 # Park
@@ -111,6 +111,18 @@ Surface candidates for beans, but DO NOT auto-create them.]
 Filename: `[topic-slug]-wrapped.md`
 
 Close-out has no Resume Prompt and no Next Steps. If you find yourself wanting to write either, the work is probably a continuation: re-check the mode.
+
+## Commit the Handoff
+
+Applies to both modes. After the file is written, commit it at its source so the handoff doesn't sit as uncommitted noise in the work tree (and survives a hard kill of the session). Run:
+
+```
+scripts/commit-handoff.sh <handoff-path> "<commit-message>"
+```
+
+- Single file, commit only, **no push**. The script scopes the commit to just the handoff, so a dirty index around it is fine.
+- It is **fail soft**: if the path is gitignored (the default `.parkinglot/` is), not in a git work tree, or already committed, it skips silently and never breaks the park. Do not retry or treat a skip as an error.
+- Commit message: you have the narrative context, so pass a real one. Continuation → `docs: park handoff <topic-slug>`; close-out → `docs: wrap handoff <topic-slug>`. If you omit it, the script defaults to `docs: park handoff <filename>`. (`docs:` needs no scope and is safe across repos; if the target repo enforces a different convention, match it.)
 
 ## After Parking
 

--- a/plugins/agent-meta/skills/park/scripts/commit-handoff.sh
+++ b/plugins/agent-meta/skills/park/scripts/commit-handoff.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Commit a freshly-written park handoff at its source: single file, commit only
+# (no push), fail soft. A git hiccup must never break the park itself, so every
+# bail-out path exits 0.
+#
+# Usage: commit-handoff.sh <handoff-path> [commit-message]
+#
+# Skips silently (exit 0) when the file is gitignored (the default .parkinglot/
+# is gitignored on purpose), not inside a git work tree, or has nothing staged.
+# Mirrors `pt beans` auto-commit: pathspec on both add and commit so the commit
+# stays scoped to this one file even if the rest of the index is dirty.
+
+set -u
+unset CDPATH  # keep `cd` from jumping elsewhere if the caller has CDPATH set
+
+file="${1:-}"
+[ -n "$file" ] || { echo "commit-handoff: no path given, skipping" >&2; exit 0; }
+[ -f "$file" ] || { echo "commit-handoff: no such file: $file" >&2; exit 0; }
+
+dir=$(cd -- "$(dirname -- "$file")" 2>/dev/null && pwd) || {
+  echo "commit-handoff: cannot resolve dir for $file, skipping" >&2; exit 0; }
+base=$(basename -- "$file")
+msg="${2:-docs: park handoff $base}"
+
+git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "commit-handoff: $dir is not a git work tree, skipping" >&2; exit 0; }
+
+# Respect .gitignore. The default parking location (.parkinglot/) is gitignored,
+# so committing there is neither possible nor wanted.
+if git -C "$dir" check-ignore -q -- "$file"; then
+  echo "commit-handoff: $base is gitignored, skipping commit" >&2; exit 0
+fi
+
+git -C "$dir" add -- "$file" 2>/dev/null || {
+  echo "commit-handoff: git add failed, skipping" >&2; exit 0; }
+
+# No staged change for this path (already committed / unchanged): no empty commit.
+if git -C "$dir" diff --cached --quiet -- "$file" 2>/dev/null; then
+  echo "commit-handoff: nothing to commit for $base" >&2; exit 0
+fi
+
+if git -C "$dir" commit --quiet -m "$msg" -- "$file" 2>/dev/null; then
+  echo "commit-handoff: committed $base"
+else
+  echo "commit-handoff: git commit failed, skipping" >&2
+fi
+exit 0


### PR DESCRIPTION
## Summary

park writes a handoff and then walks away, so the file just sits there uncommitted until something else sweeps it in. This makes park commit the handoff it just wrote: a new `scripts/commit-handoff.sh` that commits the single file at its source, no push.

- It's fail soft. If the path is gitignored (the default `.parkinglot/` is), not in a git work tree, or already committed, it skips silently and never breaks the park.
- Scoped pathspec on add and commit, so a dirty index around the handoff is fine. Mirrors the `pt beans` auto-commit pattern.
- The handoff now also survives a hard kill of the session, instead of being lost with the working tree.

## Test plan

`scripts/commit-handoff.sh` was exercised against a throwaway repo: fresh handoff in a tracked dir commits, a re-run makes no empty commit, a gitignored path skips, outside-a-repo and missing-arg both exit 0. `sh -n` parses clean.
