### PR TITLE
Add harness-binary-spelunking skill to agent-meta

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "2.1.0"
+      "version": "2.2.0"
     },
     {
       "name": "buildkite",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "2.2.0"
+      "version": "2.3.0"
     },
     {
       "name": "buildkite",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See individual plugin READMEs for details on what each plugin provides.
 | Plugin | Description | Skills |
 |--------|-------------|--------|
 | [actually-lsp](plugins/actually-lsp) | Closes the LSP activation gap end-to-end (detection, setup, activation, failure diagnosis) for Rust, TypeScript, and Ruby projects | actually-lsp-doctor, actually-lsp-ignore |
-| [agent-meta](plugins/agent-meta) | Meta-development tools for agentic workflows | park, snapshot, unpark |
+| [agent-meta](plugins/agent-meta) | Meta-development tools for agentic workflows | harness-binary-spelunking, park, snapshot, unpark |
 | [buildkite](plugins/buildkite) | Buildkite CI tools: build investigation, pipeline development, and tool preference enforcement | developing-pipelines, investigating-builds |
 | [ci-cd-tools](plugins/ci-cd-tools) | CI/CD pipeline tools and integrations | fixing-ci |
 | [cq](https://github.com/technicalpickles/cq) | Query past Claude Code sessions via the cq CLI (SQL over session transcripts) | [see repo](https://github.com/technicalpickles/cq) |

--- a/docs/specs/2026-06-26-binary-spelunking-design.md
+++ b/docs/specs/2026-06-26-binary-spelunking-design.md
@@ -1,0 +1,148 @@
+# Design: `binary-spelunking` skill
+
+**Date:** 2026-06-26
+**Status:** Approved (brainstorming), pending implementation plan
+**Branch:** `harness-binary-spelunking` (evolving the open PR #99 in place)
+
+## Context
+
+PR #99 added a Claude-Code-specific `harness-binary-spelunking` skill to the
+`agent-meta` plugin: how to read string constants out of the Claude Code CLI
+binary (a Bun-compiled Mach-O) with `strings` + `grep`. The technique is not
+actually Claude-specific. It generalizes to any single-file binary that embeds
+its logic as string constants. This design evolves that unmerged work into a
+general `binary-spelunking` skill, adds reproducibility scripts, and relocates
+it to the `dev-tools` plugin.
+
+## Decisions (resolved during brainstorming)
+
+1. **One general skill, Claude as the anchor example** (not two layered skills).
+2. **Technique-first, any binary**: lead with the universal method, then
+   bundle-specific recipes as the concrete instantiation.
+3. **A few focused POSIX scripts** for the fiddly/error-prone steps (not a full
+   CLI, not just the strings dump).
+4. **Evolve PR #99 in place** (don't ship `harness-binary-spelunking` then
+   rename it).
+5. **Home + name:** move to `dev-tools`, name `binary-spelunking`.
+6. **Claude-specific knowledge** (Piebald shortcut, anchor catalog, real-world
+   investigation writeups) lives in a progressive-disclosure reference file
+   inside the dev-tools skill: `references/claude-code.md`. agent-meta gets
+   nothing from this work (consistent with the move).
+
+## Skill design
+
+Location: `plugins/dev-tools/skills/binary-spelunking/SKILL.md`
+
+### Frontmatter
+
+- `name: binary-spelunking`
+- `description:` leads with the universal trigger (investigating a
+  compiled/bundled CLI binary's internals: extracting an embedded system prompt
+  or config schema, mapping a UI/error message to its code path, decoding
+  minified or rotated symbol names, finding undocumented settings keys), names
+  Claude Code (Bun) as the worked example, and preserves search keywords
+  (`strings`, `grep`, minified, system prompt, Claude Code). No workflow summary
+  in the description (per writing-skills CSO guidance).
+
+### Sections (technique-first)
+
+1. **Core principle.** Any single-file binary that embeds its logic as string
+   constants is readable with `strings` + `grep`. The hard part is knowing what
+   to grep for. Anchor on stable tokens (error/UI strings, telemetry events,
+   config keys), never on minified or rotated symbol names.
+2. **The universal method (any binary).**
+   - Identify the bundler/runtime: `file`, plus build markers in the strings
+     (Bun `bun-internal/`, Node SEA, PyInstaller, Electron/asar, Go buildinfo).
+   - Dump strings once and cache (script: `dump-strings.sh`).
+   - Filter runtime noise (e.g. `bun-internal`, `oniguruma`, `__STDC_*`).
+   - Anchor on a stable string, walk outward.
+   - **Boundary (honest):** for truly compiled Go/Rust/C you get symbols +
+     literals + error strings (still excellent anchors), not reassembled source.
+     "Pull the function body" is a string-readable-bundle move, not universal.
+3. **Worked example: Claude Code (Bun).** One tight example per recipe, showing
+   the method concretely:
+   - Extract the system prompt (`^You are Claude`).
+   - UI/error message to code path, disambiguated via `tengu_*` / `kind:"..."`.
+   - Pull a minified function body (brace-chaining; script: `pull-fn.sh`).
+   - Find undocumented config keys (quoted JSON-property strings).
+   Links to `references/claude-code.md` for the deeper catalog, the Piebald
+   shortcut, and the investigation writeups.
+4. **Scripts.** Document the three helpers, each shown as raw command and script
+   form (see below).
+5. **Patterns / Pitfalls / References.** Generalized, with Claude-specific notes
+   explicitly marked as such. No em-dashes or dash stand-ins.
+
+## Scripts design
+
+Location: `plugins/dev-tools/skills/binary-spelunking/scripts/`
+
+Conventions for all three: POSIX `sh`, `--help`, binary-agnostic (take a binary
+path or a command name to resolve via `command -v`/`readlink`), and detect
+GNU-vs-BSD `grep`/`strings` differences. No bashisms where avoidable.
+
+1. **`dump-strings.sh <binary|command>`** resolves the target, runs `strings`,
+   caches to a deterministic path keyed by binary + content hash
+   (e.g. `${TMPDIR:-/tmp}/binspelunk/<basename>-<sha>.txt`). Idempotent: reuses
+   a fresh cache for the same hash, re-dumps when the binary changed. Prints the
+   cache path on stdout. The keystone the other scripts reuse.
+2. **`pull-fn.sh <binary> <anchor-regex> [brace-count]`** is the function-body
+   puller. Splits on `;` (`tr ';' '\n'`) or chains `[^}]*}` `brace-count` times
+   to walk past closing braces, working around BSD grep's 255-repetition cap.
+   `brace-count` defaults to a sensible small value.
+3. **`grep-context.sh <binary> <anchor> [before] [after]`** is a context window
+   around an anchor. Defaults stay under BSD grep's 255 cap; chains to extend
+   when asked for more.
+
+Out of scope for scripts: an anchor-extraction/cataloging tool (too
+binary-specific to generalize cleanly). Recipes show the catalog greps inline.
+
+## Reference file
+
+Location: `plugins/dev-tools/skills/binary-spelunking/references/claude-code.md`
+
+Holds the Claude-specific depth, linked from SKILL.md (read on demand):
+- Fuller recipe walk-throughs for the Claude binary.
+- The stable-anchor catalog (`tengu_*` events, `bashMissKind:`, `kind:"..."`).
+- **The Piebald shortcut**: `Piebald-AI/claude-code-system-prompts` as a
+  pre-extracted, version-tagged source for the system/tool/agent/skill prompts,
+  with the binary framed as ground truth. (Moved here verbatim from the current
+  SKILL.md shortcut section.)
+- The two real-world investigation writeups (sandbox internals, command parser),
+  genericized of internal paths.
+
+## dev-tools move + PR #99 evolution
+
+The branch currently adds the skill to `agent-meta` and bumps it to 2.2.0. To
+relocate without leaving agent-meta changed vs `main`:
+
+1. Add `plugins/dev-tools/skills/binary-spelunking/` (SKILL.md + scripts +
+   references) with the generalized content.
+2. Remove `plugins/agent-meta/skills/harness-binary-spelunking/`.
+3. Revert the agent-meta changes from #99: version back to 2.1.0 in
+   `marketplace.json`, remove the agent-meta README skills-table row.
+4. Bump **dev-tools** minor (1.2.0 -> 1.3.0); add its README row; regenerate the
+   root plugin table (`scripts/generate-plugin-table.sh` or
+   `bump-version.sh --auto`).
+5. New commits on the branch (`feat(dev-tools): ...`, `chore(agent-meta): revert
+   ...`). History will show add-then-move. **Squash-merge** keeps `main` clean.
+6. Retitle/rewrite PR #99 to "Add binary-spelunking skill to dev-tools."
+
+## Verification
+
+- `./scripts/validate-plugin-versions.sh` passes (dev-tools has plugin.json;
+  agent-meta is unchanged vs `main`).
+- `shellcheck` on the three scripts if available.
+- Smoke-test each script against the real `claude` binary: `dump-strings.sh`
+  produces a cache and is idempotent on re-run; `pull-fn.sh` retrieves a known
+  anchor's body; `grep-context.sh` returns a window around a known UI string.
+- Em-dash / dash-stand-in grep clean across SKILL.md and the reference file.
+- Skill self-check: description triggers on "extract Claude Code's system
+  prompt" and on general "inspect a CLI binary" asks; technique-first body reads
+  correctly with Claude as one example.
+
+## Out of scope
+
+- Deleting the original pickletown skill (`plugin/skills/claude-binary-spelunking/`):
+  a separate pt self-dev decision, tracked outside this PR.
+- A general anchor-cataloging script (too binary-specific).
+- Covering compiled Go/Rust/C beyond a short honest boundary note.

--- a/plugins/agent-meta/README.md
+++ b/plugins/agent-meta/README.md
@@ -4,7 +4,7 @@ Meta-development tools for agentic workflows.
 
 ## Philosophy
 
-Working with AI coding agents generates valuable artifacts beyond code: session patterns, failure modes, decision trails. This plugin helps capture and learn from that meta-layer.
+Working with AI coding agents generates valuable artifacts beyond code: session patterns, failure modes, decision trails. This plugin helps capture and learn from that meta-layer, including understanding the harness itself.
 
 ## Skills
 
@@ -13,6 +13,7 @@ Working with AI coding agents generates valuable artifacts beyond code: session 
 | `agent-meta:park` | Save current work context. Two modes: **continuation** (handoff to new session) and **close-out** (record of completed work). |
 | `agent-meta:unpark` | Resume work from a parked handoff, or read a wrapped close-out as reference. |
 | `agent-meta:snapshot` | Capture current session state (inline or with save). In-flow checkpoint, not a walking-away artifact. |
+| `agent-meta:harness-binary-spelunking` | Spelunk the Claude Code CLI binary to extract the system prompt, map UI messages to code paths, decode minified functions, and find undocumented config keys. |
 
 Invoke by asking naturally ("park this session", "wrap this up", "unpark docs/handoffs/foo.md") or with the fully qualified slash form (`/agent-meta:park`).
 

--- a/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-binary-spelunking
-description: Use when investigating the agent harness binary's internals - extracting the system prompt or tool descriptions, finding what code path produces a specific UI message, decoding minified function names, understanding undocumented config keys, or otherwise spelunking the binary to figure out how the harness actually behaves.
+description: Use when investigating the Claude Code CLI binary's internals (the agent harness): extracting the system prompt or tool descriptions, finding what code path produces a specific UI message, decoding minified function names, understanding undocumented config keys, or otherwise spelunking the binary to figure out how Claude Code actually behaves.
 ---
 
 # Harness Binary Spelunking
@@ -55,7 +55,7 @@ Each match is *one* line of the assembled prompt. The full prompt is composed at
 awk 'NR>=153955 && NR<=154100' $TMPDIR/claude-strings.txt
 ```
 
-Tool names (`Bash`, `Grep`, `Read`, `Glob`...) and their descriptions live as adjacent constants in the same region -- read forward until the strings stop being prose.
+Tool names (`Bash`, `Grep`, `Read`, `Glob`...) and their descriptions live as adjacent constants in the same region: read forward until the strings stop being prose.
 
 **Caveat:** the assembled prompt you see in a real session is the ground truth. The binary holds the *fragments*. If you want the exact concatenation, observe a session (e.g. via the conversation context); the binary tells you what fragments *exist*.
 
@@ -67,7 +67,7 @@ You see a specific message in the UI ("This command requires approval", "Auto-al
 grep -n "This command requires approval" $TMPDIR/claude-strings.txt
 ```
 
-If the string appears in *multiple* code paths (it usually does for generic messages), look for nearby **classification tags** or **telemetry event names** -- those are far more specific than the user-facing text:
+If the string appears in *multiple* code paths (it usually does for generic messages), look for nearby **classification tags** or **telemetry event names**, which are far more specific than the user-facing text:
 
 ```bash
 # classification tags - stable across releases
@@ -139,7 +139,7 @@ grep -ao '\.object({[^}]*})' "$CLAUDE_BIN" | grep -i sandbox | head
 - **First match for a UI string is rarely the one you want.** Generic messages like "This command requires approval" are emitted from multiple code paths. Disambiguate via nearby `bashMissKind:`, `kind:`, or `tengu_*` tags.
 - **BSD grep limit:** `grep -E '.{0,500}'` errors with "maximum repetition exceeds 255". Drop to 250 or chain.
 - **Minified names change every release.** Don't write down "the function is `Vu4`" and expect it to mean anything next week. Write down the *anchors* that lead you to the function.
-- **The system prompt is fragmented.** You can't grep one continuous blob -- the binary stores it as adjacent string constants assembled at runtime. `awk` a line range to see the neighbors.
+- **The system prompt is fragmented.** You can't grep one continuous blob: the binary stores it as adjacent string constants assembled at runtime. `awk` a line range to see the neighbors.
 - **`grep -i` over the raw binary is loud.** Match against `$TMPDIR/claude-strings.txt` for cleaner output, or use precise anchors with `grep -ao`.
 
 ## Real-world references

--- a/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
@@ -31,6 +31,19 @@ ls -lh $TMPDIR/claude-strings.txt   # ~37MB typically
 
 Every recipe below assumes `$TMPDIR/claude-strings.txt` exists.
 
+## Shortcut: pre-extracted prompts by version
+
+If all you need is the system prompt, a tool/agent/skill prompt, or the tool descriptions (not arbitrary binary internals), someone already does the extraction for you: [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) tracks these as plain markdown, grouped by kind and tagged per Claude Code version. It's faster and far more readable than reassembling adjacent string fragments out of `strings`.
+
+```bash
+git clone https://github.com/Piebald-AI/claude-code-system-prompts /tmp/ccsp
+git -C /tmp/ccsp tag | sort -V | tail        # versions available, e.g. v2.1.190
+git -C /tmp/ccsp show v2.1.190:system-prompts/<file>.md   # a specific version's prompt
+ls /tmp/ccsp/system-prompts/                 # grouped: system- tool- agent- skill- data-
+```
+
+It is a third-party extraction, so two caveats: it can lag the newest release, and it is someone else's reading, not authoritative. The binary on your machine is ground truth. Drop to the recipes below to verify a fragment, to inspect a version not yet tagged there, or for anything past the prompts (config keys, code paths, minified function bodies).
+
 ## Recipes
 
 ### Recipe 1: Extract the system prompt
@@ -57,7 +70,7 @@ awk 'NR>=153955 && NR<=154100' $TMPDIR/claude-strings.txt
 
 Tool names (`Bash`, `Grep`, `Read`, `Glob`...) and their descriptions live as adjacent constants in the same region: read forward until the strings stop being prose.
 
-**Caveat:** the assembled prompt you see in a real session is the ground truth. The binary holds the *fragments*. If you want the exact concatenation, observe a session (e.g. via the conversation context); the binary tells you what fragments *exist*.
+**Caveat:** the assembled prompt you see in a real session is the ground truth. The binary holds the *fragments*. If you want the exact concatenation, observe a session (e.g. via the conversation context); the binary tells you what fragments *exist*. For a pre-assembled, version-tagged copy, see the [shortcut](#shortcut-pre-extracted-prompts-by-version) above.
 
 ### Recipe 2: UI message to code path
 

--- a/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: harness-binary-spelunking
+description: Use when investigating the agent harness binary's internals - extracting the system prompt or tool descriptions, finding what code path produces a specific UI message, decoding minified function names, understanding undocumented config keys, or otherwise spelunking the binary to figure out how the harness actually behaves.
+---
+
+# Harness Binary Spelunking
+
+"The harness" here means the Claude Code CLI binary. The recipes are Claude-Code-specific (Bun compilation, `tengu_*` events, the `You are Claude Code` system prompt) because that IS the binary being inspected.
+
+The Claude Code CLI ships as a single Mach-O binary (~200MB) compiled by **Bun**. The application is minified JavaScript embedded as plain string constants: `strings` reads it back, `grep` queries it. No deobfuscation, no decompilation. The hard part is knowing what to grep for.
+
+## What you're working with
+
+```bash
+which claude                                          # /Users/<you>/.local/bin/claude
+file $(readlink -f $(which claude))                   # Mach-O 64-bit executable arm64
+strings $(readlink -f $(which claude)) | grep -i bun  # confirms Bun build
+```
+
+You will see references like `/Users/runner/work/bun-internal/bun-internal/embedded/oniguruma/...`. That's the Bun runtime baked into the binary. **Filter it out** when you grep, or you drown in noise.
+
+## One-time setup per session
+
+Dump strings to a temp file once, grep it many times. The binary is ~200MB; `strings` over it takes a few seconds. Re-running for every grep is wasteful.
+
+```bash
+CLAUDE_BIN=$(readlink -f $(which claude))
+strings "$CLAUDE_BIN" > $TMPDIR/claude-strings.txt
+ls -lh $TMPDIR/claude-strings.txt   # ~37MB typically
+```
+
+Every recipe below assumes `$TMPDIR/claude-strings.txt` exists.
+
+## Recipes
+
+### Recipe 1: Extract the system prompt
+
+The system prompt is stored as a literal string starting with `You are Claude Code,`. Different invocations (CLI, Agent SDK, "explanatory mode") use different opener variants.
+
+```bash
+grep -n "^You are Claude" $TMPDIR/claude-strings.txt
+```
+
+You'll see something like:
+
+```
+140267: You are Claude. Not a persona, not a character ...
+153955: You are Claude Code, Anthropic's official CLI for Claude.
+153956: You are Claude Code, ... running within the Claude Agent SDK.
+```
+
+Each match is *one* line of the assembled prompt. The full prompt is composed at runtime from many adjacent string constants. To see the surrounding fragments:
+
+```bash
+awk 'NR>=153955 && NR<=154100' $TMPDIR/claude-strings.txt
+```
+
+Tool names (`Bash`, `Grep`, `Read`, `Glob`...) and their descriptions live as adjacent constants in the same region -- read forward until the strings stop being prose.
+
+**Caveat:** the assembled prompt you see in a real session is the ground truth. The binary holds the *fragments*. If you want the exact concatenation, observe a session (e.g. via the conversation context); the binary tells you what fragments *exist*.
+
+### Recipe 2: UI message to code path
+
+You see a specific message in the UI ("This command requires approval", "Auto-allowed with sandbox", "Newline followed by `#` hides arguments"). You want the code that emits it.
+
+```bash
+grep -n "This command requires approval" $TMPDIR/claude-strings.txt
+```
+
+If the string appears in *multiple* code paths (it usually does for generic messages), look for nearby **classification tags** or **telemetry event names** -- those are far more specific than the user-facing text:
+
+```bash
+# classification tags - stable across releases
+grep -ao 'bashMissKind:"[a-z-]*"' "$CLAUDE_BIN" | sort -u
+grep -ao 'kind:"too-complex",reason:"[^"]*"' "$CLAUDE_BIN" | sort -u
+
+# telemetry events - extremely stable, prefixed with `tengu_`
+grep -ao 'tengu_[a-z_]*' "$CLAUDE_BIN" | sort -u
+```
+
+`tengu_bash_ast_too_complex`, `bashMissKind:"too-complex"`, `kind:"semantics"` etc. are the *real* names of code states. They're the right anchors for "what behavior is this."
+
+### Recipe 3: Pull a function body from minified JS
+
+The binary is one giant minified line per `;`-separated statement. Plain `grep` over the strings file works for short matches; for whole function bodies you need to split it.
+
+```bash
+# Split on ; into one line per statement, then grep
+strings "$CLAUDE_BIN" | tr ';' '\n' | grep 'function Em_' | head -5
+```
+
+Or capture a context window around a known anchor (works around BSD grep's `{0,255}` repetition cap by chaining):
+
+```bash
+# Anchor on a UI string, grab ~250 chars of surrounding minified JS
+grep -aoE '.{0,250}Auto-allowed with sandbox.{0,200}' "$CLAUDE_BIN" | head -3
+```
+
+For function bodies past one closing brace, chain `[^}]*}` as many times as you need:
+
+```bash
+strings "$CLAUDE_BIN" | grep -oE 'async function Vu4[^}]*}[^}]*}[^}]*}' | head -1 | fold -w 120
+```
+
+**Function names rotate every release** (`Vu4`, `Em_`, `w5_`, `Zj_` are all minified identifiers regenerated by the bundler). Never bake them into a plan. Always re-derive them via stable anchors (UI strings, `tengu_*` events, `kind:"..."` tags) for the version you're inspecting.
+
+### Recipe 4: Find undocumented config / settings keys
+
+Settings keys live as quoted JSON-property strings:
+
+```bash
+grep -oE '"[a-zA-Z][a-zA-Z0-9]*Sandboxed?"' $TMPDIR/claude-strings.txt | sort -u
+grep -oE '"(allow|deny|hooks?|permission)[A-Z][a-zA-Z]*"' $TMPDIR/claude-strings.txt | sort -u
+
+# Or context-window around a known one
+grep -ao '.\{0,150\}autoAllowBashIfSandboxed.\{0,150\}' "$CLAUDE_BIN" | head -3
+```
+
+For the schema of a config object, find the validator (Zod schemas leave readable shape strings):
+
+```bash
+grep -ao '\.object({[^}]*})' "$CLAUDE_BIN" | grep -i sandbox | head
+```
+
+## Patterns
+
+| Pattern | Why |
+|---------|-----|
+| Anchor on UI strings, telemetry events, classification tags | Stable across releases; minified function names are not |
+| Dump `strings` to `$TMPDIR` once, reuse | The binary is 200MB; re-running `strings` per grep is slow |
+| Use `tr ';' '\n'` before grep when looking for function definitions | Minified JS is one line; `;`-split makes per-statement matches feasible |
+| Chain `[^}]*}` to walk past N closing braces | BSD grep on macOS caps `{0,N}` at 255; chaining gets past that limit |
+| Filter out `bun-internal`, `oniguruma`, `__STDC_*` | Bun runtime noise, not Claude Code logic |
+| `grep -ao` (treat binary as text, only-matching) | Faster than `grep` of the strings file when you have a precise anchor |
+
+## Pitfalls
+
+- **"It's a Node.js bundle"**: No, it's Bun. The build paths in the strings (`bun-internal/`, `tmp_modules/bun/ffi.ts`) prove it. Matters because Bun bundles use specific naming conventions the standard JS bundlers don't.
+- **First match for a UI string is rarely the one you want.** Generic messages like "This command requires approval" are emitted from multiple code paths. Disambiguate via nearby `bashMissKind:`, `kind:`, or `tengu_*` tags.
+- **BSD grep limit:** `grep -E '.{0,500}'` errors with "maximum repetition exceeds 255". Drop to 250 or chain.
+- **Minified names change every release.** Don't write down "the function is `Vu4`" and expect it to mean anything next week. Write down the *anchors* that lead you to the function.
+- **The system prompt is fragmented.** You can't grep one continuous blob -- the binary stores it as adjacent string constants assembled at runtime. `awk` a line range to see the neighbors.
+- **`grep -i` over the raw binary is loud.** Match against `$TMPDIR/claude-strings.txt` for cleaner output, or use precise anchors with `grep -ao`.
+
+## Real-world references
+
+Two prior investigations show the technique end-to-end:
+
+- **Sandbox internals dig:** Starting from a config key (`autoAllowBashIfSandboxed`), walked the Seatbelt profile generator and dynamic ripgrep deny-scan. Decompiled a chain of minified functions (`mu4`, `bu4`, `Vu4`, `_N_`, `Zu4`, `uu4`) to understand how the sandbox profile is constructed.
+- **Command parser pipeline walk:** Starting from a UI string ("This command requires approval"), traced the full pipeline: pre-parse checks, AST walker, known-complex set, auto-allow gate, interactive-vs-agent gate, tracked-variables store.
+
+Both started from one anchor (a UI string or a config key) and walked outward.

--- a/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
@@ -1,39 +1,74 @@
 ---
 name: harness-binary-spelunking
-description: Use when investigating the Claude Code CLI binary's internals (the agent harness): extracting the system prompt or tool descriptions, finding what code path produces a specific UI message, decoding minified function names, understanding undocumented config keys, or otherwise spelunking the binary to figure out how Claude Code actually behaves.
+description: Use when investigating an agent-harness CLI's internals (Claude Code, codex, opencode, or similar): extracting the system prompt or tool descriptions, finding what code path produces a specific UI message, decoding minified function names or Rust symbols, understanding undocumented config keys, or otherwise spelunking a shipped binary (or its pinned source) to figure out how the tool actually behaves.
 ---
 
 # Harness Binary Spelunking
 
-"The harness" here means the Claude Code CLI binary. The recipes are Claude-Code-specific (Bun compilation, `tengu_*` events, the `You are Claude Code` system prompt) because that IS the binary being inspected.
+"The harness" here means whatever agent CLI you're inspecting: Claude Code, codex, opencode, pi, or any other tool that wraps an LLM in a terminal loop. The technique is the same regardless of which one you're looking at; only the recipes fork, based on how the binary was built.
 
-The Claude Code CLI ships as a single Mach-O binary (~200MB) compiled by **Bun**. The application is minified JavaScript embedded as plain string constants: `strings` reads it back, `grep` queries it. No deobfuscation, no decompilation. The hard part is knowing what to grep for.
+## Step 0: Decide your approach
 
-## What you're working with
+Before grepping anything, figure out which situation you're in:
 
-```bash
-which claude                                          # /Users/<you>/.local/bin/claude
-file $(readlink -f $(which claude))                   # Mach-O 64-bit executable arm64
-strings $(readlink -f $(which claude)) | grep -i bun  # confirms Bun build
-```
+- **Open source, and the pinned version is tagged?** Clone the source at that exact tag and read it. Fastest, most readable, no guessing at minified names. See [references/source-clone.md](references/source-clone.md).
+- **Closed source (Claude Code today), or you want ground truth of what actually shipped?** Spelunk the binary directly. Source, even when it exists, is what was *committed*; the binary is what's *running* on your machine right now.
+- **Open source but the version isn't tagged yet, or you're debugging a discrepancy between source and behavior?** Spelunk the binary even though source exists. "Open source" doesn't mean "skip verification."
 
-You will see references like `/Users/runner/work/bun-internal/bun-internal/embedded/oniguruma/...`. That's the Bun runtime baked into the binary. **Filter it out** when you grep, or you drown in noise.
+Most investigations start at one of these two ends and only cross over if the first approach runs dry (source doesn't explain the behavior you're seeing; binary strings are too fragmented to be sure).
 
-## One-time setup per session
+## Identify the build
 
-Dump strings to a temp file once, grep it many times. The binary is ~200MB; `strings` over it takes a few seconds. Re-running for every grep is wasteful.
+If you're spelunking a binary (not reading source), figure out what you're actually holding before you pick a recipe set.
 
 ```bash
-CLAUDE_BIN=$(readlink -f $(which claude))
-strings "$CLAUDE_BIN" > $TMPDIR/claude-strings.txt
-ls -lh $TMPDIR/claude-strings.txt   # ~37MB typically
+which <tool>                          # may be a shim, not the real binary
+file $(readlink -f $(which <tool>))   # classify the artifact
 ```
 
-Every recipe below assumes `$TMPDIR/claude-strings.txt` exists.
+`which` often hands you a **launcher, not the artifact**. npm-installed CLIs are frequently a thin Node script that execs a platform-specific binary elsewhere. Follow the shim:
 
-## Shortcut: pre-extracted prompts by version
+```bash
+$ which codex
+/Users/<you>/.local/bin/codex          # a Node launcher: bin/codex.js
 
-If all you need is the system prompt, a tool/agent/skill prompt, or the tool descriptions (not arbitrary binary internals), someone already does the extraction for you: [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) tracks these as plain markdown, grouped by kind and tagged per Claude Code version. It's faster and far more readable than reassembling adjacent string fragments out of `strings`.
+$ cat $(which codex)                   # spawns the real binary, e.g.:
+# .../@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+
+$ file .../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+Mach-O 64-bit executable arm64        # 203MB, this is the real target
+```
+
+Once you have the real artifact, classify it:
+
+| Tells | Build | Recipes |
+|-------|-------|---------|
+| `strings <bin> \| grep -i bun` hits; paths like `bun-internal/`, `tmp_modules/bun/ffi.ts` | Bun-compiled JS (Claude Code, opencode) | [references/bun-js.md](references/bun-js.md) |
+| `strings <bin>` shows `.rs` paths, `.cargo/registry/`, `crate_name::module` paths | Rust | [references/rust.md](references/rust.md) |
+| `file` says plain script / small size, `node_modules/` alongside it | Unbundled Node, or thin wrapper over readable source | Just read the source; see the pi note in [references/source-clone.md](references/source-clone.md) |
+
+Don't assume a binary is a Node bundle just because the CLI is npm-installed. Bun and Rust both ship as single Mach-O executables that npm happily distributes as "the binary."
+
+## General method
+
+Once you know the build, the loop is the same for every harness:
+
+1. **Dump once, grep many times.** These binaries run 100MB-200MB+; `strings` over them takes a few seconds but you'll grep dozens of times. Dump to a temp file once and reuse it.
+2. **Anchor on stable strings, not derived names.** System-prompt openers, UI-facing error text, telemetry/event names, config-key names, `.rs:line` debug locations: these survive releases. Minified JS identifiers and even some struct layouts do not.
+3. **Walk outward from the anchor.** Grep the anchor, then read the surrounding region (`awk` a line range, or grab a character window with `grep -aoE '.{0,N}anchor.{0,N}'`) to find the code, config, or prompt fragments next to it.
+4. **Filter noise, but derive the noise list per tool.** Every runtime bakes in its own boilerplate (Bun's `bun-internal`/`oniguruma`, cargo's registry paths, etc.). Don't assume one tool's noise list applies to another; a quick `grep -c` of the suspected noise string tells you whether it's even present.
+
+The per-build reference files below give you the concrete grep recipes for each anchor type (prompts, UI messages, function bodies, config keys). Read the one matching your build classification above.
+
+## Reference files
+
+- [references/bun-js.md](references/bun-js.md): Bun-compiled JS builds (Claude Code, opencode). System prompt extraction, UI-message-to-code-path, pulling minified function bodies, undocumented config keys. Covers the two tools together and calls out where they diverge (anchor scheme, noise filter, prompt fragmentation).
+- [references/rust.md](references/rust.md): Rust builds (codex). Whole-string system prompts, serde-derived config keys, `.rs:line` anchors, cargo-registry provenance, and what does NOT carry over from the JS recipes.
+- [references/source-clone.md](references/source-clone.md): version-to-git-tag mapping and clone recipe for tools that ship real source (codex, opencode, pi), plus the case (pi) where reading source beats spelunking entirely.
+
+## Shortcut: check whether someone already extracted this
+
+Before reassembling fragments yourself, check whether someone already did the extraction and published it. For Claude Code specifically, [Piebald-AI/claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) tracks system/tool/agent/skill prompts as plain markdown, tagged per Claude Code version:
 
 ```bash
 git clone https://github.com/Piebald-AI/claude-code-system-prompts /tmp/ccsp
@@ -42,124 +77,36 @@ git -C /tmp/ccsp show v2.1.190:system-prompts/<file>.md   # a specific version's
 ls /tmp/ccsp/system-prompts/                 # grouped: system- tool- agent- skill- data-
 ```
 
-It is a third-party extraction, so two caveats: it can lag the newest release, and it is someone else's reading, not authoritative. The binary on your machine is ground truth. Drop to the recipes below to verify a fragment, to inspect a version not yet tagged there, or for anything past the prompts (config keys, code paths, minified function bodies).
-
-## Recipes
-
-### Recipe 1: Extract the system prompt
-
-The system prompt is stored as a literal string starting with `You are Claude Code,`. Different invocations (CLI, Agent SDK, "explanatory mode") use different opener variants.
-
-```bash
-grep -n "^You are Claude" $TMPDIR/claude-strings.txt
-```
-
-You'll see something like:
-
-```
-140267: You are Claude. Not a persona, not a character ...
-153955: You are Claude Code, Anthropic's official CLI for Claude.
-153956: You are Claude Code, ... running within the Claude Agent SDK.
-```
-
-Each match is *one* line of the assembled prompt. The full prompt is composed at runtime from many adjacent string constants. To see the surrounding fragments:
-
-```bash
-awk 'NR>=153955 && NR<=154100' $TMPDIR/claude-strings.txt
-```
-
-Tool names (`Bash`, `Grep`, `Read`, `Glob`...) and their descriptions live as adjacent constants in the same region: read forward until the strings stop being prose.
-
-**Caveat:** the assembled prompt you see in a real session is the ground truth. The binary holds the *fragments*. If you want the exact concatenation, observe a session (e.g. via the conversation context); the binary tells you what fragments *exist*. For a pre-assembled, version-tagged copy, see the [shortcut](#shortcut-pre-extracted-prompts-by-version) above.
-
-### Recipe 2: UI message to code path
-
-You see a specific message in the UI ("This command requires approval", "Auto-allowed with sandbox", "Newline followed by `#` hides arguments"). You want the code that emits it.
-
-```bash
-grep -n "This command requires approval" $TMPDIR/claude-strings.txt
-```
-
-If the string appears in *multiple* code paths (it usually does for generic messages), look for nearby **classification tags** or **telemetry event names**, which are far more specific than the user-facing text:
-
-```bash
-# classification tags - stable across releases
-grep -ao 'bashMissKind:"[a-z-]*"' "$CLAUDE_BIN" | sort -u
-grep -ao 'kind:"too-complex",reason:"[^"]*"' "$CLAUDE_BIN" | sort -u
-
-# telemetry events - extremely stable, prefixed with `tengu_`
-grep -ao 'tengu_[a-z_]*' "$CLAUDE_BIN" | sort -u
-```
-
-`tengu_bash_ast_too_complex`, `bashMissKind:"too-complex"`, `kind:"semantics"` etc. are the *real* names of code states. They're the right anchors for "what behavior is this."
-
-### Recipe 3: Pull a function body from minified JS
-
-The binary is one giant minified line per `;`-separated statement. Plain `grep` over the strings file works for short matches; for whole function bodies you need to split it.
-
-```bash
-# Split on ; into one line per statement, then grep
-strings "$CLAUDE_BIN" | tr ';' '\n' | grep 'function Em_' | head -5
-```
-
-Or capture a context window around a known anchor (works around BSD grep's `{0,255}` repetition cap by chaining):
-
-```bash
-# Anchor on a UI string, grab ~250 chars of surrounding minified JS
-grep -aoE '.{0,250}Auto-allowed with sandbox.{0,200}' "$CLAUDE_BIN" | head -3
-```
-
-For function bodies past one closing brace, chain `[^}]*}` as many times as you need:
-
-```bash
-strings "$CLAUDE_BIN" | grep -oE 'async function Vu4[^}]*}[^}]*}[^}]*}' | head -1 | fold -w 120
-```
-
-**Function names rotate every release** (`Vu4`, `Em_`, `w5_`, `Zj_` are all minified identifiers regenerated by the bundler). Never bake them into a plan. Always re-derive them via stable anchors (UI strings, `tengu_*` events, `kind:"..."` tags) for the version you're inspecting.
-
-### Recipe 4: Find undocumented config / settings keys
-
-Settings keys live as quoted JSON-property strings:
-
-```bash
-grep -oE '"[a-zA-Z][a-zA-Z0-9]*Sandboxed?"' $TMPDIR/claude-strings.txt | sort -u
-grep -oE '"(allow|deny|hooks?|permission)[A-Z][a-zA-Z]*"' $TMPDIR/claude-strings.txt | sort -u
-
-# Or context-window around a known one
-grep -ao '.\{0,150\}autoAllowBashIfSandboxed.\{0,150\}' "$CLAUDE_BIN" | head -3
-```
-
-For the schema of a config object, find the validator (Zod schemas leave readable shape strings):
-
-```bash
-grep -ao '\.object({[^}]*})' "$CLAUDE_BIN" | grep -i sandbox | head
-```
+It's a third-party extraction: it can lag the newest release, and it's someone else's reading, not authoritative. The binary (or source, per Step 0) on your machine is ground truth. Drop to the recipes when you need to verify a fragment, inspect a version not yet covered, or dig into anything past prompts (config keys, code paths, function bodies). The same instinct applies to other harnesses too: check for an existing extraction project before you start from scratch.
 
 ## Patterns
 
 | Pattern | Why |
 |---------|-----|
-| Anchor on UI strings, telemetry events, classification tags | Stable across releases; minified function names are not |
-| Dump `strings` to `$TMPDIR` once, reuse | The binary is 200MB; re-running `strings` per grep is slow |
-| Use `tr ';' '\n'` before grep when looking for function definitions | Minified JS is one line; `;`-split makes per-statement matches feasible |
-| Chain `[^}]*}` to walk past N closing braces | BSD grep on macOS caps `{0,N}` at 255; chaining gets past that limit |
-| Filter out `bun-internal`, `oniguruma`, `__STDC_*` | Bun runtime noise, not Claude Code logic |
-| `grep -ao` (treat binary as text, only-matching) | Faster than `grep` of the strings file when you have a precise anchor |
+| Anchor on UI strings, telemetry events, config keys, `.rs:line` locations | Stable across releases; minified names and even struct shapes are not |
+| Dump `strings` to a temp file once, reuse it | Binaries run 100-200MB+; re-running `strings` per grep is slow |
+| Follow `which` through shims to the real artifact before classifying | npm/pip installs often distribute a launcher script, not the binary |
+| Derive the noise filter per tool instead of reusing another tool's | Bun/Rust/Node each bake in different runtime boilerplate; presence isn't guaranteed |
+| Prefer cloning tagged source over spelunking when the tool is open source and tagged | Faster, more readable, no guessing at derived names |
 
 ## Pitfalls
 
-- **"It's a Node.js bundle"**: No, it's Bun. The build paths in the strings (`bun-internal/`, `tmp_modules/bun/ffi.ts`) prove it. Matters because Bun bundles use specific naming conventions the standard JS bundlers don't.
-- **First match for a UI string is rarely the one you want.** Generic messages like "This command requires approval" are emitted from multiple code paths. Disambiguate via nearby `bashMissKind:`, `kind:`, or `tengu_*` tags.
-- **BSD grep limit:** `grep -E '.{0,500}'` errors with "maximum repetition exceeds 255". Drop to 250 or chain.
-- **Minified names change every release.** Don't write down "the function is `Vu4`" and expect it to mean anything next week. Write down the *anchors* that lead you to the function.
-- **The system prompt is fragmented.** You can't grep one continuous blob: the binary stores it as adjacent string constants assembled at runtime. `awk` a line range to see the neighbors.
-- **`grep -i` over the raw binary is loud.** Match against `$TMPDIR/claude-strings.txt` for cleaner output, or use precise anchors with `grep -ao`.
+- **Assuming build type from install method.** npm-installed does not mean JS bundle; codex installs via npm but ships a Rust binary. Always `file` the real artifact.
+- **Trusting `which` at face value.** It frequently returns a launcher/shim, not the artifact you want to classify.
+- **Reusing one tool's noise filter on another.** `bun-internal` noise present in Claude Code is entirely absent from opencode's Bun build; check before you filter.
+- **First match for a generic UI string is rarely the only code path.** Disambiguate with nearby classification tags, telemetry event names, or (in Rust) `.rs:line` locations.
+- **Baking derived/minified names into a plan.** Minified JS identifiers rotate every release. Rust struct/function names are more stable but crate-internal ones can still shift. Write down the anchor that leads you there, not the name itself.
+- **BSD grep's `{0,N}` cap at 255.** `grep -E '.{0,500}'` errors with "maximum repetition exceeds 255" on macOS. Drop below 255 or chain `[^}]*}` segments.
+- **Assuming source and shipped binary agree.** Source is what was committed; the binary is what's running. When behavior doesn't match source, or the version isn't tagged yet, spelunk the binary even for open-source tools.
 
 ## Real-world references
 
-Two prior investigations show the technique end-to-end:
+Five investigations show the technique end-to-end, across three harnesses:
 
-- **Sandbox internals dig:** Starting from a config key (`autoAllowBashIfSandboxed`), walked the Seatbelt profile generator and dynamic ripgrep deny-scan. Decompiled a chain of minified functions (`mu4`, `bu4`, `Vu4`, `_N_`, `Zu4`, `uu4`) to understand how the sandbox profile is constructed.
-- **Command parser pipeline walk:** Starting from a UI string ("This command requires approval"), traced the full pipeline: pre-parse checks, AST walker, known-complex set, auto-allow gate, interactive-vs-agent gate, tracked-variables store.
+- **Claude Code, sandbox internals:** starting from a config key (`autoAllowBashIfSandboxed`), walked the Seatbelt profile generator and dynamic ripgrep deny-scan, decompiling a chain of minified functions (`mu4`, `bu4`, `Vu4`, `_N_`, `Zu4`, `uu4`) to understand how the sandbox profile is constructed.
+- **Claude Code, command parser pipeline:** starting from a UI string ("This command requires approval"), traced pre-parse checks, the AST walker, the known-complex set, the auto-allow gate, the interactive-vs-agent gate, and the tracked-variables store.
+- **codex, Node-shim-to-Rust-binary chase:** `which codex` resolved to a Node launcher; following the spawn target landed on a 203MB Mach-O Rust binary, confirmed via cargo-registry paths and `.rs` locations in the strings output.
+- **codex, whole-prompt and config-key extraction:** grepping `you are (codex|a coding)` pulled entire system-prompt constants (not fragments), and grepping `approval_policy|sandbox_mode|model_reasoning_effort` pulled plain serde snake_case config keys directly.
+- **opencode, Bun-build comparison:** confirmed the same Bun-compiled family as Claude Code, but with zero `bun-internal` noise, named-string function/provider wrappers (`l.fn("Gemini.fromRequest")`, `bo.make("google")`) standing in for `tengu_*` anchors, and a near-whole system-prompt template literal instead of Claude's fragmented assembly.
 
-Both started from one anchor (a UI string or a config key) and walked outward.
+Each started from one anchor (a config key, a UI string, or a "what is this binary" question) and walked outward.

--- a/plugins/agent-meta/skills/harness-binary-spelunking/references/bun-js.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/references/bun-js.md
@@ -1,0 +1,157 @@
+# Bun-compiled JS builds: Claude Code and opencode
+
+Claude Code and opencode are both shipped as single Mach-O binaries compiled by **Bun**, with the application as minified JavaScript embedded as plain string constants. `strings` reads it back, `grep` queries it. No deobfuscation, no decompilation needed. The hard part is knowing what to grep for.
+
+The recipes below were developed against Claude Code and confirmed to transfer to opencode with two real differences, called out inline: the noise filter, and the anchor scheme for stable functions/providers. Everything else (splitting minified JS, chaining past braces, the BSD grep 255 cap) applies to both as written.
+
+## What you're working with
+
+```bash
+which claude                                          # /Users/<you>/.local/bin/claude
+file $(readlink -f $(which claude))                   # Mach-O 64-bit executable arm64
+strings $(readlink -f $(which claude)) | grep -i bun   # confirms Bun build
+```
+
+For opencode, the same shape applies:
+
+```bash
+which opencode
+file $(readlink -f $(which opencode))                 # Mach-O 64-bit executable arm64, ~114MB
+```
+
+**Noise filter is tool-specific, don't assume it transfers.** Claude Code's strings include `/Users/runner/work/bun-internal/bun-internal/embedded/oniguruma/...`, Bun-runtime boilerplate you filter out or drown in. opencode's build has **none of it**:
+
+```bash
+strings $(readlink -f $(which opencode)) | grep -c bun-internal   # 0
+```
+
+Check what noise is actually present in the binary you're looking at before you build a filter; don't reuse another tool's list.
+
+## One-time setup per session
+
+Dump strings to a temp file once, grep it many times. The binary is 100-200MB+; `strings` over it takes a few seconds. Re-running for every grep is wasteful.
+
+```bash
+BIN=$(readlink -f $(which claude))       # or opencode
+strings "$BIN" > $TMPDIR/harness-strings.txt
+ls -lh $TMPDIR/harness-strings.txt       # ~37MB typically for Claude Code
+```
+
+Every recipe below assumes `$TMPDIR/harness-strings.txt` exists and `$BIN` points at the real artifact.
+
+## Recipe 1: Extract the system prompt
+
+**Claude Code:** the system prompt is stored as a literal string starting with `You are Claude Code,`. Different invocations (CLI, Agent SDK, "explanatory mode") use different opener variants.
+
+```bash
+grep -n "^You are Claude" $TMPDIR/harness-strings.txt
+```
+
+You'll see something like:
+
+```
+140267: You are Claude. Not a persona, not a character ...
+153955: You are Claude Code, Anthropic's official CLI for Claude.
+153956: You are Claude Code, ... running within the Claude Agent SDK.
+```
+
+Each match is *one line* of the assembled prompt. The full prompt is composed at runtime from many adjacent string constants. To see the surrounding fragments:
+
+```bash
+awk 'NR>=153955 && NR<=154100' $TMPDIR/harness-strings.txt
+```
+
+Tool names (`Bash`, `Grep`, `Read`, `Glob`...) and their descriptions live as adjacent constants in the same region: read forward until the strings stop being prose.
+
+**Caveat:** the assembled prompt you see in a real session is the ground truth. The binary holds the *fragments*. If you want the exact concatenation, observe a session; the binary tells you what fragments *exist*. For a pre-assembled, version-tagged copy of Claude Code's prompts, see the shortcut in the main SKILL.md.
+
+**opencode is different here: the prompt is a near-whole template literal**, not fragmented adjacent constants. From opencode 1.17.5:
+
+```
+Vi = "You are OpenCode, the best coding agent on the planet.\nYou are an interactive CLI tool..."
+```
+
+One grep on a distinctive opener phrase lands the (mostly) whole prompt in a single match, no `awk` reassembly needed. Don't assume every Bun-compiled tool fragments its prompt the way Claude Code does; check whether your first match already looks complete before reaching for a line-range walk.
+
+## Recipe 2: UI message to code path
+
+You see a specific message in the UI ("This command requires approval", "Auto-allowed with sandbox", "Newline followed by `#` hides arguments"). You want the code that emits it.
+
+```bash
+grep -n "This command requires approval" $TMPDIR/harness-strings.txt
+```
+
+If the string appears in *multiple* code paths (it usually does for generic messages), look for nearby **classification tags** or **telemetry event names**, which are far more specific than the user-facing text.
+
+**Claude Code** prefixes its stable telemetry events with `tengu_`:
+
+```bash
+# classification tags - stable across releases
+grep -ao 'bashMissKind:"[a-z-]*"' "$BIN" | sort -u
+grep -ao 'kind:"too-complex",reason:"[^"]*"' "$BIN" | sort -u
+
+# telemetry events - extremely stable
+grep -ao 'tengu_[a-z_]*' "$BIN" | sort -u
+```
+
+`tengu_bash_ast_too_complex`, `bashMissKind:"too-complex"`, `kind:"semantics"` etc. are the *real* names of code states.
+
+**opencode has no `tengu_*` equivalent.** Its stable anchors are **named-string function/provider wrappers**: the minified bundler keeps a literal string name attached to the wrapped function or provider, even though the variable holding it is minified:
+
+```bash
+grep -ao 'l\.fn("[A-Za-z.]*")' "$BIN" | sort -u    # e.g. l.fn("Gemini.fromRequest")
+grep -ao 'bo\.make("[a-z]*")' "$BIN" | sort -u     # e.g. bo.make("google"), bo.make("openai")
+```
+
+These are the opencode equivalent of `tengu_*`: stable, semantic, safe to anchor on even as the surrounding minified code changes. The wrapper function names (`l.fn`, `bo.make`) are themselves minified and could shift release to release; the *string literal argument* is the durable anchor. When you land in an unfamiliar Bun bundle, look for this pattern (a short minified call wrapping a human-readable string) before assuming there's no stable anchor.
+
+## Recipe 3: Pull a function body from minified JS
+
+The binary is one giant minified line per `;`-separated statement. Plain `grep` over the strings file works for short matches; for whole function bodies you need to split it. This applies as-is to both Claude Code and opencode.
+
+```bash
+# Split on ; into one line per statement, then grep
+strings "$BIN" | tr ';' '\n' | grep 'function Em_' | head -5
+```
+
+Or capture a context window around a known anchor (works around BSD grep's `{0,255}` repetition cap by chaining):
+
+```bash
+# Anchor on a UI string, grab ~250 chars of surrounding minified JS
+grep -aoE '.{0,250}Auto-allowed with sandbox.{0,200}' "$BIN" | head -3
+```
+
+For function bodies past one closing brace, chain `[^}]*}` as many times as you need:
+
+```bash
+strings "$BIN" | grep -oE 'async function Vu4[^}]*}[^}]*}[^}]*}' | head -1 | fold -w 120
+```
+
+**Function names rotate every release** (`Vu4`, `Em_`, `w5_`, `Zj_` are all minified identifiers regenerated by the bundler, in both tools). Never bake them into a plan. Always re-derive them via stable anchors (UI strings, `tengu_*` events, `l.fn(...)`/`bo.make(...)` wrappers, `kind:"..."` tags) for the version you're inspecting.
+
+## Recipe 4: Find undocumented config / settings keys
+
+Settings keys live as quoted JSON-property strings, in both tools:
+
+```bash
+grep -oE '"[a-zA-Z][a-zA-Z0-9]*Sandboxed?"' $TMPDIR/harness-strings.txt | sort -u
+grep -oE '"(allow|deny|hooks?|permission)[A-Z][a-zA-Z]*"' $TMPDIR/harness-strings.txt | sort -u
+
+# Or context-window around a known one
+grep -ao '.\{0,150\}autoAllowBashIfSandboxed.\{0,150\}' "$BIN" | head -3
+```
+
+For the schema of a config object, find the validator (Zod schemas leave readable shape strings):
+
+```bash
+grep -ao '\.object({[^}]*})' "$BIN" | grep -i sandbox | head
+```
+
+## Pitfalls specific to Bun-compiled JS
+
+- **"It's a Node.js bundle"**: No, it's Bun. The build paths in the strings (`bun-internal/`, `tmp_modules/bun/ffi.ts`, when present) prove it. Matters because Bun bundles use naming conventions standard JS bundlers don't.
+- **Assuming Claude Code's noise filter (`bun-internal`, `oniguruma`) applies to every Bun build.** opencode's build has zero `bun-internal` hits. Check with `grep -c` first.
+- **Assuming every Bun-compiled prompt is fragmented like Claude Code's.** opencode's is a near-whole template literal. Look at your first match before reaching for line-range reassembly.
+- **First match for a UI string is rarely the one you want.** Generic messages like "This command requires approval" are emitted from multiple code paths. Disambiguate via nearby `bashMissKind:`, `kind:`, `tengu_*`, or `l.fn(...)`/`bo.make(...)` tags.
+- **BSD grep limit:** `grep -E '.{0,500}'` errors with "maximum repetition exceeds 255". Drop to 250 or chain.
+- **Minified names change every release.** Don't write down "the function is `Vu4`" and expect it to mean anything next week. Write down the *anchors* that lead you to the function.

--- a/plugins/agent-meta/skills/harness-binary-spelunking/references/rust.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/references/rust.md
@@ -1,0 +1,95 @@
+# Rust builds: codex
+
+codex (`openai/codex`, 0.139.0 at the time of this recon) installs via npm but ships a **Rust** binary, not a JS bundle. `which codex` returns a Node launcher (`.../@openai/codex/bin/codex.js`) that spawns the real platform binary; follow the shim before you classify anything:
+
+```
+$ which codex
+/Users/<you>/.local/bin/codex                          # Node launcher
+
+$ cat $(which codex)                                    # spawns the real binary at:
+/Users/<you>/.local/share/mise/installs/node/<v>/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+
+$ file .../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+Mach-O 64-bit executable arm64                          # 203MB
+```
+
+**Lesson:** `which` may hand you a shim. Chase the spawn target to the real artifact before classifying it as a build type. An npm-installed CLI is not automatically a JS bundle.
+
+## Confirming it's Rust
+
+Strings carry unmistakable Rust/cargo provenance:
+
+```bash
+CODEX=.../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+strings "$CODEX" | grep -c '.cargo/registry'    # cargo-registry paths, nonzero
+strings "$CODEX" | grep -oE '[a-z_]+::[a-z_]+' | sort -u | head    # crate::module paths
+```
+
+You'll see things like `/Users/runner/.cargo/registry/...`, `.rs` file paths, and crate paths like `codex_models_manager::manager`.
+
+## What transfers from the JS recipes, and what doesn't
+
+The general method (dump strings once, anchor on stable strings, walk outward) is the same. The concrete recipes are different because Rust doesn't minify or bundle the way a JS build does:
+
+- **No `tr ';' '\n'` splitting.** That trick exists because minified JS is one giant `;`-joined statement; Rust binaries aren't shaped that way.
+- **No Zod `.object({...})` schema strings.** That's a JS-validator-library artifact. Rust's config schema shows up differently (see below).
+- **Rust tells instead:** whole-string prompts (not fragments), serde field-name runs, `.rs:line` debug/panic locations, and cargo-registry paths as provenance.
+
+## Recipe 1: Extract the system prompt (comes out WHOLE)
+
+This is the biggest divergence from the JS recipes. Claude Code and opencode store prompts as string fragments or a near-whole template literal that still needs a grep to locate. codex's Rust build embeds each prompt as a **complete string constant**, so one grep on a distinctive opening clause returns the entire block:
+
+```bash
+strings "$CODEX" | grep -iE 'you are (codex|a coding)'
+```
+
+From codex 0.139.0, this yields entire prompt blocks in one match each, no reassembly:
+
+- `You are Codex, an OpenAI general-purpose agentic assistant that helps the user complete tasks...`
+- `You are a coding agent running in the Codex CLI, a terminal-based coding assistant...`
+- `You are Codex, a coding agent based on GPT-5. You and the user share the same workspace...`
+
+Templating is visible too, as literal placeholder strings rather than assembled fragments: `{{ personality }}`, `instructions_template`, `instructions_variables`.
+
+## Recipe 2: Find undocumented config keys (plain serde snake_case)
+
+Rust's serde-derived config structs serialize field names as plain snake_case strings, directly greppable with no JSON-quote or camelCase guessing:
+
+```bash
+strings "$CODEX" | grep -iE 'approval_policy|sandbox_mode|model_reasoning_effort'
+```
+
+From codex 0.139.0, this also surfaces `personality_default`, `personality_pragmatic`, `context_window`, `auto_compact_token_limit`, and serde struct summaries like:
+
+```
+struct ModelInfo with 36 elements
+```
+
+followed by a run of the struct's field names as adjacent strings. That struct-summary line is itself a useful anchor: grep `struct \w+ with \d+ elements` to enumerate config/data structs you didn't know existed, then read the field-name run that follows.
+
+## Recipe 3: Anchor on `.rs:line` locations
+
+Rust's panic and debug-assertion machinery embeds source file:line pairs as strings. These are semantically stable (they name the actual source location) and, unlike minified JS identifiers, don't rotate on every release the same way, though line numbers shift as the file changes:
+
+```bash
+strings "$CODEX" | grep -oE '[a-z_/-]+\.rs:[0-9]+' | sort -u | head -20
+```
+
+From this recon: `models-manager/src/manager.rs:231`, `models-manager/src/model_info.rs:67`. These double as a map of the crate layout: the path segment before `src/` is usually the crate name (`models-manager`), which you can cross-reference against the cloned source (see [source-clone.md](source-clone.md)) to jump straight to the relevant file.
+
+## Patterns specific to Rust builds
+
+| Pattern | Why |
+|---------|-----|
+| Follow npm-launcher shims to the real platform binary before classifying | `which` returns the Node wrapper, not the Rust artifact |
+| Grep whole prompt openers directly, expect complete matches | Rust embeds prompts as full string constants, not fragments |
+| Grep snake_case config-key fragments directly, no quoting needed | serde field names are plain strings, not JSON-quoted like JS `"camelCase"` keys |
+| Anchor on `.rs:line` locations | Semantically named, tied to real source structure, crosses over cleanly to a source clone |
+| Grep `struct \w+ with \d+ elements` to enumerate structs | serde/debug summaries name structs you didn't know to look for |
+
+## Pitfalls
+
+- **Assuming npm install means JS bundle.** codex installs via `npm install -g @openai/codex`; the actual binary is Rust. Always `file` the real artifact after following shims.
+- **Reaching for JS-bundle recipes first.** `tr ';' '\n'` and Zod schema greps do nothing useful here; they assume a minified-JS shape codex doesn't have.
+- **Treating `.rs:line` as immutable.** The file path segment is stable; the line number will drift between versions as the source changes. Use it as a "which file" anchor, then re-locate the exact line in a fresh clone if you need precision.
+- **Missing the struct-summary anchor.** `struct X with N elements` lines are an easy way to enumerate config/data shapes wholesale instead of guessing field names one at a time.

--- a/plugins/agent-meta/skills/harness-binary-spelunking/references/source-clone.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/references/source-clone.md
@@ -1,0 +1,54 @@
+# Source-clone path: version to git tag to reading source
+
+codex, opencode, and pi are all open source. When the installed version has a corresponding git tag, cloning the source and reading it directly beats spelunking a binary: no minified names, no fragment reassembly, no guessing at a Rust struct's field order.
+
+## Find the tag scheme, don't assume it
+
+Every one of these tools uses a **different tag scheme** for the same-looking version string. Don't guess; derive it with `git ls-remote --tags` before cloning:
+
+```bash
+V=$(codex --version | awk '{print $NF}')                             # e.g. 0.139.0
+git ls-remote --tags https://github.com/openai/codex.git | grep "$V"  # confirms the exact tag string
+```
+
+Confirmed mappings from this recon:
+
+| Tool | Installed version | Repo | Tag |
+|------|-------------------|------|-----|
+| codex | `0.139.0` (`codex --version`) | github.com/openai/codex | `rust-v0.139.0` |
+| opencode | `1.17.5` (`opencode --version`) | github.com/sst/opencode | `v1.17.5` |
+| pi | `0.67.6` (`pi --version`) | github.com/badlogic/pi-mono (monorepo, `packages/coding-agent`) | `v0.67.6` |
+
+Note codex prefixes with `rust-v`, not bare `v`; opencode and pi use bare `v`. This is exactly the kind of detail `git ls-remote --tags | grep` catches and blind-guessing doesn't.
+
+## Clone recipe
+
+```bash
+V=$(codex --version | awk '{print $NF}')
+git ls-remote --tags https://github.com/openai/codex.git | grep "$V"
+git clone --depth 1 --branch rust-v$V https://github.com/openai/codex.git /tmp/codex-src
+```
+
+Swap the repo URL and tag prefix per the table above. `--depth 1` is enough; you're reading one version's source, not the history.
+
+For a monorepo (pi), clone the whole thing and locate the relevant package rather than assuming a matching subdirectory tag exists:
+
+```bash
+V=$(pi --version)
+git clone --depth 1 --branch v$V https://github.com/badlogic/pi-mono.git /tmp/pi-src
+ls /tmp/pi-src/packages/coding-agent
+```
+
+## pi is the boundary case: source this readable means "just read it"
+
+pi's shipped `dist/cli.js` is a thin, readable entry point; the actual coding-agent logic is TypeScript source living in the monorepo, not a minified bundle worth spelunking. There is almost nothing to reverse-engineer: no fragment reassembly, no anchor-hunting, no build-classification step. You clone, `cd packages/coding-agent`, and read the TypeScript like any other open-source project.
+
+This is the far end of the Step 0 decision in the main SKILL.md: when the source is this available and this readable, spelunking the binary is strictly more work for the same or worse answer. Reach for the clone first, every time, for tools built this way. Only fall back to binary spelunking if you specifically need to verify what's *actually installed* on a machine (e.g. confirming a patched build matches source, or the version isn't tagged yet).
+
+## When to still spelunk the binary despite source being available
+
+- The installed version has no matching tag yet (a nightly, a pre-release, a locally patched build).
+- You suspect the shipped binary diverges from what the tagged source claims to build.
+- You need to confirm the exact build that's running on a specific machine right now, not what the source repo says it should be.
+
+In all of these, drop to [bun-js.md](bun-js.md) or [rust.md](rust.md) depending on the build classification from the main SKILL.md's "Identify the build" step.


### PR DESCRIPTION
## Summary

- `harness-binary-spelunking` is now technique-first: how to spelunk any agent-harness CLI binary (Claude Code, codex, opencode, and similar) to learn how it actually behaves, rather than a Claude-Code-only recipe list.
- Leads with the decision that matters. If the tool is open source and the running version is tagged, clone the source at that tag and read it. If it's closed (Claude Code today) or you want ground truth of what actually shipped, spelunk the binary. The recipes then fork on how the binary was built.
- SKILL.md is now a router (decide the approach, identify the build, general method) pointing at three reference files: Bun-compiled JS (Claude Code + opencode), Rust (codex), and the version-to-git-tag source-clone path (with pi as the "just read the source" boundary case).
- Grounded in real recon across three harnesses: codex ships a Rust binary behind an npm launcher shim (prompts come out whole, config keys are plain serde snake_case), and opencode is Bun-compiled like Claude Code but with a different noise profile and anchor scheme (`l.fn(...)` wrappers instead of `tengu_*`).

## Test plan

- `./scripts/validate-plugin-versions.sh` passes and `hk run pre-commit` is green; agent-meta bumped to 2.3.0.
- Skill description stays keyword-rich (system prompt / tool descriptions, UI message to code path, minified function names, undocumented config keys) and now names multiple harnesses, so it surfaces beyond Claude-Code-only asks.
