### PR TITLE
Add em-dash outbound-content enforcement hook to writing-tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -96,7 +96,7 @@
     {
       "name": "writing-tools",
       "source": "./plugins/writing-tools",
-      "version": "0.1.0"
+      "version": "0.2.0"
     },
     {
       "name": "sandbox-advisor",

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See individual plugin READMEs for details on what each plugin provides.
 | [taskwarrior](plugins/taskwarrior) | Token-dense recipes for taskwarrior CLI: dense listings, single-field lookups, batched exports, full-text search | taskwarrior |
 | [tool-routing](plugins/tool-routing) | Route tool calls to better alternatives (e.g., gh CLI instead of WebFetch for GitHub PRs) | – |
 | [working-in-monorepos](plugins/working-in-monorepos) | Navigate and execute commands in monorepo subprojects | working-in-monorepos |
-| [writing-tools](plugins/writing-tools) | Skills for structuring and formatting prose so it reads well | writing-for-scannability |
+| [writing-tools](plugins/writing-tools) | Prose skills plus a send-time hook that keeps em-dashes out of content you author | writing-for-scannability |
 <!-- END GENERATED PLUGINS -->
 
 ## Usage

--- a/plugins/writing-tools/.claude-plugin/plugin.json
+++ b/plugins/writing-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "writing-tools",
-  "description": "Skills for structuring and formatting prose so it reads well",
+  "description": "Prose skills plus a send-time hook that keeps em-dashes out of content you author",
   "author": {
     "name": "Josh Nichols",
     "email": "josh@technicalpickles.com"

--- a/plugins/writing-tools/.gitignore
+++ b/plugins/writing-tools/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+*.egg-info/

--- a/plugins/writing-tools/README.md
+++ b/plugins/writing-tools/README.md
@@ -1,6 +1,6 @@
 # writing-tools Plugin
 
-Skills for structuring and formatting prose so it reads well.
+Skills for structuring and formatting prose so it reads well, plus a send-time hook that keeps em-dashes out of content you author.
 
 ## Installation
 
@@ -9,6 +9,33 @@ Requires the [pickled-claude-plugins marketplace](../../README.md#installation).
 ```bash
 /plugin install writing-tools@pickled-claude-plugins
 ```
+
+The em-dash hook additionally needs [`uv`](https://docs.astral.sh/uv/) on your PATH (same runtime the `tool-routing` and `buildkite` hooks use). Without `uv` the hook simply doesn't run; the skills are unaffected.
+
+## Em-dash outbound enforcement (hook)
+
+A `PreToolUse` hook that blocks an em-dash (—) when it appears in a send-time call for a tool you've opted in: Slack sends, `gh pr`/`gh issue` authoring, and the like. It never touches `Write`/`Edit` or arbitrary Bash, so docs, code, and your own `grep "—"` / `perl 's/—/:/'` cleanup commands are never blocked.
+
+**Inert by default.** The shipped config (`hooks/emdash-outbound.yaml`) has empty lists, so a fresh install blocks nothing. Opt in by creating your own config at one of (first found wins):
+
+1. `$EMDASH_OUTBOUND_CONFIG` (explicit override)
+2. `${CLAUDE_PROJECT_DIR}/.claude/emdash-outbound.yaml` (per project)
+3. `$HOME/.claude/emdash-outbound.yaml` (personal, all projects)
+
+```yaml
+# ~/.claude/emdash-outbound.yaml
+mcpTools:
+  - mcp__slack__slack_send_message   # your Slack MCP server name will differ
+bashCommands:
+  - gh pr create
+  - gh pr edit
+  - gh pr comment
+  - gh issue comment
+```
+
+Bash commands are matched at the start of the command or after a shell separator (`;` `&&` `||` `|`). For gated `gh` commands, the hook also resolves `--body-file`/`-F` and scans that file. See `hooks/emdash-outbound.yaml` for the annotated default.
+
+Blog and draft-time prose stay with the `writing-voice` skill (which already covers em-dashes) rather than the hook, since there's no clean "publish" call to gate.
 
 ## Skills
 

--- a/plugins/writing-tools/README.md
+++ b/plugins/writing-tools/README.md
@@ -20,7 +20,7 @@ A `PreToolUse` hook that blocks an em-dash (—) when it appears in a send-time 
 
 1. `$EMDASH_OUTBOUND_CONFIG` (explicit override)
 2. `${CLAUDE_PROJECT_DIR}/.claude/emdash-outbound.yaml` (per project)
-3. `$HOME/.claude/emdash-outbound.yaml` (personal, all projects)
+3. `<user config dir>/emdash-outbound.yaml` (personal, all projects), where the user config dir is `$CLAUDE_CONFIG_DIR` if set (a single dir or a `:`/`,`-separated list), otherwise `$HOME/.claude`
 
 ```yaml
 # ~/.claude/emdash-outbound.yaml

--- a/plugins/writing-tools/hooks/emdash-outbound.yaml
+++ b/plugins/writing-tools/hooks/emdash-outbound.yaml
@@ -8,7 +8,9 @@
 # To enable it, copy this file to one of (first found wins):
 #   - $EMDASH_OUTBOUND_CONFIG           (explicit override)
 #   - ${CLAUDE_PROJECT_DIR}/.claude/emdash-outbound.yaml   (per project)
-#   - $HOME/.claude/emdash-outbound.yaml                   (personal, all projects)
+#   - <user config dir>/emdash-outbound.yaml               (personal, all projects)
+#       where <user config dir> is $CLAUDE_CONFIG_DIR if set (a single dir or a
+#       :/,-separated list), otherwise $HOME/.claude
 # and add the tools/commands you want enforced.
 
 # MCP tool names that send content authored as you. Exact-match.

--- a/plugins/writing-tools/hooks/emdash-outbound.yaml
+++ b/plugins/writing-tools/hooks/emdash-outbound.yaml
@@ -1,0 +1,28 @@
+# Em-dash outbound enforcement config (shipped default: INERT).
+#
+# The writing-tools `check` hook blocks an em-dash (—) only when it appears in a
+# send-time call for a tool listed here. With both lists empty, the hook is a
+# no-op: nothing is ever blocked. This is deliberate, so installing the plugin
+# imposes no send-blocking until you opt in.
+#
+# To enable it, copy this file to one of (first found wins):
+#   - $EMDASH_OUTBOUND_CONFIG           (explicit override)
+#   - ${CLAUDE_PROJECT_DIR}/.claude/emdash-outbound.yaml   (per project)
+#   - $HOME/.claude/emdash-outbound.yaml                   (personal, all projects)
+# and add the tools/commands you want enforced.
+
+# MCP tool names that send content authored as you. Exact-match.
+# Example (your Slack MCP server name will differ):
+#   mcpTools:
+#     - mcp__slack__slack_send_message
+mcpTools: []
+
+# Bash command prefixes to enforce (PR/issue authoring, not arbitrary bash).
+# Matched at the start of the command or after a shell separator (; && || |).
+# Example:
+#   bashCommands:
+#     - gh pr create
+#     - gh pr edit
+#     - gh pr comment
+#     - gh issue comment
+bashCommands: []

--- a/plugins/writing-tools/hooks/hooks.json
+++ b/plugins/writing-tools/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --quiet --directory \"${CLAUDE_PLUGIN_ROOT}\" writing-tools check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/writing-tools/pyproject.toml
+++ b/plugins/writing-tools/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "writing-tools"
+version = "0.2.0"
+description = "Claude Code plugin for writing hygiene (em-dash send-time enforcement) plus prose skills"
+requires-python = ">=3.9"
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[project.scripts]
+writing-tools = "writing_tools.cli:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "ruff>=0.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/plugins/writing-tools/src/writing_tools/__init__.py
+++ b/plugins/writing-tools/src/writing_tools/__init__.py
@@ -1,0 +1,3 @@
+"""Writing-tools plugin for Claude Code."""
+
+__version__ = "0.2.0"

--- a/plugins/writing-tools/src/writing_tools/__main__.py
+++ b/plugins/writing-tools/src/writing_tools/__main__.py
@@ -1,0 +1,7 @@
+"""Allow running as python -m writing_tools."""
+
+import sys
+
+from writing_tools.cli import main
+
+sys.exit(main())

--- a/plugins/writing-tools/src/writing_tools/checker.py
+++ b/plugins/writing-tools/src/writing_tools/checker.py
@@ -1,0 +1,142 @@
+"""Em-dash detection and tool/command gating for outbound content.
+
+The rule: block an em-dash (U+2014) only when it appears in a send-time call
+for a tool the config opts in (Slack sends, gh PR/issue authoring). Everything
+else, including arbitrary Bash and the Write/Edit tools, is left alone so
+docs/code and my own cleanup commands never get blocked.
+"""
+
+import json
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from writing_tools.config import Config
+
+EMDASH = "—"  # —
+
+BLOCK_MESSAGE = (
+    "Em-dash (—) in outbound-as-you content. Rewrite it before sending: "
+    "use a comma, colon, parentheses, or split into two sentences."
+)
+
+# gh flags that point at a file whose contents become the outbound body.
+_BODY_FILE_FLAGS = ("--body-file", "-F")
+
+
+@dataclass
+class CheckResult:
+    """Result of checking a tool call."""
+
+    blocked: bool
+    reason: Optional[str] = None
+
+
+def _serialize(tool_input: dict) -> str:
+    """Serialize tool_input for scanning.
+
+    ``ensure_ascii=False`` is required so an em-dash stays as the literal
+    character rather than being escaped to ``\\u2014``.
+    """
+    try:
+        return json.dumps(tool_input, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(tool_input)
+
+
+def _matches_bash_prefix(command: str, prefixes: list[str]) -> bool:
+    """True if the command starts with a configured prefix at a command boundary.
+
+    Matches at the start of the string or right after a shell separator
+    (``;`` ``&&`` ``||`` ``|``), so ``gh pr create ...`` matches but
+    ``grep "gh pr create" foo`` (the prefix quoted inside an argument) does not.
+    """
+    for prefix in prefixes:
+        pattern = r"(?:^|[;&|]\s*)" + re.escape(prefix)
+        if re.search(pattern, command):
+            return True
+    return False
+
+
+def _body_file_paths(command: str) -> list[str]:
+    """Extract file paths referenced by gh's --body-file/-F flags."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return []
+
+    paths: list[str] = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        # --body-file=path or -F=path
+        matched_inline = False
+        for flag in _BODY_FILE_FLAGS:
+            if token.startswith(flag + "="):
+                paths.append(token[len(flag) + 1 :])
+                matched_inline = True
+                break
+        if matched_inline:
+            i += 1
+            continue
+        # --body-file path or -F path
+        if token in _BODY_FILE_FLAGS and i + 1 < len(tokens):
+            paths.append(tokens[i + 1])
+            i += 2
+            continue
+        i += 1
+    return paths
+
+
+def _body_file_has_emdash(command: str) -> bool:
+    for path in _body_file_paths(command):
+        try:
+            content = Path(path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if EMDASH in content:
+            return True
+    return False
+
+
+def check_tool_call(tool_call: dict, load_config: Callable[[], Config]) -> CheckResult:
+    """Check a PreToolUse tool call for outbound em-dashes.
+
+    ``load_config`` is a zero-arg callable returning a :class:`Config`. It's
+    passed lazily so the config is only loaded when there's actually something
+    to check (the common no-em-dash case stays cheap).
+    """
+    tool_name = tool_call.get("tool_name", "")
+    tool_input = tool_call.get("tool_input", {}) or {}
+
+    serialized = _serialize(tool_input)
+    command = tool_input.get("command", "") if tool_name == "Bash" else ""
+    has_body_file = bool(command) and any(f in command for f in _BODY_FILE_FLAGS)
+
+    # Fast path: no em-dash in the direct input and no body-file to chase means
+    # there is nothing to block. Skip loading the config entirely.
+    if EMDASH not in serialized and not has_body_file:
+        return CheckResult(blocked=False)
+
+    config = load_config()
+    if config.is_empty():
+        # Inert: no tools opted in (e.g. a fresh installer). Never block.
+        return CheckResult(blocked=False)
+
+    if tool_name.startswith("mcp__"):
+        if tool_name in config.mcp_tools and EMDASH in serialized:
+            return CheckResult(blocked=True, reason=BLOCK_MESSAGE)
+        return CheckResult(blocked=False)
+
+    if tool_name == "Bash":
+        if not _matches_bash_prefix(command, config.bash_commands):
+            # Arbitrary bash (incl. my own grep/perl em-dash cleanup): allow.
+            return CheckResult(blocked=False)
+        if EMDASH in command or _body_file_has_emdash(command):
+            return CheckResult(blocked=True, reason=BLOCK_MESSAGE)
+        return CheckResult(blocked=False)
+
+    # Any other tool (Write, Edit, unmonitored MCP tools): leave it alone.
+    return CheckResult(blocked=False)

--- a/plugins/writing-tools/src/writing_tools/cli.py
+++ b/plugins/writing-tools/src/writing_tools/cli.py
@@ -1,0 +1,69 @@
+"""Command-line interface for writing-tools."""
+
+import argparse
+import json
+import os
+import sys
+
+from writing_tools.checker import check_tool_call
+from writing_tools.config import load_config
+
+DEBUG = os.environ.get("WRITING_TOOLS_DEBUG", "").lower() in ("1", "true", "yes")
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    """PreToolUse hook entry point: block outbound em-dashes.
+
+    Reads the tool call JSON from stdin, decides, and on a block emits the
+    Claude Code deny decision to stdout. Always exits 0 (fail open); a crash
+    or malformed input must never wedge the tool it's gating.
+    """
+    try:
+        raw_input = sys.stdin.read()
+        tool_call = json.loads(raw_input)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    try:
+        result = check_tool_call(tool_call, load_config)
+    except Exception as e:  # noqa: BLE001 - fail open on any checker error
+        if DEBUG:
+            print(f"writing-tools check errored (allowing): {e}", file=sys.stderr)
+        return 0
+
+    if result.blocked:
+        if DEBUG:
+            print(f"❌ writing-tools: {result.reason}", file=sys.stderr)
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": result.reason,
+            }
+        }
+        print(json.dumps(output))
+        return 0
+
+    return 0
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        prog="writing-tools",
+        description="Writing hygiene checks for Claude Code",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = subparsers.add_parser(
+        "check",
+        help="Check a tool call for outbound em-dashes (hook entry point)",
+    )
+    check_parser.set_defaults(func=cmd_check)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/writing-tools/src/writing_tools/config.py
+++ b/plugins/writing-tools/src/writing_tools/config.py
@@ -7,6 +7,7 @@ outside the versioned plugin (see the discovery order in ``find_config_path``).
 """
 
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -35,13 +36,35 @@ def _shipped_config_path() -> Path:
     return Path(__file__).resolve().parent.parent.parent / "hooks" / "emdash-outbound.yaml"
 
 
+def _user_config_dirs() -> list[Path]:
+    """User-level Claude config directories, honoring ``CLAUDE_CONFIG_DIR``.
+
+    When ``CLAUDE_CONFIG_DIR`` is set it relocates Claude Code's ``~/.claude``
+    directory, so a personal config would live there instead. It accepts a
+    single path or a ``:``/``,``-separated list; when unset, ``$HOME/.claude``
+    is the default. Returned in precedence order.
+    """
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    if config_dir:
+        dirs = [Path(p.strip()) for p in re.split(r"[:,]", config_dir) if p.strip()]
+        if dirs:
+            return dirs
+
+    home = os.environ.get("HOME", "")
+    if home:
+        return [Path(home) / ".claude"]
+
+    return []
+
+
 def find_config_path() -> Optional[Path]:
     """Locate the config file, first found wins.
 
     Discovery order:
       1. ``$EMDASH_OUTBOUND_CONFIG`` (env override, used by tests)
       2. ``${CLAUDE_PROJECT_DIR}/.claude/emdash-outbound.yaml``
-      3. ``$HOME/.claude/emdash-outbound.yaml``
+      3. ``<user config dir>/emdash-outbound.yaml`` for each user config dir
+         (``$CLAUDE_CONFIG_DIR`` if set, else ``$HOME/.claude``)
       4. the plugin's shipped ``hooks/emdash-outbound.yaml`` (inert default)
     """
     candidates: list[Path] = []
@@ -54,9 +77,8 @@ def find_config_path() -> Optional[Path]:
     if project_dir:
         candidates.append(Path(project_dir) / ".claude" / "emdash-outbound.yaml")
 
-    home = os.environ.get("HOME", "")
-    if home:
-        candidates.append(Path(home) / ".claude" / "emdash-outbound.yaml")
+    for config_dir in _user_config_dirs():
+        candidates.append(config_dir / "emdash-outbound.yaml")
 
     candidates.append(_shipped_config_path())
 

--- a/plugins/writing-tools/src/writing_tools/config.py
+++ b/plugins/writing-tools/src/writing_tools/config.py
@@ -1,0 +1,107 @@
+"""Configuration loading for em-dash outbound enforcement.
+
+The config names which tools send content authored as me, so em-dashes get
+blocked only in those. Everything else is left alone. The config is discovered
+from the first of several locations that exists, so personal targeting can live
+outside the versioned plugin (see the discovery order in ``find_config_path``).
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+@dataclass
+class Config:
+    """Which tools/commands to enforce em-dash blocking on."""
+
+    mcp_tools: list[str] = field(default_factory=list)
+    bash_commands: list[str] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        """True when nothing is opted in, so the hook is a no-op (inert)."""
+        return not self.mcp_tools and not self.bash_commands
+
+
+def _shipped_config_path() -> Path:
+    """The plugin's own inert default config (empty lists).
+
+    Located relative to this file: src/writing_tools/config.py ->
+    <plugin_root>/hooks/emdash-outbound.yaml.
+    """
+    return Path(__file__).resolve().parent.parent.parent / "hooks" / "emdash-outbound.yaml"
+
+
+def find_config_path() -> Optional[Path]:
+    """Locate the config file, first found wins.
+
+    Discovery order:
+      1. ``$EMDASH_OUTBOUND_CONFIG`` (env override, used by tests)
+      2. ``${CLAUDE_PROJECT_DIR}/.claude/emdash-outbound.yaml``
+      3. ``$HOME/.claude/emdash-outbound.yaml``
+      4. the plugin's shipped ``hooks/emdash-outbound.yaml`` (inert default)
+    """
+    candidates: list[Path] = []
+
+    explicit = os.environ.get("EMDASH_OUTBOUND_CONFIG", "")
+    if explicit:
+        candidates.append(Path(explicit))
+
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if project_dir:
+        candidates.append(Path(project_dir) / ".claude" / "emdash-outbound.yaml")
+
+    home = os.environ.get("HOME", "")
+    if home:
+        candidates.append(Path(home) / ".claude" / "emdash-outbound.yaml")
+
+    candidates.append(_shipped_config_path())
+
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def load_config() -> Config:
+    """Load the enforcement config (fail open to inert on any problem)."""
+    path = find_config_path()
+    if path is None:
+        return Config()
+    return load_config_file(path)
+
+
+def load_config_file(path: Path) -> Config:
+    """Load a config from a specific YAML file.
+
+    Returns an empty (inert) Config if the file is missing or unparseable
+    (fail open).
+    """
+    if not path.exists():
+        return Config()
+
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return Config()
+
+    if not isinstance(data, dict):
+        return Config()
+
+    mcp_tools = data.get("mcpTools") or []
+    bash_commands = data.get("bashCommands") or []
+
+    # Guard against a scalar or malformed value where a list is expected.
+    if not isinstance(mcp_tools, list):
+        mcp_tools = []
+    if not isinstance(bash_commands, list):
+        bash_commands = []
+
+    return Config(
+        mcp_tools=[str(t) for t in mcp_tools],
+        bash_commands=[str(c) for c in bash_commands],
+    )

--- a/plugins/writing-tools/tests/conftest.py
+++ b/plugins/writing-tools/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Pytest configuration for writing-tools tests."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def cli_env(tmp_path):
+    """Environment dict for CLI subprocess calls.
+
+    Includes PYTHONPATH so the subprocess can import writing_tools, and points
+    EMDASH_OUTBOUND_CONFIG at a per-test config path for isolation (bypassing
+    the personal/project/shipped discovery chain).
+    """
+    src_path = Path(__file__).parent.parent / "src"
+    config_file = tmp_path / "emdash-outbound.yaml"
+    return {
+        "PYTHONPATH": str(src_path),
+        "PATH": os.environ.get("PATH", ""),
+        "EMDASH_OUTBOUND_CONFIG": str(config_file),
+    }

--- a/plugins/writing-tools/tests/test_checker.py
+++ b/plugins/writing-tools/tests/test_checker.py
@@ -1,0 +1,151 @@
+"""Tests for the em-dash checker."""
+
+from writing_tools.checker import check_tool_call
+from writing_tools.config import Config
+
+EMDASH = "—"
+
+SLACK_TOOL = "mcp__slackgustoofficialmcp__slack_send_message"
+
+
+def cfg(mcp_tools=None, bash_commands=None):
+    """Build a config-loader callable for a given Config."""
+    config = Config(mcp_tools=mcp_tools or [], bash_commands=bash_commands or [])
+    return lambda: config
+
+
+def test_configured_mcp_tool_with_emdash_blocks():
+    call = {
+        "tool_name": SLACK_TOOL,
+        "tool_input": {"text": f"hey {EMDASH} check this"},
+    }
+    result = check_tool_call(call, cfg(mcp_tools=[SLACK_TOOL]))
+    assert result.blocked is True
+    assert result.reason
+
+
+def test_configured_mcp_tool_without_emdash_allows():
+    call = {
+        "tool_name": SLACK_TOOL,
+        "tool_input": {"text": "hey, check this"},
+    }
+    result = check_tool_call(call, cfg(mcp_tools=[SLACK_TOOL]))
+    assert result.blocked is False
+
+
+def test_unconfigured_mcp_tool_with_emdash_allows():
+    call = {
+        "tool_name": "mcp__other__send",
+        "tool_input": {"text": f"hey {EMDASH} there"},
+    }
+    result = check_tool_call(call, cfg(mcp_tools=[SLACK_TOOL]))
+    assert result.blocked is False
+
+
+def test_gh_pr_create_with_emdash_in_command_blocks():
+    call = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f'gh pr create --title "Fix {EMDASH} thing"'},
+    }
+    result = check_tool_call(call, cfg(bash_commands=["gh pr create"]))
+    assert result.blocked is True
+
+
+def test_gh_pr_create_body_file_with_emdash_blocks(tmp_path):
+    body = tmp_path / "body.md"
+    body.write_text(f"This PR does a thing {EMDASH} and another thing.")
+    call = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f"gh pr create --title clean --body-file {body}"},
+    }
+    result = check_tool_call(call, cfg(bash_commands=["gh pr create"]))
+    assert result.blocked is True
+
+
+def test_gh_pr_create_body_file_clean_allows(tmp_path):
+    body = tmp_path / "body.md"
+    body.write_text("This PR does a thing, and another thing.")
+    call = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f"gh pr create --title clean --body-file {body}"},
+    }
+    result = check_tool_call(call, cfg(bash_commands=["gh pr create"]))
+    assert result.blocked is False
+
+
+def test_gh_pr_create_body_file_equals_form_blocks(tmp_path):
+    body = tmp_path / "body.md"
+    body.write_text(f"body with {EMDASH} dash")
+    call = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f"gh pr create --body-file={body}"},
+    }
+    result = check_tool_call(call, cfg(bash_commands=["gh pr create"]))
+    assert result.blocked is True
+
+
+def test_non_gh_bash_with_emdash_allows():
+    """My own cleanup commands must never be blocked."""
+    call = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f'grep "{EMDASH}" foo.md'},
+    }
+    result = check_tool_call(call, cfg(bash_commands=["gh pr create"]))
+    assert result.blocked is False
+
+
+def test_perl_emdash_substitution_allows():
+    call = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f"perl -pi -e 's/{EMDASH}/: /g' notes.md"},
+    }
+    result = check_tool_call(call, cfg(bash_commands=["gh pr create"]))
+    assert result.blocked is False
+
+
+def test_prefix_quoted_inside_argument_does_not_match():
+    """A gated prefix appearing inside a quoted arg is not a real invocation."""
+    call = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f'grep "gh pr create" log.txt {EMDASH}x'},
+    }
+    result = check_tool_call(call, cfg(bash_commands=["gh pr create"]))
+    assert result.blocked is False
+
+
+def test_gated_command_after_separator_matches():
+    call = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f'cd repo && gh pr comment --body "wait {EMDASH} no"'},
+    }
+    result = check_tool_call(call, cfg(bash_commands=["gh pr comment"]))
+    assert result.blocked is True
+
+
+def test_empty_config_allows_everything():
+    """Inert default: nothing opted in, nothing blocked."""
+    call = {
+        "tool_name": SLACK_TOOL,
+        "tool_input": {"text": f"hey {EMDASH} there"},
+    }
+    result = check_tool_call(call, cfg())
+    assert result.blocked is False
+
+
+def test_write_tool_left_alone():
+    call = {
+        "tool_name": "Write",
+        "tool_input": {"file_path": "/tmp/x.md", "content": f"doc with {EMDASH} dash"},
+    }
+    result = check_tool_call(call, cfg(mcp_tools=[SLACK_TOOL], bash_commands=["gh pr create"]))
+    assert result.blocked is False
+
+
+def test_emdash_escaped_in_json_still_detected():
+    """ensure_ascii=False keeps the literal char, so nested dict values match."""
+    call = {
+        "tool_name": SLACK_TOOL,
+        "tool_input": {"blocks": [{"type": "section", "text": f"nested {EMDASH} dash"}]},
+    }
+    result = check_tool_call(call, cfg(mcp_tools=[SLACK_TOOL]))
+    assert result.blocked is True

--- a/plugins/writing-tools/tests/test_cli.py
+++ b/plugins/writing-tools/tests/test_cli.py
@@ -1,0 +1,80 @@
+"""End-to-end tests for the CLI hook entry point (subprocess)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+EMDASH = "—"
+SLACK_TOOL = "mcp__slackgustoofficialmcp__slack_send_message"
+
+
+def run_check(payload: dict, cli_env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "writing_tools", "check"],
+        input=json.dumps(payload, ensure_ascii=False),
+        capture_output=True,
+        text=True,
+        env=cli_env,
+    )
+
+
+def write_config(cli_env: dict, contents: str) -> None:
+    Path(cli_env["EMDASH_OUTBOUND_CONFIG"]).write_text(contents)
+
+
+def test_blocks_configured_slack_send(cli_env):
+    write_config(cli_env, f"mcpTools:\n  - {SLACK_TOOL}\n")
+    payload = {"tool_name": SLACK_TOOL, "tool_input": {"text": f"hi {EMDASH} there"}}
+    result = run_check(payload, cli_env)
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+
+
+def test_allows_clean_slack_send(cli_env):
+    write_config(cli_env, f"mcpTools:\n  - {SLACK_TOOL}\n")
+    payload = {"tool_name": SLACK_TOOL, "tool_input": {"text": "hi there"}}
+    result = run_check(payload, cli_env)
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_allows_when_config_empty(cli_env):
+    write_config(cli_env, "mcpTools: []\nbashCommands: []\n")
+    payload = {"tool_name": SLACK_TOOL, "tool_input": {"text": f"hi {EMDASH} there"}}
+    result = run_check(payload, cli_env)
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_blocks_gh_pr_create(cli_env):
+    write_config(cli_env, "bashCommands:\n  - gh pr create\n")
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f'gh pr create --title "x {EMDASH} y"'},
+    }
+    result = run_check(payload, cli_env)
+    out = json.loads(result.stdout)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_allows_grep_cleanup(cli_env):
+    write_config(cli_env, "bashCommands:\n  - gh pr create\n")
+    payload = {"tool_name": "Bash", "tool_input": {"command": f'grep "{EMDASH}" f.md'}}
+    result = run_check(payload, cli_env)
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_malformed_stdin_fails_open(cli_env):
+    result = subprocess.run(
+        [sys.executable, "-m", "writing_tools", "check"],
+        input="not json{{{",
+        capture_output=True,
+        text=True,
+        env=cli_env,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""

--- a/plugins/writing-tools/tests/test_config.py
+++ b/plugins/writing-tools/tests/test_config.py
@@ -1,0 +1,75 @@
+"""Tests for config loading and discovery."""
+
+import os
+
+from writing_tools.config import Config, find_config_path, load_config, load_config_file
+
+
+def test_missing_file_is_inert(tmp_path):
+    config = load_config_file(tmp_path / "nope.yaml")
+    assert config.is_empty()
+
+
+def test_empty_lists_is_inert(tmp_path):
+    path = tmp_path / "c.yaml"
+    path.write_text("mcpTools: []\nbashCommands: []\n")
+    config = load_config_file(path)
+    assert config.is_empty()
+
+
+def test_loads_lists(tmp_path):
+    path = tmp_path / "c.yaml"
+    path.write_text(
+        "mcpTools:\n  - mcp__slack__send\nbashCommands:\n  - gh pr create\n"
+    )
+    config = load_config_file(path)
+    assert config.mcp_tools == ["mcp__slack__send"]
+    assert config.bash_commands == ["gh pr create"]
+    assert not config.is_empty()
+
+
+def test_absent_keys_default_empty(tmp_path):
+    path = tmp_path / "c.yaml"
+    path.write_text("# just a comment\n")
+    config = load_config_file(path)
+    assert config.is_empty()
+
+
+def test_malformed_yaml_fails_open(tmp_path):
+    path = tmp_path / "c.yaml"
+    path.write_text("mcpTools: [unterminated\n")
+    config = load_config_file(path)
+    assert config.is_empty()
+
+
+def test_scalar_where_list_expected_fails_open(tmp_path):
+    path = tmp_path / "c.yaml"
+    path.write_text("mcpTools: nope\nbashCommands: 5\n")
+    config = load_config_file(path)
+    assert config.is_empty()
+
+
+def test_explicit_env_override_wins(tmp_path, monkeypatch):
+    path = tmp_path / "explicit.yaml"
+    path.write_text("mcpTools:\n  - mcp__x__y\n")
+    monkeypatch.setenv("EMDASH_OUTBOUND_CONFIG", str(path))
+    assert find_config_path() == path
+    assert load_config().mcp_tools == ["mcp__x__y"]
+
+
+def test_shipped_default_is_fallback_and_inert(monkeypatch):
+    """With no overrides, discovery falls back to the shipped inert config."""
+    monkeypatch.delenv("EMDASH_OUTBOUND_CONFIG", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    # Point HOME somewhere without a config so we fall through to shipped.
+    monkeypatch.setenv("HOME", os.path.join(os.sep, "nonexistent-writing-tools-home"))
+    path = find_config_path()
+    assert path is not None
+    assert path.name == "emdash-outbound.yaml"
+    assert load_config_file(path).is_empty()
+
+
+def test_config_dataclass_is_empty():
+    assert Config().is_empty()
+    assert not Config(mcp_tools=["x"]).is_empty()
+    assert not Config(bash_commands=["y"]).is_empty()

--- a/plugins/writing-tools/tests/test_config.py
+++ b/plugins/writing-tools/tests/test_config.py
@@ -57,16 +57,70 @@ def test_explicit_env_override_wins(tmp_path, monkeypatch):
     assert load_config().mcp_tools == ["mcp__x__y"]
 
 
-def test_shipped_default_is_fallback_and_inert(monkeypatch):
-    """With no overrides, discovery falls back to the shipped inert config."""
+def _clear_discovery_env(monkeypatch):
     monkeypatch.delenv("EMDASH_OUTBOUND_CONFIG", raising=False)
     monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+
+def test_shipped_default_is_fallback_and_inert(monkeypatch):
+    """With no overrides, discovery falls back to the shipped inert config."""
+    _clear_discovery_env(monkeypatch)
     # Point HOME somewhere without a config so we fall through to shipped.
     monkeypatch.setenv("HOME", os.path.join(os.sep, "nonexistent-writing-tools-home"))
     path = find_config_path()
     assert path is not None
     assert path.name == "emdash-outbound.yaml"
     assert load_config_file(path).is_empty()
+
+
+def test_claude_config_dir_is_honored(tmp_path, monkeypatch):
+    """A relocated config dir is where the personal config is looked up."""
+    _clear_discovery_env(monkeypatch)
+    cfg_dir = tmp_path / "custom-claude"
+    cfg_dir.mkdir()
+    (cfg_dir / "emdash-outbound.yaml").write_text("mcpTools:\n  - mcp__relocated__send\n")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(cfg_dir))
+    assert find_config_path() == cfg_dir / "emdash-outbound.yaml"
+    assert load_config().mcp_tools == ["mcp__relocated__send"]
+
+
+def test_claude_config_dir_overrides_home(tmp_path, monkeypatch):
+    """When CLAUDE_CONFIG_DIR is set, ~/.claude is not the personal location."""
+    _clear_discovery_env(monkeypatch)
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude" / "emdash-outbound.yaml").write_text("mcpTools:\n  - mcp__home__send\n")
+    cfg_dir = tmp_path / "custom-claude"
+    cfg_dir.mkdir()
+    (cfg_dir / "emdash-outbound.yaml").write_text("mcpTools:\n  - mcp__custom__send\n")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(cfg_dir))
+    assert load_config().mcp_tools == ["mcp__custom__send"]
+
+
+def test_claude_config_dir_list_first_existing_wins(tmp_path, monkeypatch):
+    """A :/,-separated CLAUDE_CONFIG_DIR list is searched in order."""
+    _clear_discovery_env(monkeypatch)
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    # Only the second dir has a config; the first is skipped.
+    (second / "emdash-outbound.yaml").write_text("mcpTools:\n  - mcp__second__send\n")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", f"{first}:{second}")
+    assert find_config_path() == second / "emdash-outbound.yaml"
+    assert load_config().mcp_tools == ["mcp__second__send"]
+
+
+def test_home_used_when_config_dir_unset(tmp_path, monkeypatch):
+    _clear_discovery_env(monkeypatch)
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude" / "emdash-outbound.yaml").write_text("bashCommands:\n  - gh pr create\n")
+    monkeypatch.setenv("HOME", str(home))
+    assert find_config_path() == home / ".claude" / "emdash-outbound.yaml"
+    assert load_config().bash_commands == ["gh pr create"]
 
 
 def test_config_dataclass_is_empty():

--- a/plugins/writing-tools/uv.lock
+++ b/plugins/writing-tools/uv.lock
@@ -1,0 +1,305 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/67fc8e68a75f738c9200422bf65693fb79a4cd0dc5b23310e5202e978090/pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da", size = 184450, upload-time = "2025-09-25T21:33:00.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/92/861f152ce87c452b11b9d0977952259aa7df792d71c1053365cc7b09cc08/pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917", size = 174319, upload-time = "2025-09-25T21:33:02.086Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cd/f0cfc8c74f8a030017a2b9c771b7f47e5dd702c3e28e5b2071374bda2948/pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9", size = 737631, upload-time = "2025-09-25T21:33:03.25Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/b2/18f2bd28cd2055a79a46c9b0895c0b3d987ce40ee471cecf58a1a0199805/pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5", size = 836795, upload-time = "2025-09-25T21:33:05.014Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b9/793686b2d54b531203c160ef12bec60228a0109c79bae6c1277961026770/pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a", size = 750767, upload-time = "2025-09-25T21:33:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/86/a137b39a611def2ed78b0e66ce2fe13ee701a07c07aebe55c340ed2a050e/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926", size = 727982, upload-time = "2025-09-25T21:33:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/62/71c27c94f457cf4418ef8ccc71735324c549f7e3ea9d34aba50874563561/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7", size = 755677, upload-time = "2025-09-25T21:33:09.876Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/6f5e0d58bd924fb0d06c3a6bad00effbdae2de5adb5cda5648006ffbd8d3/pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0", size = 142592, upload-time = "2025-09-25T21:33:10.983Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0c/25113e0b5e103d7f1490c0e947e303fe4a696c10b501dea7a9f49d4e876c/pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007", size = 158777, upload-time = "2025-09-25T21:33:15.55Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "writing-tools"
+version = "0.2.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+]
+provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

- Adds an em-dash send-time hook to `writing-tools`: a `PreToolUse` hook that blocks an em-dash (—) when it shows up in a send-time call for an opted-in tool (Slack sends, `gh` PR/issue authoring). It's the reliability net behind the "no em-dashes in outbound-as-me content" rule.
- Config-driven and **inert by default**. The shipped `hooks/emdash-outbound.yaml` has empty lists, so installing the plugin blocks nothing until you opt in via a personal `~/.claude/emdash-outbound.yaml` or a per-project `.claude/emdash-outbound.yaml`. Personal targeting stays out of the versioned plugin.
- Deliberately narrow: `Write`/`Edit` and arbitrary Bash are never touched, so docs, code, and your own `grep "—"` / `perl 's/—/:/'` cleanup commands are safe. For gated `gh` commands it also resolves `--body-file`/`-F` and scans that file.
- Mirrors the `tool-routing` house pattern (uv-run Python package, `pyyaml`, `check` subcommand, JSON deny decision on stdout, fail-open on any error).

## Test plan

- `uv run --extra dev pytest tests/` in `plugins/writing-tools` (checker units, config discovery, CLI subprocess round-trips).
- Manual smoke: `echo '<PreToolUse payload>' | uv run --quiet --directory plugins/writing-tools writing-tools check` returns a deny decision for a configured tool carrying an em-dash and stays silent otherwise.
