### PR TITLE
Consume Johnny Decimal destinations in second-brain routing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.8.1"
+      "version": "1.9.0"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/skills/obsidian/references/johnny-decimal.md
+++ b/plugins/second-brain/skills/obsidian/references/johnny-decimal.md
@@ -1,0 +1,107 @@
+# Johnny Decimal Reference
+
+Johnny Decimal is an organizational system by David Thornton. It numbers folders so every note has a short, stable address. Many Obsidian vaults use it instead of (or alongside) PARA.
+
+## The Three Levels
+
+Johnny Decimal has exactly three folder levels. Depth stops at the ID level: there is no `NN.NN.NN`.
+
+### Areas
+
+**Definition:** A broad range of related topics. The widest grouping, a drawer of drawers.
+
+**Shape:** `NN-NN ` (a number range, hyphen, then a name)
+
+**Characteristics:**
+- Spans ten possible categories (e.g. `60-69` reserves categories `60` through `69`)
+- Names a domain, not a specific thing
+- Holds categories, never loose notes directly
+
+**Examples:**
+- `60-69 Software & Engineering`
+- `10-19 Life Admin`
+- `30-39 Finances`
+
+**In Obsidian:** A top-level folder whose name starts with a range like `60-69 `.
+
+---
+
+### Categories
+
+**Definition:** A single drawer inside an area. The everyday unit you file into.
+
+**Shape:** `NN ` (two digits, a space, then a name)
+
+**Characteristics:**
+- Belongs to exactly one area (category `67` lives in area `60-69`)
+- Holds **both** loose notes AND ID subfolders
+- The right home for a general or loose note about the category's topic
+
+**Examples:**
+- `67 Tools & developer experience`
+- `11 Health`
+- `32 Taxes`
+
+**In Obsidian:** A folder inside an area whose name starts with two digits and a space, like `67 `.
+
+---
+
+### IDs
+
+**Definition:** A specific-thing folder inside a category. The most precise address.
+
+**Shape:** `NN.NN ` (the category number, a dot, two more digits, then a name)
+
+**Characteristics:**
+- Belongs to exactly one category (`67.01` lives in category `67`)
+- Holds zettel notes; this is a leaf, it has no deeper subfolders
+- The right home for a note about that one specific thing
+
+**Examples:**
+- `67.01 git`
+- `67.02 docker`
+- `11.03 sleep`
+
+**In Obsidian:** A folder inside a category whose name starts with `NN.NN `, like `67.01 `.
+
+---
+
+## Decision Flow
+
+When deciding where a note goes:
+
+```
+Which area's topic range does this belong to?
+└── Within that area, which category (drawer) fits?
+    └── Is the note about one specific thing that has (or deserves) its own ID folder?
+        ├── Yes → route to the ID folder (NN.NN ...)
+        └── No  → route to the category folder (NN ...), as a loose note
+```
+
+**The core heuristic:** specific note goes to an ID, loose/general note stays at the category.
+
+A note titled "git rebase onto vs merge" belongs in `67.01 git` (specific). A note titled "thoughts on developer tooling in general" belongs at `67 Tools & developer experience` (loose). Prefer an ID destination over its parent category when the note is clearly about that one thing.
+
+## How the Levels Compare
+
+| Level | Shape | Example | Holds | Route here when |
+|-------|-------|---------|-------|-----------------|
+| Area | `NN-NN ` (range, hyphen) | `60-69 Software & Engineering` | categories | (never routed to directly) |
+| Category | `NN ` (two digits, space) | `67 Tools & developer experience` | loose notes AND ID subfolders | the note is loose/general for the drawer |
+| ID | `NN.NN ` (dot) | `67.01 git` | zettel notes (leaves) | the note is about that one specific thing |
+
+You route notes to **categories** and **IDs**. Areas are the addressing scaffold; nothing files directly into an area.
+
+## Discovering Structure
+
+`sb vault structure` is the source of truth for which folders exist and what they are. For Johnny Decimal vaults it emits each destination with:
+
+- `type: 'jd'` - marks the destination as Johnny Decimal (vs PARA)
+- `code` - the number: `67` for a category, `67.01` for an ID
+- `area` - the raw area folder name the destination sits under (e.g. `60-69 Software & Engineering`)
+
+The sb side emits both a category and its IDs as a flat list, so routing picks granularity per note by scoring (see [routing.md](routing.md)). Never guess at numbers or paths; only suggest destinations that appear in `sb vault structure` output.
+
+## Coexisting with PARA
+
+A vault mid-migration can hold both Johnny Decimal and PARA folders at once. `sb vault structure` tags each destination's `type` so routing can score them side by side. Don't assume a vault is one or the other; route to whatever exists. See [para.md](para.md) for the PARA side.

--- a/plugins/second-brain/skills/obsidian/references/routing.md
+++ b/plugins/second-brain/skills/obsidian/references/routing.md
@@ -8,28 +8,25 @@ Systematic algorithm for discovering vault structure and matching notes to desti
 
 **Never guess at paths.** Only suggest destinations that actually exist.
 
-```bash
-# List actual PARA folders (handle emoji prefixes)
-ls -d "{vault}"/*Projects*/*/  2>/dev/null
-ls -d "{vault}"/*Areas*/*/     2>/dev/null
-ls -d "{vault}"/*Resources*/*/ 2>/dev/null
-```
+Run `sb vault structure` (see [sb-cli.md](sb-cli.md) for invocation). It is the deterministic source of truth for which folders exist and what each one is. It returns destinations as JSON, each carrying a `type` and (for Johnny Decimal vaults) `code`/`area` metadata:
 
-Build a destination map from the output:
+- **PARA destinations** look like `{ type: 'para', path: 'Areas/health/' }`. See [para.md](para.md).
+- **Johnny Decimal destinations** look like `{ type: 'jd', code: '67', area: '60-69 Software & Engineering', path: '60-69 Software & Engineering/67 Tools & developer experience/' }` for a category, or `code: '67.01'` for an ID. See [johnny-decimal.md](johnny-decimal.md).
+
+A vault mid-migration can return both types; route to whatever exists. Build a destination map from the output:
 
 ```
 Available Destinations:
-- Areas/AI/agentic development/
-- Areas/gusto/
-- Areas/health/
-- Resources/software engineering/
-- Resources/tools/
-- Projects/home-renovation/
+- Areas/AI/agentic development/            (para)
+- Areas/health/                            (para)
+- Resources/software engineering/          (para)
+- 60-69 Software & Engineering/67 Tools & developer experience/        (jd, code 67)
+- 60-69 Software & Engineering/67 Tools & developer experience/67.01 git/   (jd, code 67.01)
 ```
 
 **Important:**
-- Use exact folder names from `ls` output (including emoji prefixes)
-- Only go two levels deep (Category/Subcategory/)
+- Use exact folder names and paths from the `sb vault structure` output (including emoji or number prefixes)
+- Respect each system's depth: PARA goes two levels (Category/Subcategory/); Johnny Decimal goes to the ID level (Area/Category/ID/, e.g. `60-69 .../67 .../67.01 git/`). Don't invent paths deeper than the JD ID level.
 - Include Inbox as always-available option
 
 ---
@@ -154,8 +151,16 @@ Apply baseline scoring to all destinations:
 |--------|--------|-------------|
 | Keyword in folder name | 40% | Direct match: "claude" in title → "AI/agentic development/" |
 | Related notes in folder | 30% | Grep for similar terms in destination folder |
-| PARA category fit | 20% | Is this ongoing (Area), reference (Resource), or active (Project)? |
+| Area/category fit | 20% | Does the note's topic match the destination's container? (see below) |
 | Recency | 10% | Recently modified files in folder suggest active use |
+
+#### Area/category fit
+
+This signal scores how well the note's topic matches the destination's containing group, using the `type` of each destination from `sb vault structure`:
+
+- **Johnny Decimal destinations** (`type: 'jd'`): does the note's topic match the destination's `area` and `code`? A note about developer tooling matches an `area` of `60-69 Software & Engineering`, so categories/IDs under that area score up. Within a matching category, prefer granularity by note specificity: a specific note (clearly about one thing) should score the matching **ID** destination (`code: 67.01`) above its parent **category** (`code: 67`); a loose/general note should score the **category** above its IDs. See [johnny-decimal.md](johnny-decimal.md).
+- **PARA destinations** (`type: 'para'`): is this ongoing (Area), reference (Resource), or active (Project)? See [para.md](para.md).
+- **Mixed vaults:** score each destination by its own `type`. A note can match a JD category and a PARA Area at once; let the other signals and any disambiguation rules break the tie.
 
 ### 4c: Combine Scores
 
@@ -181,6 +186,15 @@ Final score = Generic score + Disambiguation adjustments
 - Key question: "Is this about MY machine?" → Yes → +25%
 - Final: `Areas/tool sharpening/` → 120% (capped at 95%)
 - Final: `Resources/programming/` → 35% (disambiguation mismatch: -20%)
+
+**Johnny Decimal granularity:** `202602031300 git rebase onto vs merge.md`
+- Keywords: "git", "rebase", "merge"
+- Category: Tool configuration / specific tool
+- `sb vault structure` returns both `67 Tools & developer experience/` (code 67) and `67.01 git/` (code 67.01) under area `60-69 Software & Engineering`
+- This note is about one specific thing (git), so the ID scores above its parent category:
+  - `60-69 .../67 .../67.01 git/` → 90% (area/category fit + specific match)
+  - `60-69 .../67 Tools & developer experience/` → 60% (right drawer, but loose-note fit)
+- A looser note ("thoughts on developer tooling") would flip this: the category scores above its IDs.
 
 ---
 
@@ -247,12 +261,11 @@ When implementing routing in a command:
 ```markdown
 ## Routing Analysis
 
-1. Discover destinations:
+1. Discover destinations with `sb vault structure` (see [sb-cli.md](sb-cli.md)):
    ```bash
-   ls -d "{vault}"/*Areas*/*/
-   ls -d "{vault}"/*Resources*/*/
-   ls -d "{vault}"/*Projects*/*/
+   npx @techpickles/sb vault structure
    ```
+   Use the returned paths and their `type`/`code`/`area` metadata; never guess at paths.
 
 2. For each note, extract signals (keywords, category, source)
 
@@ -282,12 +295,12 @@ When implementing routing in a command:
 
 ## Constraints
 
-- **Never suggest non-existent paths** - Only paths from `ls` output
+- **Never suggest non-existent paths** - Only paths from `sb vault structure` output
 - **Always include inbox option** - Safe default for uncertain cases
 - **Show reasoning** - Users should understand why
-- **Two-level depth max** - Don't suggest `Area/Sub/Sub/Sub/`
+- **Respect each system's depth** - PARA goes two levels (`Area/Sub/`); Johnny Decimal goes to the ID level (`Area/Category/ID/`, e.g. `60-69 .../67 .../67.01 git/`). Don't suggest paths deeper than the JD ID level.
 - **Preserve filenames** - Don't rename when moving
-- **Respect emoji prefixes** - Use exact folder names from filesystem
+- **Respect prefixes** - Use exact folder names from `sb vault structure` (emoji prefixes for PARA, number prefixes for Johnny Decimal)
 
 ---
 

--- a/plugins/second-brain/skills/obsidian/references/routing.md
+++ b/plugins/second-brain/skills/obsidian/references/routing.md
@@ -10,16 +10,16 @@ Systematic algorithm for discovering vault structure and matching notes to desti
 
 Run `sb vault structure` (see [sb-cli.md](sb-cli.md) for invocation). It is the deterministic source of truth for which folders exist and what each one is. It returns destinations as JSON, each carrying a `type` and (for Johnny Decimal vaults) `code`/`area` metadata:
 
-- **PARA destinations** look like `{ type: 'para', path: 'Areas/health/' }`. See [para.md](para.md).
+- **PARA destinations** carry one of three types, `area`, `resource`, or `project`, e.g. `{ type: 'area', path: 'Areas/health/' }`. See [para.md](para.md).
 - **Johnny Decimal destinations** look like `{ type: 'jd', code: '67', area: '60-69 Software & Engineering', path: '60-69 Software & Engineering/67 Tools & developer experience/' }` for a category, or `code: '67.01'` for an ID. See [johnny-decimal.md](johnny-decimal.md).
 
 A vault mid-migration can return both types; route to whatever exists. Build a destination map from the output:
 
 ```
 Available Destinations:
-- Areas/AI/agentic development/            (para)
-- Areas/health/                            (para)
-- Resources/software engineering/          (para)
+- Areas/AI/agentic development/            (area)
+- Areas/health/                            (area)
+- Resources/software engineering/          (resource)
 - 60-69 Software & Engineering/67 Tools & developer experience/        (jd, code 67)
 - 60-69 Software & Engineering/67 Tools & developer experience/67.01 git/   (jd, code 67.01)
 ```
@@ -159,7 +159,7 @@ Apply baseline scoring to all destinations:
 This signal scores how well the note's topic matches the destination's containing group, using the `type` of each destination from `sb vault structure`:
 
 - **Johnny Decimal destinations** (`type: 'jd'`): does the note's topic match the destination's `area` and `code`? A note about developer tooling matches an `area` of `60-69 Software & Engineering`, so categories/IDs under that area score up. Within a matching category, prefer granularity by note specificity: a specific note (clearly about one thing) should score the matching **ID** destination (`code: 67.01`) above its parent **category** (`code: 67`); a loose/general note should score the **category** above its IDs. See [johnny-decimal.md](johnny-decimal.md).
-- **PARA destinations** (`type: 'para'`): is this ongoing (Area), reference (Resource), or active (Project)? See [para.md](para.md).
+- **PARA destinations** (`type: 'area'`, `'resource'`, or `'project'`): is this ongoing (Area), reference (Resource), or active (Project)? See [para.md](para.md).
 - **Mixed vaults:** score each destination by its own `type`. A note can match a JD category and a PARA Area at once; let the other signals and any disambiguation rules break the tie.
 
 ### 4c: Combine Scores

--- a/plugins/second-brain/skills/obsidian/references/sb-cli.md
+++ b/plugins/second-brain/skills/obsidian/references/sb-cli.md
@@ -34,7 +34,7 @@ Or install globally for faster execution: npm i -g @techpickles/sb
 ### Vault
 - `npx @techpickles/sb vault info` - vault metadata
 - `npx @techpickles/sb vault obsidian` - parse .obsidian config as JSON
-- `npx @techpickles/sb vault structure` - discover PARA folders as JSON
+- `npx @techpickles/sb vault structure` - discover routable destinations (PARA and/or Johnny Decimal) as JSON, each tagged with a `type`
 
 ### Notes
 - `npx @techpickles/sb note create --source auto --title "..."` - create note scaffold in inbox (frontmatter + heading, returns path as JSON)

--- a/plugins/second-brain/skills/route/SKILL.md
+++ b/plugins/second-brain/skills/route/SKILL.md
@@ -16,6 +16,7 @@ Analyze an enriched note against routing memory, vault rules, and generic signal
 
 See `references/pipeline.md` for stage definitions and status flow.
 See `references/routing.md` for the scoring algorithm.
+See `references/para.md` and `references/johnny-decimal.md` for the two folder systems a vault may use (often both, mid-migration).
 See `references/routing-memory.md` for the correction and learning loop.
 
 ## Input
@@ -35,6 +36,8 @@ An enriched note in the inbox with `status: enriched`.
    b. Check `.routing-memory.md` learned patterns
    c. Apply vault CLAUDE.md disambiguation rules
    d. Apply generic signal scoring (per `references/routing.md`)
+
+   Each destination from `sb vault structure` carries a `type`. For Johnny Decimal destinations (`type: 'jd'`) also use `area` and `code` when scoring: match the note's topic to the `area`, and prefer an ID `code` (e.g. `67.01`) for a specific note or its parent category `code` (e.g. `67`) for a loose note. See `references/johnny-decimal.md`.
 
 3. Apply threshold:
    - Score >= `auto-route-threshold`: auto-route, move file, set `status: routed`
@@ -61,6 +64,7 @@ When the user picks a destination different from the top suggestion:
    - {YYYY-MM-DD}: "{note title}" routed to "{suggested}", corrected to "{chosen}"
      Reason: {user's reason}
    ```
+   For Johnny Decimal destinations, key the correction on the JD `code` (e.g. "corrected to 67.01") so the learning loop can match by number, not just folder name.
 
 ## Output
 


### PR DESCRIPTION
## Summary

- The `sb` CLI started emitting Johnny Decimal destinations (areas, categories, IDs) with `type`/`code`/`area` metadata, but the routing layer was still PARA-only, so none of it got used. This teaches second-brain to actually consume it.
- Discovery now reads `sb vault structure` instead of raw PARA `ls -d` globs. The globs never matched numbered JD folders like `60-69 .../`, and they already contradicted `route/SKILL.md`, which said to use `sb vault structure`.
- Depth and scoring now split by system: PARA stays two levels, JD goes to the ID level (`Area/Category/ID/`). The old "PARA category fit" signal becomes "area/category fit" that scores JD destinations by `area`/`code` and picks ID-vs-category by how specific the note is.
- New `johnny-decimal.md` reference, sibling to `para.md`, so the agent understands areas-vs-categories-vs-IDs. PARA routing is unchanged, and a vault mid-migration gets both.

## Test plan

There's no automated harness for skill markdown, so this is grep-and-eyeball: `routing.md` no longer mentions `ls -d`, "two-level depth", or "PARA category fit"; `johnny-decimal.md` exists; PARA examples still read correctly. `check-commit-scope.sh` and `validate-plugin-versions.sh` both pass with the `feat(second-brain)` commit and the 1.9.0 bump.

## Follow-up work

`plugins/second-brain/skills/obsidian/references/sb-cli.md:37` still describes `vault structure` as discovering "PARA folders" (it's PARA + JD now). Left out to keep this diff scoped, it's a one-liner.
