### PR TITLE
fix(actually-lsp): stop set -e from swallowing the probe fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "actually-lsp",
       "source": "./plugins/actually-lsp",
-      "version": "0.7.0"
+      "version": "0.7.1"
     },
     {
       "name": "working-in-monorepos",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,12 +142,13 @@ Scope must match `[a-z0-9-]+` (lowercase letters, numbers, hyphens only).
 - `fix: ...` - bare `feat`/`fix`/`perf` without a scope is rejected (use `fix(repo): ...`)
 - `fix(ci-cd-tools,dev-tools): ...` - commas not allowed
 - `fix(CI-CD): ...` - uppercase not allowed
+- `fix(plugin): ...` / `chore(plugin): ...` - literal `plugin` is not a scope; use the actual plugin name (e.g. `chore(actually-lsp): ...`)
 
 For changes touching multiple plugins, either:
 1. Use the `repo` scope: `fix(repo): use markdown links in skills`
 2. Make separate commits per plugin
 
-**Bump versions in your PR.** Run `./scripts/bump-version.sh --auto` to apply the bumps that conventional commits imply, then commit the result as `chore(plugin): bump version to X.Y.Z`. The Version Check workflow blocks merge until pending bumps are applied.
+**Bump versions in your PR.** Run `./scripts/bump-version.sh --auto` to apply the bumps that conventional commits imply, then commit the result as `chore({plugin}): bump version to X.Y.Z` — `{plugin}` is the actual plugin name being bumped (e.g. `chore(actually-lsp): bump version to 0.7.1`), not the literal word `plugin`. The Version Check workflow blocks merge until pending bumps are applied.
 
 → Full details: [`docs/versioning.md`](docs/versioning.md)
 
@@ -184,7 +185,7 @@ The `@path/to/file` import syntax is a CLAUDE.md-specific feature. In SKILL.md f
 1. Create a branch from `main`
 2. Make changes to plugin source in `plugins/{name}/`
 3. Test locally with appropriate env vars
-4. Commit using conventional format: `feat(plugin): description`
-5. Run `./scripts/bump-version.sh --auto` (also regenerates the README plugin table) and commit as `chore(plugin): bump version to X.Y.Z`
+4. Commit using conventional format: `feat({plugin}): description` — `{plugin}` is the actual plugin name, e.g. `feat(actually-lsp): description`
+5. Run `./scripts/bump-version.sh --auto` (also regenerates the README plugin table) and commit as `chore({plugin}): bump version to X.Y.Z`
 6. Create PR - CI validates commits and that pending bumps are applied
 7. Merge once green and approved

--- a/plugins/actually-lsp/hooks/session-start.sh
+++ b/plugins/actually-lsp/hooks/session-start.sh
@@ -78,10 +78,14 @@ compute_state() {
       IFS=$'\t' read -r langid sample probe_args <<< "$pinputs"
       # probe_args is unquoted on purpose: empty -> no extra args, "--no-stdio" -> one flag
       # shellcheck disable=SC2086
+      # `cmd; rc=$?` doesn't work under `set -e`: a nonzero exit from a bare
+      # statement (not part of if/&&/||) aborts the script before `rc=$?`
+      # ever runs, so the "fall through to heuristic" case below silently
+      # never happens -- the whole hook dies here with no output instead
+      # (gt-... session-start hook error, "No stderr output").
       timeout 5s node "$PLUGIN_ROOT/lib/probe-server.mjs" \
         --server "$server_binary" --root "$PROJECT_DIR" --sample "$sample" --langid "$langid" $probe_args \
-        >/dev/null 2>&1
-      probe_rc=$?
+        >/dev/null 2>&1 && probe_rc=0 || probe_rc=$?
       case "$probe_rc" in
         0) _verdict "ready" "probe"; return ;;
         1) _verdict "server-not-runnable" "probe"; return ;;


### PR DESCRIPTION
## Summary
- `compute_state()` in the SessionStart hook ran `timeout 5s node lib/probe-server.mjs ...; probe_rc=$?` as a bare statement under `set -e`. Any nonzero probe exit (2/124/other, the documented "couldn't probe, fall back to the env_check heuristic" case) aborted the script before `probe_rc=$?` ever ran.
- Since the probe's own output is redirected to `/dev/null` by design, the hook died with exit 1 and zero bytes on stdout/stderr, surfacing in Claude Code as an opaque `SessionStart:startup hook error ... No stderr output` with no indication of which hook or why.
- Fix: `... >/dev/null 2>&1 && probe_rc=0 || probe_rc=$?` so a failing probe no longer trips `set -e`.

Reproduced against a real repo where `ruby-lsp` is installed and enabled but its `initialize` handshake didn't complete inside the probe's 5s budget (probe exit 2). Before the fix: silent exit 1. After: falls through to the heuristic as designed and emits the LSP activation context.

## Test plan
- [x] Reproduced the silent failure locally by invoking the hook directly against a repo where the ruby-lsp probe times out (exit 2)
- [x] Confirmed the same repro exits 0 and emits activation context after the fix
- [x] `grep`'d the plugin for the same `cmd; rc=$?` pattern elsewhere — this was the only instance