### PR TITLE
Add git-ssh and keychain-write sandbox failure modes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -101,7 +101,7 @@
     {
       "name": "sandbox-advisor",
       "source": "./plugins/sandbox-advisor",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "name": "gut-check",

--- a/plugins/sandbox-advisor/README.md
+++ b/plugins/sandbox-advisor/README.md
@@ -9,8 +9,8 @@ it. The message is advisory, not a directive.
 Knowledge lives in a **failure-mode registry**. Each mode pairs a command
 matcher with the error fingerprints that mode is known to produce. When a Bash
 command **fails**, the hook checks whether the command matches a known mode and
-whether that mode's fingerprints appear in the failure output. Three modes ship
-in v1, all of which need to run unsandboxed:
+whether that mode's fingerprints appear in the failure output. Five modes ship,
+all of which need to run unsandboxed:
 
 - **git writes inside pt worktrees** -- blocked-path set (`.claude/`, `.vscode/`,
   `.gitmodules`) and `.git/worktrees/.../index.lock`. This deny is *polymorphic*:
@@ -19,6 +19,34 @@ in v1, all of which need to run unsandboxed:
   fingerprint set.
 - **`srb` (sorbet)** -- LMDB uses SysV semaphores the sandbox denies.
 - **`ps` / `top`** -- setuid-root binaries; the sandbox denies setuid exec.
+- **git/gh over SSH** (`git push`/`fetch`/`pull`/`clone`/`ls-remote`, or
+  `gh pr checkout`/`gh repo sync` against a repo whose remote is an SSH URL)
+  -- the sandbox network layer only allows HTTPS to specific allowlisted
+  hosts, so raw SSH on port 22 is denied outright, regardless of the
+  ssh-agent socket (which is already open via `allowAllUnixSockets`).
+  `gh`'s broader command surface is pure REST/GraphQL over HTTPS and
+  unaffected; only `pr checkout`/`co`/`sw` and `repo sync` shell out to git
+  against the *current repo's existing remote* (so they inherit whatever
+  protocol that remote already uses). Commands that clone fresh (`repo
+  clone`, `gist clone`, `repo fork --clone`, `extension install`) use gh's
+  own `git_protocol` config instead, independent of any local remote, and
+  aren't affected unless that config is set to `ssh`. Confirmed empirically:
+  `ssh -T git@github.com` fails with `connect to host github.com port 22:
+  Operation not permitted`; `git`'s own SSH transport (via `core.sshCommand`)
+  fails differently, with `nc: authentication method negotiation failed` /
+  `Connection closed by UNKNOWN port`. `gh` wraps the latter with `failed to
+  run git: exit status 128`. The durable fix is switching the remote/gh
+  protocol to HTTPS, not a sandbox setting -- there's no `allowedHosts`-style
+  knob for raw TCP ports.
+- **macOS Keychain writes** (`gh auth login`/`refresh`/`logout`/`setup-git`,
+  or `security add-*-password`/`delete-*-password`) -- Keychain *writes* go
+  through a `Security.framework` call the sandbox denies outright
+  (`SecKeychainItemCreateFromContent ... Operation not permitted`). Reads are
+  unaffected: `security find-generic-password` and `gh auth status` (which
+  reads an already-stored token) both succeed sandboxed. There's no durable
+  sandbox-side fix here either; the practical workaround is running the
+  auth/write step once unsandboxed -- subsequent reads of that credential
+  work fine sandboxed.
 
 When a mode matches, it injects an advisory note ("this command is known to fail
 under the sandbox; if that's why it failed, re-run with

--- a/plugins/sandbox-advisor/hooks/advise.py
+++ b/plugins/sandbox-advisor/hooks/advise.py
@@ -28,6 +28,29 @@ _MODE_FINGERPRINTS = {
         "operation not permitted",
         "os error 1",
     ),
+    "git-ssh": (
+        # SSH (port 22) egress is blocked outright by the sandbox network
+        # allowlist, which only permits HTTPS to specific hosts -- not the
+        # ssh-agent socket, which is a separate (and already-open) surface.
+        # Deliberately excludes the generic "operation not permitted"
+        # fingerprint: the `gh` matcher below is broad (any gh subcommand),
+        # and that string is common enough in unrelated gh failures to
+        # false-positive.
+        "port 22",
+        "could not read from remote repository",
+        "authentication method negotiation failed",
+        "connection closed by unknown port",
+        "failed to run git: exit status",
+    ),
+    "keychain-write": (
+        # macOS Keychain WRITES go through a Security.framework call the
+        # sandbox denies outright; READS are unaffected (confirmed
+        # empirically: `security find-generic-password` and `gh auth status`
+        # both succeed against an existing item). Narrow matcher below makes
+        # the generic "operation not permitted" fingerprint safe here.
+        "seckeychainitemcreatefromcontent",
+        "operation not permitted",
+    ),
 }
 
 
@@ -39,16 +62,41 @@ def matches_mode_fingerprints(text: str, mode: str) -> bool:
     return any(fp in low for fp in _MODE_FINGERPRINTS.get(mode, ()))
 
 
-# git subcommands that write (worktree/index/refs). Read-only forms
-# (log/show/diff/status/...) are intentionally absent so they classify as None.
+# git subcommands that write locally (worktree/index/refs), MINUS the ones
+# that talk to a remote -- those go through _GIT_NETWORK_SUBCOMMANDS instead,
+# since their sandbox failure mode (SSH port 22 egress) is unrelated to the
+# blocked-path denies this mode covers. Read-only forms (log/show/diff/
+# status/...) are intentionally absent so they classify as None.
 _GIT_WRITE_SUBCOMMANDS = {
     "add", "commit", "rebase", "merge", "cherry-pick", "revert", "rm", "mv",
-    "restore", "reset", "pull", "fetch", "push", "am", "apply", "clean",
-    "checkout", "switch", "clone", "init", "stash", "worktree", "branch", "tag",
+    "restore", "reset", "am", "apply", "clean",
+    "checkout", "switch", "init", "stash", "worktree", "branch", "tag",
 }
+
+# git subcommands that talk to a remote -- fail under the sandbox because raw
+# SSH (port 22) egress is blocked, not because of a blocked write path.
+_GIT_NETWORK_SUBCOMMANDS = {"push", "fetch", "pull", "clone", "ls-remote"}
 
 _SRB_RE = re.compile(r"^(bundle\s+exec\s+)?(\./)?(bin/)?srb(\s|$)")
 _PS_TOP_RE = re.compile(r"^(rtk\s+)?(/usr/bin/|/bin/)?(ps|top)(\s|$)")
+# Deliberately broad: matches ANY gh subcommand, not just the ones that shell
+# out to git. Only `pr checkout`/`co`/`sw` and `repo sync` actually inherit
+# the current repo's remote protocol (and so hit this bug when that remote is
+# SSH); `repo clone`/`gist clone`/`repo fork --clone`/`extension install` use
+# gh's own `git_protocol` config instead, independent of any local remote.
+# The rest of gh is pure REST/GraphQL over HTTPS and never touches this path.
+# Fingerprint gating in decide_advice() is what keeps the broad match safe.
+_GH_RE = re.compile(r"^gh(\s|$)")
+# gh subcommands that write credentials to the macOS Keychain. Checked before
+# _GH_RE so these take "keychain-write" instead of falling into "git-ssh".
+_GH_AUTH_WRITE_RE = re.compile(
+    r"^gh\s+auth\s+(login|refresh|logout|setup-git)(\s|$)"
+)
+# `security` subcommands that write/delete keychain items (vs. find-*, which
+# only reads and is unaffected).
+_SECURITY_WRITE_RE = re.compile(
+    r"^security\s+(add|delete)-(generic|internet)-password(\s|$)"
+)
 _ENV_PREFIX_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*=\S*\s+)+")
 
 
@@ -66,10 +114,11 @@ def _strip_leading_cd_and_env(command: str) -> str:
     return seg.strip()
 
 
-def _is_git_write(seg: str) -> bool:
+def _git_subcommand(seg: str):
+    """Return the git subcommand token, or None if `seg` isn't a `git ...` call."""
     toks = seg.split()
     if not toks or toks[0] != "git":
-        return False
+        return None
     # Skip git global options to find the subcommand.
     i = 1
     while i < len(toks):
@@ -81,18 +130,22 @@ def _is_git_write(seg: str) -> bool:
             i += 1
             continue
         break
-    sub = toks[i] if i < len(toks) else ""
-    return sub in _GIT_WRITE_SUBCOMMANDS
+    return toks[i] if i < len(toks) else ""
 
 
 def classify_command(command: str):
-    """Return 'git-write', 'srb', 'ps-top', or None."""
+    """Return 'git-write', 'git-ssh', 'keychain-write', 'srb', 'ps-top', or None."""
     seg = _strip_leading_cd_and_env(command)
     if _SRB_RE.match(seg):
         return "srb"
     if _PS_TOP_RE.match(seg):
         return "ps-top"
-    if _is_git_write(seg):
+    if _GH_AUTH_WRITE_RE.match(seg) or _SECURITY_WRITE_RE.match(seg):
+        return "keychain-write"
+    sub = _git_subcommand(seg)
+    if sub in _GIT_NETWORK_SUBCOMMANDS or _GH_RE.match(seg):
+        return "git-ssh"
+    if sub in _GIT_WRITE_SUBCOMMANDS:
         return "git-write"
     return None
 
@@ -122,6 +175,30 @@ _ADVICE = {
         "executing setuid/setgid binaries. They are read-only and safe "
         "unsandboxed. If that's why this failed, re-run with "
         "dangerouslyDisableSandbox: true."
+    ),
+    "git-ssh": (
+        "Heads up: git operations over SSH (push, fetch, pull, clone, "
+        "ls-remote), or `gh pr checkout`/`gh repo sync` against a repo whose "
+        "remote is an SSH URL, are KNOWN to fail under the Claude Code "
+        "command sandbox -- the network sandbox only allows HTTPS to "
+        "specific allowlisted hosts, so raw SSH on port 22 is blocked "
+        "outright. This is NOT the ssh-agent socket, which is already open. "
+        "If that's why this failed, re-run with dangerouslyDisableSandbox: "
+        "true, or fix it durably by switching the remote to HTTPS: `git "
+        "remote set-url origin https://github.com/OWNER/REPO.git` (and, if "
+        "cloning/forking fresh via gh, `gh config set -h github.com "
+        "git_protocol https`)."
+    ),
+    "keychain-write": (
+        "Heads up: writing to the macOS Keychain (`gh auth login`/`refresh`/"
+        "`logout`/`setup-git`, or `security add-*-password`/`delete-*-"
+        "password`) is KNOWN to fail under the Claude Code command sandbox "
+        "-- Keychain reads are fine (gh reading an already-stored token "
+        "works), but the write call is denied outright. If that's why this "
+        "failed, re-run with dangerouslyDisableSandbox: true. There's no "
+        "sandbox setting that fixes this durably; the practical workaround "
+        "is to run the auth/write step once outside the sandbox -- reads "
+        "of the resulting credential work fine sandboxed afterward."
     ),
 }
 

--- a/plugins/sandbox-advisor/tests/fixtures/gh-auth-login-keychain-eperm.json
+++ b/plugins/sandbox-advisor/tests/fixtures/gh-auth-login-keychain-eperm.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "gh auth login", "dangerouslyDisableSandbox": false},
+  "tool_response": {"stderr": "security: SecKeychainItemCreateFromContent (<default>): UNIX[Operation not permitted]", "exit_code": 1}
+}

--- a/plugins/sandbox-advisor/tests/fixtures/gh-checkout-ssh-eperm.json
+++ b/plugins/sandbox-advisor/tests/fixtures/gh-checkout-ssh-eperm.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "gh pr checkout 99", "dangerouslyDisableSandbox": false},
+  "tool_response": {"stderr": "nc: authentication method negotiation failed\nConnection closed by UNKNOWN port 65535\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.\nfailed to run git: exit status 128", "exit_code": 1}
+}

--- a/plugins/sandbox-advisor/tests/fixtures/gh-unrelated-error.json
+++ b/plugins/sandbox-advisor/tests/fixtures/gh-unrelated-error.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "gh issue create --title ''", "dangerouslyDisableSandbox": false},
+  "tool_response": {"stderr": "validation failed: title can't be blank", "exit_code": 1}
+}

--- a/plugins/sandbox-advisor/tests/fixtures/git-push-ssh-eperm.json
+++ b/plugins/sandbox-advisor/tests/fixtures/git-push-ssh-eperm.json
@@ -1,0 +1,5 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {"command": "git push origin main", "dangerouslyDisableSandbox": false},
+  "tool_response": {"stderr": "ssh: connect to host github.com port 22: Operation not permitted", "exit_code": 255}
+}

--- a/plugins/sandbox-advisor/tests/test_advise_integration.py
+++ b/plugins/sandbox-advisor/tests/test_advise_integration.py
@@ -51,6 +51,35 @@ def test_ps_eperm_advises_unsandbox():
     assert advice and "setuid" in advice.lower()
 
 
+def test_git_push_ssh_eperm_advises_unsandbox():
+    result = _run_fixture("git-push-ssh-eperm.json")
+    assert result.returncode == 0
+    advice = _advice(result)
+    assert advice and "dangerouslyDisableSandbox" in advice
+    assert "https" in advice.lower()
+
+
+def test_gh_checkout_ssh_eperm_advises_unsandbox():
+    result = _run_fixture("gh-checkout-ssh-eperm.json")
+    assert result.returncode == 0
+    advice = _advice(result)
+    assert advice and "ssh-agent" in advice.lower()
+
+
+def test_gh_unrelated_error_stays_silent():
+    result = _run_fixture("gh-unrelated-error.json")
+    assert result.returncode == 0
+    assert _advice(result) is None
+
+
+def test_gh_auth_login_keychain_eperm_advises_unsandbox():
+    result = _run_fixture("gh-auth-login-keychain-eperm.json")
+    assert result.returncode == 0
+    advice = _advice(result)
+    assert advice and "dangerouslyDisableSandbox" in advice
+    assert "keychain" in advice.lower()
+
+
 def test_srb_typecheck_error_stays_silent():
     result = _run_fixture("srb-typecheck-error.json")
     assert result.returncode == 0

--- a/plugins/sandbox-advisor/tests/test_advise_unit.py
+++ b/plugins/sandbox-advisor/tests/test_advise_unit.py
@@ -56,6 +56,52 @@ class TestMatchesModeFingerprints:
     def test_empty(self):
         assert not advise.matches_mode_fingerprints("", "git-write")
 
+    def test_git_ssh_port_22(self):
+        assert advise.matches_mode_fingerprints(
+            "ssh: connect to host github.com port 22: Operation not permitted",
+            "git-ssh",
+        )
+
+    def test_git_ssh_negotiation_failed(self):
+        assert advise.matches_mode_fingerprints(
+            "nc: authentication method negotiation failed\n"
+            "Connection closed by UNKNOWN port 65535\n"
+            "fatal: Could not read from remote repository.",
+            "git-ssh",
+        )
+
+    def test_git_ssh_gh_wrapped(self):
+        assert advise.matches_mode_fingerprints(
+            "fatal: Could not read from remote repository.\n\n"
+            "Please make sure you have the correct access rights\n"
+            "and the repository exists.\n"
+            "failed to run git: exit status 128",
+            "git-ssh",
+        )
+
+    def test_git_ssh_does_not_fire_on_bare_operation_not_permitted(self):
+        # The generic EPERM string alone must not trigger git-ssh -- it's
+        # excluded from this mode's fingerprints because the `gh` matcher is
+        # broad and would otherwise false-positive on unrelated gh failures.
+        assert not advise.matches_mode_fingerprints(
+            "Operation not permitted", "git-ssh"
+        )
+
+    def test_keychain_write_seckeychain_api_name(self):
+        assert advise.matches_mode_fingerprints(
+            "security: SecKeychainItemCreateFromContent (<default>): "
+            "UNIX[Operation not permitted]",
+            "keychain-write",
+        )
+
+    def test_keychain_write_bare_eperm(self):
+        # Safe here (unlike git-ssh) because the command matcher is narrow:
+        # only gh auth login/refresh/logout/setup-git and security add-/
+        # delete-*-password classify as keychain-write in the first place.
+        assert advise.matches_mode_fingerprints(
+            "Operation not permitted", "keychain-write"
+        )
+
 
 class TestClassifyCommand:
     def test_bare_git_write(self):
@@ -95,6 +141,70 @@ class TestClassifyCommand:
 
     def test_env_prefix_stripped(self):
         assert advise.classify_command("FOO=bar srb tc") == "srb"
+
+    def test_git_push_is_git_ssh_not_git_write(self):
+        assert advise.classify_command("git push origin main") == "git-ssh"
+
+    def test_git_fetch_is_git_ssh(self):
+        assert advise.classify_command("git fetch origin") == "git-ssh"
+
+    def test_git_pull_is_git_ssh(self):
+        assert advise.classify_command("git pull") == "git-ssh"
+
+    def test_git_clone_is_git_ssh(self):
+        assert advise.classify_command(
+            "git clone git@github.com:foo/bar.git"
+        ) == "git-ssh"
+
+    def test_git_ls_remote_is_git_ssh(self):
+        assert advise.classify_command("git ls-remote origin") == "git-ssh"
+
+    def test_gh_pr_checkout_is_git_ssh(self):
+        assert advise.classify_command("gh pr checkout 99") == "git-ssh"
+
+    def test_gh_pr_list_is_git_ssh(self):
+        # Broad on purpose -- fingerprint gating in decide_advice() keeps
+        # unrelated gh failures silent.
+        assert advise.classify_command("gh pr list") == "git-ssh"
+
+    def test_git_add_stays_git_write(self):
+        assert advise.classify_command("git add .") == "git-write"
+
+    def test_gh_auth_login_is_keychain_write(self):
+        assert advise.classify_command("gh auth login") == "keychain-write"
+
+    def test_gh_auth_refresh_is_keychain_write(self):
+        assert advise.classify_command(
+            "gh auth refresh -h github.com"
+        ) == "keychain-write"
+
+    def test_gh_auth_logout_is_keychain_write(self):
+        assert advise.classify_command("gh auth logout") == "keychain-write"
+
+    def test_gh_auth_setup_git_is_keychain_write(self):
+        assert advise.classify_command("gh auth setup-git") == "keychain-write"
+
+    def test_gh_auth_status_is_not_keychain_write(self):
+        # Read-only: must fall through to the broad gh (git-ssh) bucket, not
+        # keychain-write.
+        assert advise.classify_command("gh auth status") == "git-ssh"
+
+    def test_security_add_generic_password_is_keychain_write(self):
+        assert advise.classify_command(
+            "security add-generic-password -a foo -s bar -w baz"
+        ) == "keychain-write"
+
+    def test_security_delete_generic_password_is_keychain_write(self):
+        assert advise.classify_command(
+            "security delete-generic-password -a foo -s bar"
+        ) == "keychain-write"
+
+    def test_security_find_generic_password_is_not_keychain_write(self):
+        # Read-only: unaffected by the sandbox, so it must classify as None
+        # rather than trigger keychain-write advice.
+        assert advise.classify_command(
+            "security find-generic-password -a foo -s bar"
+        ) is None
 
 
 class TestDecideAdvice:
@@ -162,4 +272,74 @@ class TestDecideAdvice:
             "git commit -m 'operation not permitted'",
             "nothing to commit, working tree clean",
         ))
+        assert reason is None
+
+    def test_git_push_ssh_block_advises(self):
+        reason = advise.decide_advice(
+            self._payload(
+                "git push origin main",
+                "ssh: connect to host github.com port 22: "
+                "Operation not permitted",
+            )
+        )
+        assert reason is not None
+        assert "dangerouslyDisableSandbox" in reason
+        assert "https" in reason.lower()
+
+    def test_gh_pr_checkout_ssh_block_advises(self):
+        reason = advise.decide_advice(
+            self._payload(
+                "gh pr checkout 99",
+                "nc: authentication method negotiation failed\n"
+                "Connection closed by UNKNOWN port 65535\n"
+                "fatal: Could not read from remote repository.\n"
+                "failed to run git: exit status 128",
+            )
+        )
+        assert reason is not None
+        assert "ssh-agent" in reason.lower()
+
+    def test_gh_unrelated_failure_stays_silent(self):
+        # gh classifies broadly as git-ssh, but a validation error shares no
+        # fingerprint with the mode -> must stay silent.
+        reason = advise.decide_advice(
+            self._payload(
+                "gh issue create --title ''",
+                "validation failed: title can't be blank",
+            )
+        )
+        assert reason is None
+
+    def test_gh_auth_login_keychain_block_advises(self):
+        reason = advise.decide_advice(
+            self._payload(
+                "gh auth login",
+                "security: SecKeychainItemCreateFromContent (<default>): "
+                "UNIX[Operation not permitted]",
+            )
+        )
+        assert reason is not None
+        assert "dangerouslyDisableSandbox" in reason
+        assert "keychain" in reason.lower()
+
+    def test_security_add_password_keychain_block_advises(self):
+        reason = advise.decide_advice(
+            self._payload(
+                "security add-generic-password -a foo -s bar -w baz",
+                "security: SecKeychainItemCreateFromContent (<default>): "
+                "UNIX[Operation not permitted]",
+            )
+        )
+        assert reason is not None
+        assert "keychain" in reason.lower()
+
+    def test_security_find_password_success_stays_silent(self):
+        # Reads aren't classified at all, so this hook never even considers
+        # it -- included as a belt-and-suspenders check.
+        reason = advise.decide_advice(
+            self._payload(
+                "security find-generic-password -a foo -s bar",
+                "Operation not permitted",
+            )
+        )
         assert reason is None

--- a/plugins/sandbox-advisor/uv.lock
+++ b/plugins/sandbox-advisor/uv.lock
@@ -1,0 +1,156 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "sandbox-advisor"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Summary

- Add a `git-ssh` failure mode: `git push`/`fetch`/`pull`/`clone`/`ls-remote`, and `gh pr checkout`/`gh repo sync` against an SSH remote, fail because the sandbox network layer only allows HTTPS to specific hosts — not raw SSH on port 22. Splits these subcommands out of `git-write`, which they were incorrectly sharing a fingerprint with.
- Add a `keychain-write` failure mode: `gh auth login`/`refresh`/`logout`/`setup-git`, and `security add-*-password`/`delete-*-password`, fail because macOS Keychain writes hit a denied `Security.framework` call. Reads are unaffected.
- Both were previously misdiagnosed as an ssh-agent-socket problem in taskwarrior (`1d5d8fbb`, `66b03c8e`) — confirmed empirically that isn't it; the connection never gets far enough to touch the agent.

## Test plan

- `uv run pytest -q` in `plugins/sandbox-advisor` — 70 passed
- Dogfooded the `git-ssh` mode live: `git push` on this branch hit the exact fingerprint this PR adds coverage for
