### PR TITLE
fix(second-brain): strip leading # from tags in note templates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.10.0"
+      "version": "1.10.1"
     },
     {
       "name": "tool-routing",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.10.1"
+      "version": "1.10.2"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/skills/capture/references/note-format.md
+++ b/plugins/second-brain/skills/capture/references/note-format.md
@@ -19,7 +19,7 @@ source: https://glide-browser.app/
 | Field | Value |
 |-------|-------|
 | `status` | `seedling` for a fresh capture. This is the **zettelkasten maturity** axis (`seedling` → `budding` → `evergreen`), not the lifecycle axis. |
-| `tags` | Inline list, lowercase, hyphenated. Topic tags for a concept note; a type tag (`#person`, `#meeting`, `#idea`) where one applies. |
+| `tags` | Inline list, lowercase, hyphenated, **no leading `#`** (e.g. `[person, meeting]` not `[#person, #meeting]` - an unquoted `#` at the start of a flow-sequence item or scalar value is a YAML comment and silently breaks or truncates the frontmatter). Topic tags for a concept note; a type tag (`person`, `meeting`, `idea`) where one applies. |
 | `created` | `YYYY-MM-DD`. |
 | `source` | The URL, file path, or origin. Omit only when there genuinely isn't one. |
 

--- a/plugins/second-brain/skills/obsidian/references/note-patterns.md
+++ b/plugins/second-brain/skills/obsidian/references/note-patterns.md
@@ -8,7 +8,7 @@ For tracking people - colleagues, contacts, authors, etc.
 
 ```markdown
 ---
-tags: #person
+tags: [person]
 ---
 
 # [Full Name]
@@ -39,7 +39,7 @@ For capturing meeting discussions and outcomes.
 
 ```markdown
 ---
-tags: #meeting
+tags: [meeting]
 ---
 
 # [Meeting Title]
@@ -85,7 +85,7 @@ For capturing ideas worth developing.
 
 ```markdown
 ---
-tags: #idea
+tags: [idea]
 ---
 
 # [Idea Title]
@@ -123,7 +123,7 @@ For debugging, research, or analysis work.
 
 ```markdown
 ---
-tags: #investigation
+tags: [investigation]
 ---
 
 # [Investigation Title]
@@ -175,7 +175,7 @@ For tracking a project with deliverables.
 
 ```markdown
 ---
-tags: #project
+tags: [project]
 ---
 
 # [Project Name]
@@ -218,7 +218,7 @@ See vault's `Fleeting/CLAUDE.md` or use this default:
 
 ```markdown
 ---
-tags: #daily
+tags: [daily]
 ---
 
 ## Action Items


### PR DESCRIPTION
## Summary
- The obsidian note-pattern templates wrote type tags as `tags: #person` (and similar for meeting/idea/investigation/project/daily). In YAML, an unquoted `#` preceded by whitespace starts a comment, so this silently truncates the value to null - the tag never actually gets written.
- The capture note-format reference described type tags with a leading `#` too, which invites the same mistake in a flow-sequence (`tags: [foo, #person]`), where a leading `#` on a list item breaks parsing of the rest of the frontmatter.
- Fixed both docs to use hashless tags (`tags: [person]`, etc.) and called out the YAML-comment gotcha so it doesn't get reintroduced.

## Test plan
- [x] Grepped the repo for any remaining `tags: #...` / `tags: [#...` patterns - none found
- [x] Verified the fix against PyYAML's parsing behavior for the broken vs fixed forms