### PR TITLE
fix(second-brain): collapse distill-conversation note staging into one atomic call

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.9.0"
+      "version": "1.9.1"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/commands/distill-conversation.md
+++ b/plugins/second-brain/commands/distill-conversation.md
@@ -119,39 +119,40 @@ For each selected insight, write a clean prose bullet:
 - One short paragraph per insight
 - Format: `- **{name}**: {description}`
 
-Stage the full content (optional framing paragraph + bullets) in a temp file:
+**5c. Stage and create the note in one Bash call:**
+
+Stage the full content (optional framing paragraph + bullets) in a `mktemp`-generated file and immediately read it back for `sb note create`, **in the same Bash tool call**:
 
 ```bash
-cat > "$TMPDIR/distill-content.txt" <<'EOF'
+STAGE=$(mktemp)
+cat > "$STAGE" <<'EOF'
 {optional framing paragraph}
 
 - **{name}**: {description}
 - **{name}**: {description}
 EOF
-```
 
-A temp file is preferred over inlining `--content "..."` because heredoc-quoted content avoids shell escaping bugs on multi-line markdown.
-
-**5c. Create the note:**
-
-```bash
 npx @techpickles/sb note create \
   --title "Session: {topic}" \
   --source "{session-context-string}" \
-  --content "$(cat "$TMPDIR/distill-content.txt")"
+  --content "$(cat "$STAGE")"
+
+rm -f "$STAGE"
 ```
+
+A staged file is preferred over inlining `--content "..."` because heredoc-quoted content avoids shell escaping bugs on multi-line markdown. It must be a fresh `mktemp` path, not a fixed filename: `$TMPDIR` is shared across every Claude Code session on the machine, and a fixed-name file (e.g. `$TMPDIR/distill-content.txt`) can be overwritten or read by a stale write from a different session. The stage-then-read must also happen in one Bash call, not two — see 5d for why.
 
 Parse the returned JSON for the `path` field; show it in the confirmation.
 
 **5d. Sandbox EPERM on vault writes:**
 
-Vault paths like `~/.claude/vaults/primary` symlink into directories outside Claude Code's sandbox writeable allowlist. The first `sb note create` against the vault in a session will fail with:
+Vault paths like `~/.claude/vaults/primary` symlink into directories outside Claude Code's sandbox writeable allowlist. The `sb note create` call above will fail with:
 
 ```
 Error: EPERM: operation not permitted, open '/path/to/vault/📫 Inbox/...'
 ```
 
-This is not an sb bug — retry the same command with the Bash tool's `dangerouslyDisableSandbox: true` option. Subsequent vault writes in the same session usually succeed without retry.
+This is not an sb bug. But `$TMPDIR` resolves to a *different path* under `dangerouslyDisableSandbox: true` than under the normal sandbox, so a file staged in the sandboxed call is not visible to an unsandboxed retry (and vice versa). **Never retry just the `note create` half** — re-run the entire 5c block (mktemp + heredoc + note-create + rm) as one Bash call with `dangerouslyDisableSandbox: true`, so staging and reading happen under the same sandbox mode. Subsequent vault writes in the same session usually succeed without retry.
 
 **5e. Confirm:**
 


### PR DESCRIPTION
## Summary
- `distill-conversation` staged note content in a fixed-name `$TMPDIR/distill-content.txt` and read it back in a separate Bash call, then retried only the `note create` half on sandbox EPERM without restaging.
- `$TMPDIR` resolves to different paths under sandboxed vs `dangerouslyDisableSandbox: true` Bash calls, and both are shared across every Claude Code session on the machine, so the EPERM-retry path could silently read a stale file left by an unrelated session, clobbering a note's body with old content while frontmatter/title stayed correct.
- Fix: use a fresh `mktemp` path per invocation, and do stage + create + cleanup in a single Bash call so both sandbox-mode boundaries see the same file. The EPERM retry now reruns the whole block instead of just re-reading the old path.
- Bumped `second-brain` plugin version 1.9.0 → 1.9.1.

Fixes #103

## Test plan
- [x] Confirmed the fixed-filename staging pattern is fully removed from `distill-conversation.md`
- [x] Confirmed no other second-brain command uses the same `$TMPDIR/<fixed-name>` pattern (`grep -rn 'TMPDIR/' plugins/second-brain/`)
- [x] Read through the updated steps 5b-5e as an instruction a future Claude session would follow
- [ ] No automated test harness exists for markdown-instruction skills; this is a documentation/instruction fix, not exercised by CI