### PR TITLE
Add capture skill for source-to-note flow, with trigger evals

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.9.2"
+      "version": "1.10.0"
     },
     {
       "name": "tool-routing",

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See individual plugin READMEs for details on what each plugin provides.
 | [mcpproxy](plugins/mcpproxy) | MCP server management and integration tools | working-with-mcp |
 | [petri-dish](https://github.com/technicalpickles/petri-dish) | Author Claude Code experiments (petri-dish cultures) with disciplined schema, baselines, and multi-run averaging | [see repo](https://github.com/technicalpickles/petri-dish) |
 | [sandbox-advisor](plugins/sandbox-advisor) | Turns Claude Code sandbox EPERMs into crisp re-run-unsandboxed guidance | – |
-| [second-brain](plugins/second-brain) | Knowledge management for Obsidian vaults and structured markdown repositories | connect, distill-rules, enrich, ingest, link-daily, obsidian, process-inbox, route |
+| [second-brain](plugins/second-brain) | Knowledge management for Obsidian vaults and structured markdown repositories | capture, connect, distill-rules, enrich, ingest, link-daily, obsidian, process-inbox, route |
 | [stay-on-target](plugins/stay-on-target) | Focused development mode - clarify, plan, verify, detect drift | – |
 | [taskwarrior](plugins/taskwarrior) | Token-dense recipes for taskwarrior CLI: dense listings, single-field lookups, batched exports, full-text search | taskwarrior |
 | [tool-routing](plugins/tool-routing) | Route tool calls to better alternatives (e.g., gh CLI instead of WebFetch for GitHub PRs) | – |

--- a/plugins/second-brain/README.md
+++ b/plugins/second-brain/README.md
@@ -119,13 +119,32 @@ Symlinks:
 
 ## Skills & References
 
-The plugin includes an `obsidian` skill with:
+### `capture` — read a source, write a note
+
+The front door for "read this and make a note for it." Runs the whole loop as one arc so no step
+gets silently skipped:
+
+1. **Search first** via the qmd MCP tools, showing what already exists before anything is written
+2. **Read the primary source** (lightpanda / WebFetch / xtweet / Read / Notion), never a snippet
+3. **Create through `sb note create`**, which owns the inbox path, timestamp, and filename slug
+4. **Leave it in the inbox** — routing is offered, not performed
+5. **Offer connections** plus a daily-note breadcrumb
+
+Also handles "do we have a note about X already?" lookups, including the recall fallbacks for when
+semantic search misses (basename search across the vault, checking both inbox folders).
+
+| Reference | Content |
+|-----------|---------|
+| `skills/capture/references/note-format.md` | Frontmatter and body shape for a fresh capture |
+
+### `obsidian` — vault mechanics
 
 | Reference | Content |
 |-----------|---------|
 | `references/para.md` | PARA methodology (Projects, Areas, Resources, Archive) |
 | `references/zettelkasten.md` | Timestamp naming convention |
 | `references/note-patterns.md` | Templates for person, meeting, insight, investigation notes |
+| `references/sb-cli.md` | The `sb` CLI command surface |
 
 ## Note Format
 

--- a/plugins/second-brain/skills/capture/SKILL.md
+++ b/plugins/second-brain/skills/capture/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: capture
+description: Use when the user asks to read a source and make a note for it, create or find an atomic note, or check whether a note already exists. Triggers on "read <url> and make a note", "make a note for", "create (or find) an atomic note", "do we have notes about X?", "check if we have a note for", "capture this", "put together a note", "distill this", and on a bare URL/PDF/tweet/thread handed over with intent to write it up. Covers the whole loop as one arc - search the vault first, read the primary source, write the note through the sb CLI, then offer connections. Use inside an Obsidian vault or anywhere a vault is configured. Do NOT use for draining an accumulated inbox backlog (that is process-inbox), for extracting insights from the current conversation (that is distill-conversation), or for routing already-captured notes to their homes (that is route).
+allowed-tools:
+  - Read
+  - Write(~/.claude/vaults/**/*.md)
+  - Edit(~/.claude/vaults/**/*.md)
+  - Glob
+  - Grep
+  - Bash(npx @techpickles/sb:*)
+  - mcp__qmd__query
+  - mcp__qmd__get
+  - mcp__qmd__multi_get
+  - mcp__qmd__status
+---
+
+# Capture
+
+Write a note into the vault from a source the user hands you. One arc, five steps:
+**search → read the primary source → create through sb → leave it in the inbox → offer connections.**
+
+This is the dominant vault interaction. Do not decompose it into separate asks; the user saying
+"read this and make a note" means all five steps, and the connect step in particular will not
+happen unless this skill runs it.
+
+See [references/note-format.md](references/note-format.md) for frontmatter and body shape.
+See [../obsidian/references/sb-cli.md](../obsidian/references/sb-cli.md) for the full sb command surface.
+
+## Step 0: Locate the vault
+
+```bash
+npx @techpickles/sb vault info
+npx @techpickles/sb config qmd-collection
+```
+
+Read the vault's own `CLAUDE.md` if you haven't this session. Vault-specific policy (destinations,
+status vocabulary, disambiguation rules) overrides the defaults here.
+
+## Step 1: Search before creating - never skip this
+
+Run a `lex` + `vec` pair through the **qmd MCP tools**, not the shell. (`mcp__qmd__query` is the
+working path; shelling out to `qmd` hits Metal-init failures under the sandbox.)
+
+```
+mcp__qmd__query
+  searches: [{type: 'lex', query: '<topic terms>'},
+             {type: 'vec', query: '<what the note would say>'}]
+  collection: <from sb config qmd-collection>
+  intent: '<why you are searching>'
+  rerank: false        # CPU-only box, reranking is not worth the latency here
+```
+
+Show the user what already exists - **path + score + snippet** - before anything gets written.
+Often the right move is extending a note, not minting one. If a result is a strong match, say so
+and ask which way to go instead of quietly creating a duplicate.
+
+### When search comes up empty
+
+A miss is not proof the note is absent. In order:
+
+1. **Basename is the stable identity.** Notes get routed between folders constantly. Search the
+   basename across the whole vault (`Glob`/`Grep`) before concluding anything is missing.
+2. **Check both inboxes.** `10-19 System & Capture/11 Inbox & triage/` and
+   `10-19 System & Capture/11 Inbox/` are separate folders with the same JD code. `sb inbox list`
+   only reads the first.
+3. **The note may genuinely not exist.** Say that plainly and offer to start one.
+
+### When the user says "that isn't the one"
+
+Do **not** re-run the same query with different phrasing, and do not widen `-n` and hope. Ask for
+one distinguishing detail (who made it, where they saw it, what it sits next to) and search on
+*that* instead. Re-running near-identical searches has burned entire sessions, including the same
+lookup failing twice across two separate sessions.
+
+## Step 2: Read the actual primary source
+
+**Never write a note from search snippets.** Fetch the real thing:
+
+| Source | Tool |
+|--------|------|
+| Web page | `mcp__lightpanda__markdown {url}` preferred; `WebFetch` as fallback |
+| Tweet / thread | `xtweet <url-or-id>` (`-q` for quoted chain, `-r` for replies) |
+| PDF or local file | `Read` |
+| Notion page | `mcp__notiongusto__notion-fetch` |
+| Slack thread | the `slack` skill |
+
+**If you cannot reach the source, or cannot find the thing the user described, stop and say so.**
+Do not write a note containing a URL you did not load, a title you inferred, or details you filled
+in from background knowledge. Reporting "I couldn't find anything matching this" is the correct
+outcome and is more useful than a plausible note that is wrong.
+
+## Step 3: Create the note through sb
+
+```bash
+npx @techpickles/sb note create --source auto --title "<title>" --dry-run   # check the path first
+npx @techpickles/sb note create --source auto --title "<title>"            # returns JSON with path
+```
+
+Then write the body at the returned path with `Write`/`Edit`.
+
+**Do not hand-roll the destination path.** sb resolves the inbox, the zettelkasten timestamp, and
+the filename slug (`202608141249 note-title.md` - space after the timestamp, hyphens inside the
+slug). Hand-rolled `Write` calls are how captures end up in the inbox the pipeline never reads:
+as of 2026-08-14 that had orphaned 46 notes, and untangling it took a single 211-message session.
+
+For a title, prefer the source's own framing over a topic label. `# Glide browser` beats
+`# Notes on a keyboard-driven browser`.
+
+## Step 4: Leave it in the inbox - routing is opt-in
+
+The note stays where sb put it. **Offer** to route it; do not route it.
+
+This overrides the vault's general "capture: file rough, move on / a wrong-but-close home beats the
+global inbox" guidance, which governs notes *the user* files by hand. Notes *the agent* writes on
+request stay in the inbox until the user says otherwise. Both rules coexist in the vault CLAUDE.md
+and the scope of the override has historically been read as ambiguous, which produced a roughly
+50/50 split between inbox and direct-to-area filing. It is not ambiguous: **agent-written note on
+request → inbox, stop.**
+
+The exception is an explicit destination from the user ("put it in 66"). Then write it there.
+
+## Step 5: Offer connections, then the daily breadcrumb
+
+Connection discovery does not fire on its own, and the user should not have to notice it was
+skipped. **Offer it every time**, using the step 1 results plus a fresh search from the finished
+note's content.
+
+- Only link notes **confirmed to exist** by an actual search hit. Never emit a `[[link]]` to a note
+  you have not verified, and never create side notes on your own initiative. Surface those as
+  suggestions ("want me to make a note for X too?") and let the user decide.
+- Add links under `## Related` with a few words on *why* each one relates. A bare link list decays.
+- Then offer the daily-note breadcrumb:
+  ```bash
+  npx @techpickles/sb daily append --section "Notes" --content "- [[<note>]] - <one-line why>"
+  ```
+  Keep it to links unless asked for more. Do not restructure or rewrite the daily note.
+
+For deeper backlink weaving, hand off to the `connect` skill rather than reimplementing it.
+
+## Capturing several sources at once
+
+When the user hands over a batch ("make notes for each of these", "write them up"), dispatch **one
+subagent per note** so each reads its source in isolation and cannot cross-contaminate. This is a
+pattern the user asks for explicitly; default to it for 3+ sources.
+
+Each subagent: read the primary source, write one note via sb, and report back **path, title,
+verified wiki-links used, and anything it could not confirm**. Then do the cross-linking pass
+yourself once all notes exist, since connections need the whole set in view.
+
+## Constraints
+
+- **Search first, always.** No note gets written before the user has seen what already exists.
+- **Primary sources only.** No note written from a snippet, a memory, or a guess.
+- **Never fabricate.** No invented URLs, no unverified `[[links]]`, no filled-in details. Stop and
+  report the gap instead.
+- **sb owns paths.** No hand-rolled destinations.
+- **Inbox by default.** Routing and connecting are offered, not performed.
+- **One note, one idea.** If the source carries several distinct ideas, say so and offer to split
+  rather than writing one sprawling note.

--- a/plugins/second-brain/skills/capture/evals/README.md
+++ b/plugins/second-brain/skills/capture/evals/README.md
@@ -1,0 +1,78 @@
+# Trigger evals for `capture`
+
+Measures whether the skill actually fires on real user phrasings. Queries in
+`trigger-evals.json` are verbatim prompts from 50 real vault sessions (2026-07-27 → 08-14), mined
+with `cq`, including the recurring `ntoe` typo. 10 should-trigger, 10 near-miss should-not-trigger.
+
+## The headline result
+
+| Condition | Recall (10 positives) | Specificity (10 negatives) |
+|---|---|---|
+| Vault CLAUDE.md pointer, scoped to "create a note" | 70% | 100% |
+| **No pointer in vault CLAUDE.md** | **0%** | n/a |
+| Pointer widened to "create **or find** a note" | **100%** | 100% |
+
+Raw runs in `results/`. 3 runs per query, trigger threshold 0.5.
+
+Two things follow, and they matter more than the skill's own wording:
+
+1. **The SKILL.md description has no independent pull.** Thirty runs, zero triggers, on phrasings
+   as on-the-nose as "read \<url\> and make a note for it". Time spent tuning description prose is
+   wasted; the vault CLAUDE.md pointer is the mechanism. That's why the pointer ships in
+   `templates/vault-claude-md.md` with a "keep this section" warning.
+2. **Scope the pointer to every intent you want caught.** With the pointer scoped to *create*,
+   all three pure-lookup queries failed 0/3. Widening the heading and adding a lookup bullet took
+   them to 2/3, 3/3, 3/3 with no loss of specificity. The pointer's wording is doing the routing,
+   so an intent it doesn't name is an intent that won't fire.
+
+This likely generalizes to the plugin's other skills (`route`, `enrich`, `connect`, `ingest`),
+which were invoked once total across those same 50 sessions while ~150 notes were written by hand.
+Worth measuring before assuming those skills are unwanted rather than unreachable.
+
+## Running them
+
+```bash
+./trigger_eval.py \
+  --eval-set trigger-evals.json \
+  --plugin-src ../../.. \
+  --skill capture --namespace second-brain \
+  --cwd /path/to/a/vault \
+  --runs 3 --workers 6 --turns 2 \
+  --out results/$(date +%F)-my-change.json
+```
+
+Notes on getting trustworthy numbers:
+
+- **Don't run against your real vault.** At `--turns 3` the runs will happily create notes in your
+  inbox. Use a throwaway vault-shaped directory: `.obsidian/`, a CLAUDE.md, a couple of real-ish
+  notes. `--turns 2` is enough to observe triggering.
+- **Isolate the variable you care about.** Triggering is dominated by the cwd's CLAUDE.md, so
+  compare arms that differ in exactly one thing. The 0%-recall arm above is just the widened arm
+  with the pointer section deleted.
+- `--description` patches the description in a temp copy, for A/B without touching SKILL.md.
+
+## Why not skill-creator's `run_eval.py`
+
+`skill-creator` ships `scripts/run_eval.py` for exactly this job. It does not work for plugin
+skills, and it fails *silently* — it reports zeros, which reads as "bad description" rather than
+"broken harness."
+
+It injects the skill under test by writing a stub to `<project_root>/.claude/commands/<name>.md`,
+on the premise (in its own docstring) that this makes it "appear in Claude's available_skills
+list." That premise is false on current Claude Code: project `commands/` entries are *user*-invocable
+slash commands, not model-invocable skills. Verified 2026-08-14 by planting a `zzzprobe` command and
+asking the model whether it could see it — it answered NO and reached for a real installed skill
+instead. So no query can ever trigger, regardless of description quality.
+
+Its companion `scripts/run_loop.py` (automated description improvement) additionally requires
+`ANTHROPIC_API_KEY`, since it calls `anthropic.Anthropic()` directly rather than going through
+`claude -p`.
+
+`trigger_eval.py` keeps skill-creator's method — realistic verbatim queries, near-miss negatives,
+N runs per query, threshold on trigger rate — and swaps the injection for `claude --plugin-dir`
+against a temp copy of the plugin, so what gets measured is the artifact that ships.
+
+One `--plugin-dir` gotcha it works around: **an installed plugin of the same name wins.** Pointing
+`--plugin-dir` at a tree containing `second-brain` while `second-brain` is installed silently loads
+the *installed* copy, so local edits appear to do nothing. The harness copies the plugin to a temp
+dir to dodge this.

--- a/plugins/second-brain/skills/capture/evals/results/2026-08-14-no-pointer.json
+++ b/plugins/second-brain/skills/capture/evals/results/2026-08-14-no-pointer.json
@@ -1,0 +1,93 @@
+{
+  "summary": {
+    "label": "no-pointer",
+    "accuracy": 0.0,
+    "recall_on_should_trigger": 0.0,
+    "specificity_on_should_not": null,
+    "passed": 0,
+    "total": 10
+  },
+  "results": [
+    {
+      "query": "read https://zed.dev/blog/introducing-delta and make a note for it",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "use lightpanda to read https://glide-browser.app/ and create a note for it",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "read /Users/josh.nichols/Downloads/Build vs Buy Strategy.pdf to create a note for it",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "do we have harbor ntoes already?",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "create (or find) an atomic note for https://h5i.dev/ and look for related tools in the space to cross connect",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "is there a note related to hiring an agent 'chef of staff'",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "check if we have notes for caveman, ponytail, and/or rtk, cuz i want those",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "use xtweet to load https://x.com/karpathy/status/1917920338492977296 and put together an atomic note",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "what is pareto optimal? make a note",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "i want to understand aws bedrock agentcore, and make atomic notes for it, and connect to it",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    }
+  ],
+  "description": "(from SKILL.md)"
+}

--- a/plugins/second-brain/skills/capture/evals/results/2026-08-14-pointer-scoped-to-create.json
+++ b/plugins/second-brain/skills/capture/evals/results/2026-08-14-pointer-scoped-to-create.json
@@ -1,0 +1,173 @@
+{
+  "summary": {
+    "label": "baseline",
+    "accuracy": 0.85,
+    "recall_on_should_trigger": 0.7,
+    "specificity_on_should_not": 1.0,
+    "passed": 17,
+    "total": 20
+  },
+  "results": [
+    {
+      "query": "read https://zed.dev/blog/introducing-delta and make a note for it",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "use lightpanda to read https://glide-browser.app/ and create a note for it",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "read /Users/josh.nichols/Downloads/Build vs Buy Strategy.pdf to create a note for it",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "do we have harbor ntoes already?",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "create (or find) an atomic note for https://h5i.dev/ and look for related tools in the space to cross connect",
+      "should_trigger": true,
+      "trigger_rate": 0.6666666666666666,
+      "triggers": 2,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "is there a note related to hiring an agent 'chef of staff'",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "check if we have notes for caveman, ponytail, and/or rtk, cuz i want those",
+      "should_trigger": true,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": false
+    },
+    {
+      "query": "use xtweet to load https://x.com/karpathy/status/1917920338492977296 and put together an atomic note",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "what is pareto optimal? make a note",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "i want to understand aws bedrock agentcore, and make atomic notes for it, and connect to it",
+      "should_trigger": true,
+      "trigger_rate": 0.6666666666666666,
+      "triggers": 2,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "drain the inbox backlog, there are a bunch of stale notes in there",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "process today's daily note, the voice transcriptions are a mess again",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "route the notes sitting in the inbox to their JD homes",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "we are missing connections / related notes for the a2a vs mcp note",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "distill this conversation into insights and put them in my vault",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "read src/auth/session.ts and tell me how the token refresh works",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "symlink this repo's docs folder into the vault so I can see them in obsidian",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "whats the actual difference between PARA and johnny decimal, i keep mixing them up",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "go through all my notes and rename the #idea tag to #concept",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "my obsidian sync is busted, notes from my laptop arent showing up on my phone",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    }
+  ],
+  "description": "(from SKILL.md)"
+}

--- a/plugins/second-brain/skills/capture/evals/results/2026-08-14-pointer-widened.json
+++ b/plugins/second-brain/skills/capture/evals/results/2026-08-14-pointer-widened.json
@@ -1,0 +1,173 @@
+{
+  "summary": {
+    "label": "widened",
+    "accuracy": 1.0,
+    "recall_on_should_trigger": 1.0,
+    "specificity_on_should_not": 1.0,
+    "passed": 20,
+    "total": 20
+  },
+  "results": [
+    {
+      "query": "read https://zed.dev/blog/introducing-delta and make a note for it",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "use lightpanda to read https://glide-browser.app/ and create a note for it",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "read /Users/josh.nichols/Downloads/Build vs Buy Strategy.pdf to create a note for it",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "do we have harbor ntoes already?",
+      "should_trigger": true,
+      "trigger_rate": 0.6666666666666666,
+      "triggers": 2,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "create (or find) an atomic note for https://h5i.dev/ and look for related tools in the space to cross connect",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "is there a note related to hiring an agent 'chef of staff'",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "check if we have notes for caveman, ponytail, and/or rtk, cuz i want those",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "use xtweet to load https://x.com/karpathy/status/1917920338492977296 and put together an atomic note",
+      "should_trigger": true,
+      "trigger_rate": 0.6666666666666666,
+      "triggers": 2,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "what is pareto optimal? make a note",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "i want to understand aws bedrock agentcore, and make atomic notes for it, and connect to it",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "drain the inbox backlog, there are a bunch of stale notes in there",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "process today's daily note, the voice transcriptions are a mess again",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "route the notes sitting in the inbox to their JD homes",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "we are missing connections / related notes for the a2a vs mcp note",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "distill this conversation into insights and put them in my vault",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "read src/auth/session.ts and tell me how the token refresh works",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "symlink this repo's docs folder into the vault so I can see them in obsidian",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "whats the actual difference between PARA and johnny decimal, i keep mixing them up",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "go through all my notes and rename the #idea tag to #concept",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "my obsidian sync is busted, notes from my laptop arent showing up on my phone",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    }
+  ],
+  "description": "(from SKILL.md)"
+}

--- a/plugins/second-brain/skills/capture/evals/trigger-evals.json
+++ b/plugins/second-brain/skills/capture/evals/trigger-evals.json
@@ -1,0 +1,103 @@
+[
+  {
+    "query": "read https://zed.dev/blog/introducing-delta and make a note for it",
+    "should_trigger": true,
+    "note": "verbatim from session 55e13af2, 2026-08-13"
+  },
+  {
+    "query": "use lightpanda to read https://glide-browser.app/ and create a note for it",
+    "should_trigger": true,
+    "note": "verbatim from session 589e1678, 2026-08-13"
+  },
+  {
+    "query": "read /Users/josh.nichols/Downloads/Build vs Buy Strategy.pdf to create a note for it",
+    "should_trigger": true,
+    "note": "verbatim from session 852902f6, 2026-08-14. Missed in manual probe."
+  },
+  {
+    "query": "do we have harbor ntoes already?",
+    "should_trigger": true,
+    "note": "verbatim, incl. the 'ntoe' typo that recurs ~8x. Missed in manual probe."
+  },
+  {
+    "query": "create (or find) an atomic note for https://h5i.dev/ and look for related tools in the space to cross connect",
+    "should_trigger": true,
+    "note": "verbatim from session f082b4ff. Missed in manual probe despite phrasing being verbatim in the description."
+  },
+  {
+    "query": "is there a note related to hiring an agent 'chef of staff'",
+    "should_trigger": true,
+    "note": "verbatim. Pure lookup, no creation."
+  },
+  {
+    "query": "check if we have notes for caveman, ponytail, and/or rtk, cuz i want those",
+    "should_trigger": true,
+    "note": "verbatim from session 6bfe7850. Casual, multi-subject lookup."
+  },
+  {
+    "query": "use xtweet to load https://x.com/karpathy/status/1917920338492977296 and put together an atomic note",
+    "should_trigger": true,
+    "note": "pattern from session 47dca0c6 (tweet-sourced capture)"
+  },
+  {
+    "query": "what is pareto optimal? make a note",
+    "should_trigger": true,
+    "note": "verbatim from session 2a77b4fa. Concept capture with no external source."
+  },
+  {
+    "query": "i want to understand aws bedrock agentcore, and make atomic notes for it, and connect to it",
+    "should_trigger": true,
+    "note": "verbatim from session 2827ceb3. Research + capture + connect."
+  },
+
+  {
+    "query": "drain the inbox backlog, there are a bunch of stale notes in there",
+    "should_trigger": false,
+    "note": "near-miss: belongs to process-inbox"
+  },
+  {
+    "query": "process today's daily note, the voice transcriptions are a mess again",
+    "should_trigger": false,
+    "note": "near-miss: belongs to process-daily"
+  },
+  {
+    "query": "route the notes sitting in the inbox to their JD homes",
+    "should_trigger": false,
+    "note": "near-miss: belongs to route"
+  },
+  {
+    "query": "we are missing connections / related notes for the a2a vs mcp note",
+    "should_trigger": false,
+    "note": "verbatim from session 054a13d9. Hardest negative: about an existing note, so it's connect's job, but shares 'note' + relatedness vocabulary with capture."
+  },
+  {
+    "query": "distill this conversation into insights and put them in my vault",
+    "should_trigger": false,
+    "note": "near-miss: belongs to distill-conversation. Source is the conversation, not an external thing."
+  },
+  {
+    "query": "read src/auth/session.ts and tell me how the token refresh works",
+    "should_trigger": false,
+    "note": "hardest negative for the 'read <thing>' shape: same opening as the positives, but no note wanted. If the description overtriggers, this is where it shows."
+  },
+  {
+    "query": "symlink this repo's docs folder into the vault so I can see them in obsidian",
+    "should_trigger": false,
+    "note": "near-miss: belongs to link-project"
+  },
+  {
+    "query": "whats the actual difference between PARA and johnny decimal, i keep mixing them up",
+    "should_trigger": false,
+    "note": "near-miss: methodology question, obsidian skill's references at most"
+  },
+  {
+    "query": "go through all my notes and rename the #idea tag to #concept",
+    "should_trigger": false,
+    "note": "near-miss: bulk vault edit, touches notes but is not capture"
+  },
+  {
+    "query": "my obsidian sync is busted, notes from my laptop arent showing up on my phone",
+    "should_trigger": false,
+    "note": "near-miss: vault troubleshooting, not note work"
+  }
+]

--- a/plugins/second-brain/skills/capture/evals/trigger_eval.py
+++ b/plugins/second-brain/skills/capture/evals/trigger_eval.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Measure whether a *plugin* skill actually triggers on real user prompts.
+
+Why this exists instead of skill-creator's scripts/run_eval.py
+-------------------------------------------------------------
+run_eval.py injects the skill under test by writing a stub into
+`<project_root>/.claude/commands/<name>.md`, on the premise that it will "appear
+in Claude's available_skills list." That premise is false on current Claude Code:
+project commands are *user*-invocable slash commands, not model-invocable skills.
+Verified 2026-08-14 - asked directly, the model reports it cannot see such a
+command, and instead reaches for whatever real skills are installed. So every
+query scores as "not triggered" no matter how good the description is, which is
+the false-negative behavior that makes run_eval useless for plugin skills.
+
+This harness instead loads the *real* skill via `claude --plugin-dir`, so what
+gets measured is the artifact that will actually ship.
+
+One gotcha it handles: `--plugin-dir` loses to an already-installed plugin of the
+same name. Pointing at a directory that contains a plugin named `second-brain`
+while `second-brain` is installed silently gives you the *installed* version.
+So the plugin tree is copied to a temp dir per variant, which also gives a clean
+place to patch the description for A/B runs.
+
+Usage
+-----
+  ./trigger_eval.py --eval-set trigger-evals.json \\
+      --plugin-src /path/to/plugins/second-brain \\
+      --skill capture --namespace second-brain \\
+      --cwd /path/to/vault-like-dir --runs 3
+
+  # A/B a candidate description without touching the real SKILL.md
+  ./trigger_eval.py ... --description "$(cat candidate.txt)" --label candidate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+
+def patch_description(skill_md: Path, new_description: str) -> None:
+    """Replace the `description:` field in a SKILL.md's YAML frontmatter.
+
+    Uses a single-line flow scalar with quotes escaped, which is enough for the
+    descriptions we generate and avoids a YAML dependency.
+    """
+    text = skill_md.read_text()
+    if not text.startswith("---"):
+        raise ValueError(f"{skill_md} has no frontmatter")
+    end = text.index("\n---", 3)
+    fm, body = text[3:end], text[end:]
+
+    out, i, replaced = [], 0, False
+    lines = fm.split("\n")
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("description:"):
+            escaped = new_description.replace("\\", "\\\\").replace('"', '\\"')
+            out.append(f'description: "{escaped}"')
+            i += 1
+            # skip continuation lines of the old value (indented or block scalar)
+            while i < len(lines) and (lines[i].startswith((" ", "\t")) or lines[i] == ""):
+                i += 1
+            replaced = True
+            continue
+        out.append(line)
+        i += 1
+
+    if not replaced:
+        raise ValueError(f"no description: field in {skill_md}")
+    skill_md.write_text("---" + "\n".join(out) + body)
+
+
+def stage_plugin(plugin_src: Path, skill: str, description: str | None) -> Path:
+    """Copy the plugin to a temp dir so --plugin-dir can't lose to the installed copy."""
+    tmp = Path(tempfile.mkdtemp(prefix="trigeval-"))
+    dest = tmp / plugin_src.name
+    shutil.copytree(plugin_src, dest)
+    if description:
+        patch_description(dest / "skills" / skill / "SKILL.md", description)
+    return tmp
+
+
+def ran_skill(events: str, target: str) -> bool:
+    """True if any assistant turn invoked the Skill tool with our target skill."""
+    for line in events.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") != "assistant":
+            continue
+        for item in event.get("message", {}).get("content", []) or []:
+            if item.get("type") != "tool_use":
+                continue
+            if item.get("name") == "Skill" and item.get("input", {}).get("skill") == target:
+                return True
+    return False
+
+
+def one_run(query: str, plugin_dir: Path, target: str, cwd: Path, turns: int, timeout: int) -> bool:
+    cmd = [
+        "claude", "-p", query,
+        "--plugin-dir", str(plugin_dir),
+        "--max-turns", str(turns),
+        "--output-format", "stream-json", "--verbose",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout,
+            env={k: v for k, v in __import__("os").environ.items() if k != "CLAUDECODE"},
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    return ran_skill(proc.stdout, target)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--eval-set", required=True, type=Path)
+    ap.add_argument("--plugin-src", required=True, type=Path)
+    ap.add_argument("--skill", required=True, help="skill dir name, e.g. capture")
+    ap.add_argument("--namespace", required=True, help="plugin namespace, e.g. second-brain")
+    ap.add_argument("--cwd", required=True, type=Path, help="dir to run claude in")
+    ap.add_argument("--description", default=None, help="override description for A/B")
+    ap.add_argument("--label", default="current")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--turns", type=int, default=3)
+    ap.add_argument("--timeout", type=int, default=200)
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args()
+
+    evals = json.loads(args.eval_set.read_text())
+    target = f"{args.namespace}:{args.skill}"
+    plugin_dir = stage_plugin(args.plugin_src, args.skill, args.description)
+
+    jobs = [(idx, r) for idx, _ in enumerate(evals) for r in range(args.runs)]
+    triggers: dict[int, int] = {i: 0 for i in range(len(evals))}
+
+    print(f"[{args.label}] {len(evals)} queries x {args.runs} runs -> {len(jobs)} invocations",
+          file=sys.stderr)
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {
+            pool.submit(one_run, evals[i]["query"], plugin_dir, target,
+                        args.cwd, args.turns, args.timeout): i
+            for i, _ in jobs
+        }
+        done = 0
+        for fut in as_completed(futures):
+            i = futures[fut]
+            if fut.result():
+                triggers[i] += 1
+            done += 1
+            if done % 10 == 0:
+                print(f"  {done}/{len(jobs)}", file=sys.stderr)
+
+    results, tp = [], 0
+    for i, item in enumerate(evals):
+        rate = triggers[i] / args.runs
+        fired = rate >= 0.5
+        ok = fired == item["should_trigger"]
+        tp += ok
+        results.append({
+            "query": item["query"],
+            "should_trigger": item["should_trigger"],
+            "trigger_rate": rate,
+            "triggers": triggers[i],
+            "runs": args.runs,
+            "pass": ok,
+        })
+
+    pos = [r for r in results if r["should_trigger"]]
+    neg = [r for r in results if not r["should_trigger"]]
+    summary = {
+        "label": args.label,
+        "accuracy": tp / len(results),
+        "recall_on_should_trigger": sum(r["pass"] for r in pos) / len(pos) if pos else None,
+        "specificity_on_should_not": sum(r["pass"] for r in neg) / len(neg) if neg else None,
+        "passed": tp,
+        "total": len(results),
+    }
+    out = {"summary": summary, "results": results,
+           "description": args.description or "(from SKILL.md)"}
+
+    print(json.dumps(out, indent=2))
+    if args.out:
+        args.out.write_text(json.dumps(out, indent=2))
+
+    print(f"\n[{args.label}] accuracy {summary['passed']}/{summary['total']}"
+          f"  recall={summary['recall_on_should_trigger']}"
+          f"  specificity={summary['specificity_on_should_not']}", file=sys.stderr)
+    for r in results:
+        mark = "PASS" if r["pass"] else "FAIL"
+        print(f"  [{mark}] {r['triggers']}/{r['runs']} want={r['should_trigger']}: {r['query'][:70]}",
+              file=sys.stderr)
+
+    shutil.rmtree(plugin_dir, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/second-brain/skills/capture/references/note-format.md
+++ b/plugins/second-brain/skills/capture/references/note-format.md
@@ -1,0 +1,98 @@
+# Capture Note Format
+
+The shape a freshly captured note takes. This is the format that has actually accumulated in the
+vault, not an aspirational template - it was derived by reading ~150 real captures.
+
+If the vault's own `CLAUDE.md` or `Templates/` specify something different, those win.
+
+## Frontmatter
+
+```yaml
+---
+status: seedling
+tags: [browsers, firefox, keyboard-driven]
+created: 2026-08-13
+source: https://glide-browser.app/
+---
+```
+
+| Field | Value |
+|-------|-------|
+| `status` | `seedling` for a fresh capture. This is the **zettelkasten maturity** axis (`seedling` → `budding` → `evergreen`), not the lifecycle axis. |
+| `tags` | Inline list, lowercase, hyphenated. Topic tags for a concept note; a type tag (`#person`, `#meeting`, `#idea`) where one applies. |
+| `created` | `YYYY-MM-DD`. |
+| `source` | The URL, file path, or origin. Omit only when there genuinely isn't one. |
+
+### Do not hand-author these
+
+- **Lifecycle values** (`filed`, `incubating`, `active`, `complete`, `dormant`, `abandoned`) belong
+  to routed notes, not fresh captures. A capture that hasn't been routed isn't `filed` yet.
+- **Pipeline states** (`ingested`, `routed`, `connected`) are set by the pipeline skills. Writing
+  them by hand makes a note look processed when it isn't.
+- Check the vault's canonical status vocabulary note before setting anything other than `seedling`.
+
+### Reconciling with what sb scaffolds
+
+`sb note create` emits provenance frontmatter:
+
+```yaml
+captured: 2026-08-14T16:49:59Z
+source: manual
+repo: none
+branch: none
+commit: none
+---
+```
+
+That's built for conversation-captured insights, where git context is the useful provenance. For a
+source-capture it mostly isn't. So:
+
+- **Keep** `captured` (it's a real timestamp) and replace `source: manual` with the actual source.
+- **Add** `status`, `tags`, `created`.
+- **Drop** `repo`/`branch`/`commit` when they're all `none`. Keep them when the capture happened
+  while working in a repo and that context matters.
+
+## Body
+
+```markdown
+# Glide browser
+
+A [Firefox fork](https://glide-browser.app/firefox) that is keyboard-focused, with a Vim-style
+modal interface and a TypeScript config surface.
+
+## Related
+
+- [[202607111019 nate berkopec|Nate Berkopec]] - same keyboard-first tooling lineage
+- [[202106271223 pareto principle]] - same name as the pareto-optimal note, different idea
+```
+
+Rules:
+
+- **`# Title` matches the note's title.** Sentence case, the source's own framing.
+- **Prose, not an outline.** One to three paragraphs for a clip. Headings only once there's enough
+  content to need them; a three-paragraph note with five `##` sections is noise.
+- **Link out inline** to the primary source. The reader should be able to get to the real thing.
+- **`## Related` last**, with a few words on why each link relates. Bare link lists decay into
+  unreadable piles - the "why" is what makes them still useful in six months.
+- **Only verified links.** Every `[[target]]` must be a note a search actually returned.
+
+## Filenames
+
+sb generates these. Don't construct them by hand.
+
+```
+202608141249 glide-browser.md
+└──┬───────┘ └──────┬──────┘
+   │                └─ hyphenated slug
+   └─ YYYYMMDDHHMM, then a single space
+```
+
+A hyphen between the timestamp and the slug (`202608071430-shopify-...`) is the wrong shape; it
+shows up in one batch in the vault and is the outlier, not a variant.
+
+## Notes that aren't captures
+
+Person, meeting, investigation, and project notes have their own established shapes. See
+[../../obsidian/references/note-patterns.md](../../obsidian/references/note-patterns.md). Person
+notes in particular are **flat, no timestamp prefix** (`Trevor Turk.md`), because a person is a
+record with a fixed address rather than a timestamped thought.

--- a/plugins/second-brain/templates/vault-claude-md.md
+++ b/plugins/second-brain/templates/vault-claude-md.md
@@ -2,6 +2,25 @@
 
 > See `second-brain:obsidian` skill for tool conventions.
 
+## When the user asks the agent to create or find a note
+
+**Use the `second-brain:capture` skill.** It is canonical for both halves of this:
+
+- **Finding an existing note** - "do we have a note about X?", "is there a note for Y?", "check if we have notes on Z already"
+- **Creating one from a source** - "read \<url/pdf/tweet\> and make a note for it", "make an atomic note for X"
+
+These are one skill because creating *starts* with finding: whether a note already exists decides
+whether to extend it or mint a new one. The procedure is search the vault first, read the primary
+source, create through `sb note create`, leave it in the inbox, offer connections. Don't
+reimplement it from memory.
+
+**Keep this section.** It is not decoration - it is the mechanism that makes the skill fire.
+Measured 2026-08-14 over 90 `claude -p` runs against real user phrasings: with this section
+present the skill triggers on 10/10 capture-and-lookup phrasings (and correctly stays out of the
+way on 10/10 near-miss phrasings that belong to `route`, `connect`, `process-inbox`, and friends).
+With the section deleted, it triggers on **0/10** - the skill description alone has no pull. If
+you trim this file, trim something else.
+
 ## Structure
 
 - {inbox_folder}/ - New captures before routing


### PR DESCRIPTION
## Summary

- New `capture` skill owns the "read this and make a note for it" loop end to end: search the vault first, read the primary source, create through `sb note create`, leave it in the inbox, then offer connections. That's the dominant vault interaction and nothing in the plugin claimed it, so it got improvised from scratch every session.
- Captures go through `sb` now, which resolves to the inbox the pipeline actually reads. Hand-rolled `Write` paths were guessing a sibling folder that shares its Johnny Decimal code, and `sb inbox list` has never looked at it. 46 notes had piled up in there.
- The vault CLAUDE.md pointer that makes the skill fire ships in `templates/vault-claude-md.md`, so triggering is a property of the plugin instead of prose someone hand-wrote in one vault.
- `references/note-format.md` documents the frontmatter that actually accumulated across ~150 real captures, and reconciles it with what `sb note create` scaffolds (they disagree, and the scaffold's git provenance fields are mostly `none` for a web clip).

## The description doesn't trigger the skill, the vault CLAUDE.md does

This is the part worth knowing before you review, since it's why the template change is in here. Measured over 150 `claude -p` runs against verbatim prompts pulled from 50 real vault sessions:

| vault CLAUDE.md pointer | recall (10 positives) | specificity (10 negatives) |
|---|---|---|
| scoped to "create a note" | 70% | 100% |
| removed entirely | 0% | n/a |
| "create **or find** a note" | 100% | 100% |

The SKILL.md description on its own never fired. Not once in 30 runs, on prompts as on-the-nose as "read \<url\> and make a note for it". So the pointer is the entire mechanism, and it only catches the intents it actually names, which is why pure lookups ("do we have harbor ntoes already?") sat at 0/3 until the heading covered finding as well as creating.

This probably generalizes to the rest of the plugin. `route`, `enrich`, `connect`, and `ingest` were invoked once *total* across those same 50 sessions, while ~150 notes got written by hand. I'd assumed that was people bypassing them. More likely nothing names them either, and they're unreachable rather than unwanted. Not measured yet, but it's cheap to check with the harness now that it's in the repo.

## Test plan

```bash
cd plugins/second-brain/skills/capture/evals
./trigger_eval.py \
  --eval-set trigger-evals.json \
  --plugin-src ../../.. \
  --skill capture --namespace second-brain \
  --cwd /path/to/throwaway-vault \
  --runs 3 --turns 2
```

Two things that'll bite otherwise:

- Point `--cwd` at a throwaway vault-shaped directory (`.obsidian/`, a CLAUDE.md, a couple of notes), not a real vault. At higher `--turns` the runs will happily create notes in your inbox.
- Triggering is dominated by the cwd's CLAUDE.md, so any comparison needs two arms differing in exactly one thing. The 0% row above is just the 100% row with the pointer section deleted.

Raw runs behind that table are committed under `evals/results/`.

## Follow-up work

- `skill-creator`'s own `scripts/run_eval.py` can't measure plugin skills, and it fails silently by reporting zeros that read as "bad description" instead of "broken harness". It injects the skill under test as a `.claude/commands/` stub, which is user-invocable only, not model-invocable. `evals/README.md` has the details. Worth an upstream issue.
- `scripts/bump-version.sh` breaks under bash 3.2 (`declare -A` in `analyze-version-bumps.sh`). Worked around here with a PATH override, not fixed.
- Draining the 46 orphaned notes is tracked separately. This PR stops the bleeding, it doesn't clean up.
