### PR TITLE
feat(agent-meta): shared workspace + scripts for harness-binary-spelunking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "2.3.0"
+      "version": "2.4.0"
     },
     {
       "name": "buildkite",

--- a/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/SKILL.md
@@ -17,48 +17,54 @@ Before grepping anything, figure out which situation you're in:
 
 Most investigations start at one of these two ends and only cross over if the first approach runs dry (source doesn't explain the behavior you're seeing; binary strings are too fragmented to be sure).
 
-## Identify the build
+## Identify the build and set up your workspace
 
-If you're spelunking a binary (not reading source), figure out what you're actually holding before you pick a recipe set.
-
-```bash
-which <tool>                          # may be a shim, not the real binary
-file $(readlink -f $(which <tool>))   # classify the artifact
-```
-
-`which` often hands you a **launcher, not the artifact**. npm-installed CLIs are frequently a thin Node script that execs a platform-specific binary elsewhere. Follow the shim:
+If you're spelunking a binary (not reading source), run [scripts/spelunk-init.sh](scripts/spelunk-init.sh) before anything else. It resolves the binary, classifies the build, dumps `strings` once, and writes a manifest, all into a workspace shared by every recipe in this skill:
 
 ```bash
-$ which codex
-/Users/<you>/.local/bin/codex          # a Node launcher: bin/codex.js
-
-$ cat $(which codex)                   # spawns the real binary, e.g.:
-# .../@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
-
-$ file .../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
-Mach-O 64-bit executable arm64        # 203MB, this is the real target
+scripts/spelunk-init.sh claude
+# Workspace ready: $TMPDIR/spelunk/claude
+#   binary:      /path/to/the/real/binary
+#   build type:  bun-js (bun markers: 7, rust markers: 118)
+#   strings:     $TMPDIR/spelunk/claude/strings.txt
+#   manifest:    $TMPDIR/spelunk/claude/manifest.txt
 ```
 
-Once you have the real artifact, classify it:
+This exists because freelancing this step drifts fast: past investigations dumped to `claude-strings.txt`, then `harness-strings.txt`, with no per-tool suffix (so a second harness in the same session clobbers the first), and one reference file skipped the dump/reuse discipline entirely and re-ran `strings` on every recipe. One workspace shape, one script, no more re-deriving the path or the classification logic per investigation.
 
-| Tells | Build | Recipes |
-|-------|-------|---------|
-| `strings <bin> \| grep -i bun` hits; paths like `bun-internal/`, `tmp_modules/bun/ffi.ts` | Bun-compiled JS (Claude Code, opencode) | [references/bun-js.md](references/bun-js.md) |
-| `strings <bin>` shows `.rs` paths, `.cargo/registry/`, `crate_name::module` paths | Rust | [references/rust.md](references/rust.md) |
-| `file` says plain script / small size, `node_modules/` alongside it | Unbundled Node, or thin wrapper over readable source | Just read the source; see the pi note in [references/source-clone.md](references/source-clone.md) |
+`which <tool>` often hands you a **launcher, not the artifact** (npm-installed CLIs are frequently a thin Node script that execs a platform-specific binary elsewhere). The script detects this and stops, printing the shim's contents so you can find the real spawn target by hand:
 
-Don't assume a binary is a Node bundle just because the CLI is npm-installed. Bun and Rust both ship as single Mach-O executables that npm happily distributes as "the binary."
+```bash
+$ scripts/spelunk-init.sh codex
+'/Users/<you>/.local/bin/codex' looks like a launcher/shim, not the real binary:
+  a /usr/bin/env node script text executable
+...
+Find the spawn target above, then rerun: scripts/spelunk-init.sh codex <spawn-target-path>
+
+$ scripts/spelunk-init.sh codex .../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+Workspace ready: $TMPDIR/spelunk/codex
+  build type:  rust (bun markers: 0, rust markers: 3565)
+```
+
+Chasing an arbitrary spawn chain is a judgment call (it varies per tool, per platform); classifying what you're holding once you have it is not, so that part is scripted. If the build type comes back `unknown`, `file $BIN` and check whether it's unbundled Node or readable source instead; see the pi note in [references/source-clone.md](references/source-clone.md).
+
+Don't assume a binary is a Node bundle just because the CLI is npm-installed. Bun and Rust both ship as single Mach-O executables that npm happily distributes as "the binary." And don't assume bun/rust markers are mutually exclusive: a Bun-compiled JS bundle can embed a native Rust addon (Claude Code ships a napi/tokio one), so the script treats any Bun signal as decisive even when rust markers are also present.
 
 ## General method
 
-Once you know the build, the loop is the same for every harness:
+Once your workspace is set up, the loop is the same for every harness:
 
-1. **Dump once, grep many times.** These binaries run 100MB-200MB+; `strings` over them takes a few seconds but you'll grep dozens of times. Dump to a temp file once and reuse it.
+1. **Reuse the dump.** `spelunk-init.sh` skips re-dumping if the binary hasn't changed size; every recipe below reads from its `strings.txt`, not a fresh `strings` call.
 2. **Anchor on stable strings, not derived names.** System-prompt openers, UI-facing error text, telemetry/event names, config-key names, `.rs:line` debug locations: these survive releases. Minified JS identifiers and even some struct layouts do not.
-3. **Walk outward from the anchor.** Grep the anchor, then read the surrounding region (`awk` a line range, or grab a character window with `grep -aoE '.{0,N}anchor.{0,N}'`) to find the code, config, or prompt fragments next to it.
+3. **Walk outward from the anchor.** Grep the anchor, then read the surrounding region: `awk` a line range for a known window, or [scripts/extract-context.sh](scripts/extract-context.sh) `<anchor> <file> [width]` for a character window around a match anywhere in the file. Reach for the script over hand-rolling `grep -aoE '.{0,N}anchor.{0,N}'`; see the pitfall below for why.
 4. **Filter noise, but derive the noise list per tool.** Every runtime bakes in its own boilerplate (Bun's `bun-internal`/`oniguruma`, cargo's registry paths, etc.). Don't assume one tool's noise list applies to another; a quick `grep -c` of the suspected noise string tells you whether it's even present.
 
 The per-build reference files below give you the concrete grep recipes for each anchor type (prompts, UI messages, function bodies, config keys). Read the one matching your build classification above.
+
+## Scripts
+
+- [scripts/spelunk-init.sh](scripts/spelunk-init.sh): resolve, classify, and dump a harness binary into `$TMPDIR/spelunk/<tool>/` (`strings.txt` + `manifest.txt`). Run this first.
+- [scripts/extract-context.sh](scripts/extract-context.sh): print the context window around every match of an anchor, using perl instead of grep's bounded-repetition engine so it works past the widths where grep itself breaks (see Pitfalls).
 
 ## Reference files
 
@@ -84,19 +90,21 @@ It's a third-party extraction: it can lag the newest release, and it's someone e
 | Pattern | Why |
 |---------|-----|
 | Anchor on UI strings, telemetry events, config keys, `.rs:line` locations | Stable across releases; minified names and even struct shapes are not |
-| Dump `strings` to a temp file once, reuse it | Binaries run 100-200MB+; re-running `strings` per grep is slow |
+| Run `scripts/spelunk-init.sh <tool>` once per investigation, reuse its workspace | Binaries run 100-200MB+; re-running `strings` per grep is slow, and a shared path means every recipe agrees on where things are |
 | Follow `which` through shims to the real artifact before classifying | npm/pip installs often distribute a launcher script, not the binary |
 | Derive the noise filter per tool instead of reusing another tool's | Bun/Rust/Node each bake in different runtime boilerplate; presence isn't guaranteed |
 | Prefer cloning tagged source over spelunking when the tool is open source and tagged | Faster, more readable, no guessing at derived names |
+| Use `scripts/extract-context.sh` for context windows instead of hand-rolled `grep -aoE '.{0,N}...'` | Sidesteps the grep repetition-cap class of failure entirely (see Pitfalls) |
 
 ## Pitfalls
 
-- **Assuming build type from install method.** npm-installed does not mean JS bundle; codex installs via npm but ships a Rust binary. Always `file` the real artifact.
+- **Assuming build type from install method.** npm-installed does not mean JS bundle; codex installs via npm but ships a Rust binary. Always `file` the real artifact (`spelunk-init.sh` does this for you).
 - **Trusting `which` at face value.** It frequently returns a launcher/shim, not the artifact you want to classify.
+- **Assuming bun and rust markers are mutually exclusive.** A Bun-compiled JS bundle can embed a native Rust addon (Claude Code ships one via napi/tokio), so `.cargo/registry` hits alone don't mean the binary is a standalone Rust build. `spelunk-init.sh` treats any Bun-specific marker (`tmp_modules/bun`, `oniguruma`, `bun-internal`) as decisive over rust markers for exactly this reason.
 - **Reusing one tool's noise filter on another.** `bun-internal` noise present in Claude Code is entirely absent from opencode's Bun build; check before you filter.
 - **First match for a generic UI string is rarely the only code path.** Disambiguate with nearby classification tags, telemetry event names, or (in Rust) `.rs:line` locations.
 - **Baking derived/minified names into a plan.** Minified JS identifiers rotate every release. Rust struct/function names are more stable but crate-internal ones can still shift. Write down the anchor that leads you there, not the name itself.
-- **BSD grep's `{0,N}` cap at 255.** `grep -E '.{0,500}'` errors with "maximum repetition exceeds 255" on macOS. Drop below 255 or chain `[^}]*}` segments.
+- **Grep's bounded-repetition cap, in whichever error string your `grep` happens to produce.** `grep -aoE '.{0,500}anchor.{0,500}'` fails past a certain width, but the message depends on what's actually running as `grep`: BSD grep says "repetition-operator operand invalid" / "maximum repetition count exceeds 255"; ugrep (a common `grep` shim, including via Claude Code's own file-scoped grep wrapper) says "exceeds complexity limits" at a threshold that depends on the pattern, not just the width. Same root cause, different text, so grepping the docs for one message won't surface the other. Use `scripts/extract-context.sh` instead of hand-rolling this grep; it does the extraction in perl, which has no such cap, and sidesteps the whole class of failure rather than tuning the width to dodge it.
 - **Assuming source and shipped binary agree.** Source is what was committed; the binary is what's running. When behavior doesn't match source, or the version isn't tagged yet, spelunk the binary even for open-source tools.
 
 ## Real-world references

--- a/plugins/agent-meta/skills/harness-binary-spelunking/references/bun-js.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/references/bun-js.md
@@ -2,49 +2,37 @@
 
 Claude Code and opencode are both shipped as single Mach-O binaries compiled by **Bun**, with the application as minified JavaScript embedded as plain string constants. `strings` reads it back, `grep` queries it. No deobfuscation, no decompilation needed. The hard part is knowing what to grep for.
 
-The recipes below were developed against Claude Code and confirmed to transfer to opencode with two real differences, called out inline: the noise filter, and the anchor scheme for stable functions/providers. Everything else (splitting minified JS, chaining past braces, the BSD grep 255 cap) applies to both as written.
+The recipes below were developed against Claude Code and confirmed to transfer to opencode with two real differences, called out inline: the noise filter, and the anchor scheme for stable functions/providers. Everything else (splitting minified JS, context-window extraction) applies to both as written.
 
-## What you're working with
+## Setup
+
+Run the shared setup script first (see the main [SKILL.md](../SKILL.md)):
 
 ```bash
-which claude                                          # /Users/<you>/.local/bin/claude
-file $(readlink -f $(which claude))                   # Mach-O 64-bit executable arm64
-strings $(readlink -f $(which claude)) | grep -i bun   # confirms Bun build
+scripts/spelunk-init.sh claude     # or opencode
 ```
 
-For opencode, the same shape applies:
+This resolves the binary, confirms the Bun build, and dumps strings to `$TMPDIR/spelunk/<tool>/strings.txt`. The recipes below refer to that path as `$STRINGS`, and to the resolved binary (the `binary=` line in `manifest.txt`) as `$BIN`:
 
 ```bash
-which opencode
-file $(readlink -f $(which opencode))                 # Mach-O 64-bit executable arm64, ~114MB
+STRINGS=$TMPDIR/spelunk/claude/strings.txt   # or spelunk/opencode/...
+BIN=$(awk -F= '$1=="binary"{print $2}' $TMPDIR/spelunk/claude/manifest.txt)
 ```
 
-**Noise filter is tool-specific, don't assume it transfers.** Claude Code's strings include `/Users/runner/work/bun-internal/bun-internal/embedded/oniguruma/...`, Bun-runtime boilerplate you filter out or drown in. opencode's build has **none of it**:
+**Noise filter is tool-specific, don't assume it transfers.** Claude Code's strings include `oniguruma` and `tmp_modules/bun/*.ts` paths, Bun-runtime boilerplate you filter out or drown in. opencode's build has **none of the `bun-internal` variant**:
 
 ```bash
-strings $(readlink -f $(which opencode)) | grep -c bun-internal   # 0
+grep -c bun-internal $TMPDIR/spelunk/opencode/strings.txt   # 0
 ```
 
 Check what noise is actually present in the binary you're looking at before you build a filter; don't reuse another tool's list.
-
-## One-time setup per session
-
-Dump strings to a temp file once, grep it many times. The binary is 100-200MB+; `strings` over it takes a few seconds. Re-running for every grep is wasteful.
-
-```bash
-BIN=$(readlink -f $(which claude))       # or opencode
-strings "$BIN" > $TMPDIR/harness-strings.txt
-ls -lh $TMPDIR/harness-strings.txt       # ~37MB typically for Claude Code
-```
-
-Every recipe below assumes `$TMPDIR/harness-strings.txt` exists and `$BIN` points at the real artifact.
 
 ## Recipe 1: Extract the system prompt
 
 **Claude Code:** the system prompt is stored as a literal string starting with `You are Claude Code,`. Different invocations (CLI, Agent SDK, "explanatory mode") use different opener variants.
 
 ```bash
-grep -n "^You are Claude" $TMPDIR/harness-strings.txt
+grep -n "^You are Claude" $STRINGS
 ```
 
 You'll see something like:
@@ -58,7 +46,7 @@ You'll see something like:
 Each match is *one line* of the assembled prompt. The full prompt is composed at runtime from many adjacent string constants. To see the surrounding fragments:
 
 ```bash
-awk 'NR>=153955 && NR<=154100' $TMPDIR/harness-strings.txt
+awk 'NR>=153955 && NR<=154100' $STRINGS
 ```
 
 Tool names (`Bash`, `Grep`, `Read`, `Glob`...) and their descriptions live as adjacent constants in the same region: read forward until the strings stop being prose.
@@ -78,7 +66,7 @@ One grep on a distinctive opener phrase lands the (mostly) whole prompt in a sin
 You see a specific message in the UI ("This command requires approval", "Auto-allowed with sandbox", "Newline followed by `#` hides arguments"). You want the code that emits it.
 
 ```bash
-grep -n "This command requires approval" $TMPDIR/harness-strings.txt
+grep -n "This command requires approval" $STRINGS
 ```
 
 If the string appears in *multiple* code paths (it usually does for generic messages), look for nearby **classification tags** or **telemetry event names**, which are far more specific than the user-facing text.
@@ -114,11 +102,11 @@ The binary is one giant minified line per `;`-separated statement. Plain `grep` 
 strings "$BIN" | tr ';' '\n' | grep 'function Em_' | head -5
 ```
 
-Or capture a context window around a known anchor (works around BSD grep's `{0,255}` repetition cap by chaining):
+Or capture a context window around a known anchor with [scripts/extract-context.sh](../scripts/extract-context.sh) (avoids grep's bounded-repetition cap entirely, see the main SKILL.md pitfalls):
 
 ```bash
 # Anchor on a UI string, grab ~250 chars of surrounding minified JS
-grep -aoE '.{0,250}Auto-allowed with sandbox.{0,200}' "$BIN" | head -3
+scripts/extract-context.sh 'Auto-allowed with sandbox' $STRINGS 250
 ```
 
 For function bodies past one closing brace, chain `[^}]*}` as many times as you need:
@@ -134,11 +122,11 @@ strings "$BIN" | grep -oE 'async function Vu4[^}]*}[^}]*}[^}]*}' | head -1 | fol
 Settings keys live as quoted JSON-property strings, in both tools:
 
 ```bash
-grep -oE '"[a-zA-Z][a-zA-Z0-9]*Sandboxed?"' $TMPDIR/harness-strings.txt | sort -u
-grep -oE '"(allow|deny|hooks?|permission)[A-Z][a-zA-Z]*"' $TMPDIR/harness-strings.txt | sort -u
+grep -oE '"[a-zA-Z][a-zA-Z0-9]*Sandboxed?"' $STRINGS | sort -u
+grep -oE '"(allow|deny|hooks?|permission)[A-Z][a-zA-Z]*"' $STRINGS | sort -u
 
 # Or context-window around a known one
-grep -ao '.\{0,150\}autoAllowBashIfSandboxed.\{0,150\}' "$BIN" | head -3
+scripts/extract-context.sh 'autoAllowBashIfSandboxed' $STRINGS 150
 ```
 
 For the schema of a config object, find the validator (Zod schemas leave readable shape strings):
@@ -153,5 +141,5 @@ grep -ao '\.object({[^}]*})' "$BIN" | grep -i sandbox | head
 - **Assuming Claude Code's noise filter (`bun-internal`, `oniguruma`) applies to every Bun build.** opencode's build has zero `bun-internal` hits. Check with `grep -c` first.
 - **Assuming every Bun-compiled prompt is fragmented like Claude Code's.** opencode's is a near-whole template literal. Look at your first match before reaching for line-range reassembly.
 - **First match for a UI string is rarely the one you want.** Generic messages like "This command requires approval" are emitted from multiple code paths. Disambiguate via nearby `bashMissKind:`, `kind:`, `tengu_*`, or `l.fn(...)`/`bo.make(...)` tags.
-- **BSD grep limit:** `grep -E '.{0,500}'` errors with "maximum repetition exceeds 255". Drop to 250 or chain.
+- **Grep's bounded-repetition cap.** Hand-rolling `grep -aoE '.{0,500}anchor.{0,500}'` fails past a certain width, with different error text depending on which `grep` is actually running (BSD grep vs. a ugrep shim). Use `scripts/extract-context.sh` instead; see the main SKILL.md pitfalls for why.
 - **Minified names change every release.** Don't write down "the function is `Vu4`" and expect it to mean anything next week. Write down the *anchors* that lead you to the function.

--- a/plugins/agent-meta/skills/harness-binary-spelunking/references/rust.md
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/references/rust.md
@@ -1,35 +1,39 @@
 # Rust builds: codex
 
-codex (`openai/codex`, 0.139.0 at the time of this recon) installs via npm but ships a **Rust** binary, not a JS bundle. `which codex` returns a Node launcher (`.../@openai/codex/bin/codex.js`) that spawns the real platform binary; follow the shim before you classify anything:
+codex (`openai/codex`, 0.139.0 at the time of this recon) installs via npm but ships a **Rust** binary, not a JS bundle. `which codex` returns a Node launcher (`.../@openai/codex/bin/codex.js`) that spawns the real platform binary; [scripts/spelunk-init.sh](../scripts/spelunk-init.sh) detects the shim and stops so you can chase it by hand:
 
 ```
-$ which codex
-/Users/<you>/.local/bin/codex                          # Node launcher
-
-$ cat $(which codex)                                    # spawns the real binary at:
+$ scripts/spelunk-init.sh codex
+'.../codex' looks like a launcher/shim, not the real binary:
+  a /usr/bin/env node script text executable
+Contents:
+...spawns the real binary at:
 /Users/<you>/.local/share/mise/installs/node/<v>/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
 
-$ file .../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
-Mach-O 64-bit executable arm64                          # 203MB
+$ scripts/spelunk-init.sh codex .../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+Workspace ready: $TMPDIR/spelunk/codex
+  build type:  rust (bun markers: 0, rust markers: 3565)
+  strings:     $TMPDIR/spelunk/codex/strings.txt
 ```
 
 **Lesson:** `which` may hand you a shim. Chase the spawn target to the real artifact before classifying it as a build type. An npm-installed CLI is not automatically a JS bundle.
 
 ## Confirming it's Rust
 
-Strings carry unmistakable Rust/cargo provenance:
+The script's classification already told you (`build type: rust`), driven by `.cargo/registry` hits in the dump. To see the provenance yourself, or to pull crate::module paths:
 
 ```bash
-CODEX=.../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
-strings "$CODEX" | grep -c '.cargo/registry'    # cargo-registry paths, nonzero
-strings "$CODEX" | grep -oE '[a-z_]+::[a-z_]+' | sort -u | head    # crate::module paths
+STRINGS=$TMPDIR/spelunk/codex/strings.txt
+BIN=$(awk -F= '$1=="binary"{print $2}' $TMPDIR/spelunk/codex/manifest.txt)
+grep -c '.cargo/registry' $STRINGS                          # cargo-registry paths, nonzero
+grep -oE '[a-z_]+::[a-z_]+' $STRINGS | sort -u | head        # crate::module paths
 ```
 
 You'll see things like `/Users/runner/.cargo/registry/...`, `.rs` file paths, and crate paths like `codex_models_manager::manager`.
 
 ## What transfers from the JS recipes, and what doesn't
 
-The general method (dump strings once, anchor on stable strings, walk outward) is the same. The concrete recipes are different because Rust doesn't minify or bundle the way a JS build does:
+The general method (dump strings once via `spelunk-init.sh`, anchor on stable strings, walk outward) is the same. Every recipe below reads from `$STRINGS` rather than re-running `strings "$BIN"` per grep, for the same reason as the JS recipes: the binary is 100-200MB+, and re-dumping per command is exactly the freelancing the shared workspace exists to avoid. The concrete recipes are different because Rust doesn't minify or bundle the way a JS build does:
 
 - **No `tr ';' '\n'` splitting.** That trick exists because minified JS is one giant `;`-joined statement; Rust binaries aren't shaped that way.
 - **No Zod `.object({...})` schema strings.** That's a JS-validator-library artifact. Rust's config schema shows up differently (see below).
@@ -40,7 +44,7 @@ The general method (dump strings once, anchor on stable strings, walk outward) i
 This is the biggest divergence from the JS recipes. Claude Code and opencode store prompts as string fragments or a near-whole template literal that still needs a grep to locate. codex's Rust build embeds each prompt as a **complete string constant**, so one grep on a distinctive opening clause returns the entire block:
 
 ```bash
-strings "$CODEX" | grep -iE 'you are (codex|a coding)'
+grep -iE 'you are (codex|a coding)' $STRINGS
 ```
 
 From codex 0.139.0, this yields entire prompt blocks in one match each, no reassembly:
@@ -56,7 +60,7 @@ Templating is visible too, as literal placeholder strings rather than assembled 
 Rust's serde-derived config structs serialize field names as plain snake_case strings, directly greppable with no JSON-quote or camelCase guessing:
 
 ```bash
-strings "$CODEX" | grep -iE 'approval_policy|sandbox_mode|model_reasoning_effort'
+grep -iE 'approval_policy|sandbox_mode|model_reasoning_effort' $STRINGS
 ```
 
 From codex 0.139.0, this also surfaces `personality_default`, `personality_pragmatic`, `context_window`, `auto_compact_token_limit`, and serde struct summaries like:
@@ -72,7 +76,7 @@ followed by a run of the struct's field names as adjacent strings. That struct-s
 Rust's panic and debug-assertion machinery embeds source file:line pairs as strings. These are semantically stable (they name the actual source location) and, unlike minified JS identifiers, don't rotate on every release the same way, though line numbers shift as the file changes:
 
 ```bash
-strings "$CODEX" | grep -oE '[a-z_/-]+\.rs:[0-9]+' | sort -u | head -20
+grep -oE '[a-z_/-]+\.rs:[0-9]+' $STRINGS | sort -u | head -20
 ```
 
 From this recon: `models-manager/src/manager.rs:231`, `models-manager/src/model_info.rs:67`. These double as a map of the crate layout: the path segment before `src/` is usually the crate name (`models-manager`), which you can cross-reference against the cloned source (see [source-clone.md](source-clone.md)) to jump straight to the relevant file.

--- a/plugins/agent-meta/skills/harness-binary-spelunking/scripts/extract-context.sh
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/scripts/extract-context.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Print the context window around every match of an anchor in a strings
+# dump, without going through grep's bounded-repetition engine.
+#
+# `grep -aoE '.{0,N}anchor.{0,N}'` is the recipe every reference file in this
+# skill used to reach for. It fails two different ways depending on which
+# grep is on PATH:
+#   - BSD grep: "repetition-operator operand invalid" / "maximum repetition
+#     count exceeds 255" once N gets past ~255.
+#   - ugrep (common shim for `grep` on macOS): "exceeds complexity limits",
+#     at a threshold that depends on the pattern, not just N.
+# Both are the same root cause (bounded-repetition blowup in the regex
+# engine), just different error strings -- which is exactly why grepping the
+# docs for one message misses the other. Perl's regex engine has no such
+# cap, so this script does the actual extraction in perl and sidesteps the
+# whole class of failure rather than tuning N to dodge it.
+
+set -euo pipefail
+
+usage() {
+  cat << EOF
+Usage: $0 <anchor> <file> [width]
+
+Print up to <width> characters of context on each side of every match of
+<anchor> (an extended regex) in <file>.
+
+Arguments:
+  anchor   Extended regex to search for (e.g. 'autoAllowBashIfSandboxed')
+  file     File to search (typically a strings dump from spelunk-init.sh)
+  width    Characters of context per side. Default: 250.
+
+Examples:
+  $0 'autoAllowBashIfSandboxed' "\$TMPDIR/spelunk/claude/strings.txt"
+  $0 'Auto-allowed with sandbox' "\$TMPDIR/spelunk/claude/strings.txt" 400
+EOF
+  exit 1
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  usage
+fi
+
+ANCHOR="$1"
+FILE="$2"
+WIDTH="${3:-250}"
+
+if [[ ! -f "$FILE" ]]; then
+  echo "error: no such file: $FILE" >&2
+  exit 2
+fi
+
+# Cheap existence check first (plain grep, no bounded repetition -- this
+# form never hits the 255/complexity limit) so a missing anchor fails fast
+# with a clear message instead of perl silently printing nothing.
+if ! grep -qE -- "$ANCHOR" "$FILE"; then
+  echo "no matches for /$ANCHOR/ in $FILE" >&2
+  exit 1
+fi
+
+ANCHOR="$ANCHOR" WIDTH="$WIDTH" FILE="$FILE" perl -e '
+  my $anchor = $ENV{ANCHOR};
+  my $width  = $ENV{WIDTH};
+  local $/;
+  open(my $fh, "<", $ENV{FILE}) or die $!;
+  my $content = <$fh>;
+  my $n = 0;
+  while ($content =~ /(.{0,$width}$anchor.{0,$width})/gs) {
+    $n++;
+    print "--- match $n ---\n$1\n";
+  }
+  exit($n == 0 ? 1 : 0);
+'

--- a/plugins/agent-meta/skills/harness-binary-spelunking/scripts/spelunk-init.sh
+++ b/plugins/agent-meta/skills/harness-binary-spelunking/scripts/spelunk-init.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Resolve a harness binary, classify its build, and dump strings once into a
+# shared workspace under $TMPDIR so every recipe in this skill reads from the
+# same place instead of each investigation inventing its own path/filename.
+
+set -euo pipefail
+
+usage() {
+  cat << EOF
+Usage: $0 <tool> [binary-path]
+
+Set up (or reuse) the spelunking workspace for <tool>.
+
+Arguments:
+  tool          Name of the harness CLI (e.g. claude, codex, opencode)
+  binary-path   Optional: the real binary to dump, if you've already
+                followed a launcher/shim to its spawn target. If omitted,
+                resolves via \`which <tool>\`.
+
+If the resolved path is a launcher/shim (a script, not a real binary), this
+prints the shim's content and exits without dumping anything -- follow the
+spawn target by hand, then rerun with that path as <binary-path>. Chasing an
+arbitrary spawn chain is a judgment call, not a mechanical step.
+
+On success, prints the workspace directory and manifest. Every other script
+and recipe in this skill assumes:
+  \$TMPDIR/spelunk/<tool>/strings.txt   -- full strings dump
+  \$TMPDIR/spelunk/<tool>/manifest.txt  -- tool, binary, build_type, sizes
+
+Examples:
+  $0 claude
+  $0 codex ~/.local/share/mise/installs/node/22/.../codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex
+EOF
+  exit 1
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+fi
+
+TOOL="$1"
+WORKSPACE="${TMPDIR:-/tmp}/spelunk/$TOOL"
+STRINGS_FILE="$WORKSPACE/strings.txt"
+MANIFEST_FILE="$WORKSPACE/manifest.txt"
+
+resolve_binary() {
+  if [[ $# -eq 1 ]]; then
+    echo "$1"
+    return
+  fi
+  local which_path
+  which_path="$(command -v "$TOOL" || true)"
+  if [[ -z "$which_path" ]]; then
+    echo "error: \`which $TOOL\` found nothing. Pass the binary path explicitly." >&2
+    exit 2
+  fi
+  readlink -f "$which_path" 2>/dev/null || echo "$which_path"
+}
+
+if [[ $# -eq 2 ]]; then
+  BIN="$(resolve_binary "$2")"
+else
+  BIN="$(resolve_binary)"
+fi
+
+if [[ ! -f "$BIN" ]]; then
+  echo "error: resolved path does not exist: $BIN" >&2
+  exit 2
+fi
+
+FILE_INFO="$(file -b "$BIN")"
+
+# A shim/launcher is a script, not the artifact we want to classify or dump.
+# Detecting "is this a shim" is mechanical; finding the spawn target inside
+# it is not (it varies per tool, per platform) -- hand that back to the agent.
+if [[ "$FILE_INFO" == *"script"* || "$FILE_INFO" == *"ASCII text"* || "$FILE_INFO" == *"text executable"* ]]; then
+  echo "'$BIN' looks like a launcher/shim, not the real binary:"
+  echo "  $FILE_INFO"
+  echo
+  echo "Contents:"
+  cat "$BIN"
+  echo
+  echo "Find the spawn target above, then rerun: $0 $TOOL <spawn-target-path>"
+  exit 3
+fi
+
+mkdir -p "$WORKSPACE"
+
+BIN_SIZE="$(stat -f%z "$BIN" 2>/dev/null || stat -c%s "$BIN" 2>/dev/null)"
+
+# Reuse an existing dump if it was made from this same binary (path + size
+# match). Re-running `strings` over a 100-200MB+ binary on every session is
+# the exact freelancing this script exists to avoid.
+if [[ -f "$MANIFEST_FILE" ]] && grep -q "^binary=$BIN\$" "$MANIFEST_FILE" 2>/dev/null \
+   && grep -q "^size_bytes=$BIN_SIZE\$" "$MANIFEST_FILE" 2>/dev/null \
+   && [[ -f "$STRINGS_FILE" ]]; then
+  echo "Reusing existing dump for $BIN (unchanged size $BIN_SIZE bytes)."
+else
+  echo "Dumping strings for $BIN ($BIN_SIZE bytes) -- this can take a few seconds..."
+  strings "$BIN" > "$STRINGS_FILE"
+fi
+
+# Classify build type from markers in the dump. Bun markers win even when
+# rust markers are also present: a Bun-compiled JS bundle can embed a native
+# Rust addon (e.g. Claude Code ships a napi/tokio addon alongside its Bun
+# runtime, so .cargo/registry hits alone are not decisive). Only fall
+# through to "rust" when there's no Bun signal at all -- true of standalone
+# Rust binaries like codex.
+BUN_HITS="$(grep -c 'tmp_modules/bun\|oniguruma\|bun-internal' "$STRINGS_FILE" || true)"
+RUST_HITS="$(grep -c '\.cargo/registry' "$STRINGS_FILE" || true)"
+
+if [[ "${BUN_HITS:-0}" -gt 0 ]]; then
+  BUILD_TYPE="bun-js"
+elif [[ "${RUST_HITS:-0}" -gt 0 ]]; then
+  BUILD_TYPE="rust"
+else
+  BUILD_TYPE="unknown"
+fi
+
+cat > "$MANIFEST_FILE" << EOF
+tool=$TOOL
+binary=$BIN
+size_bytes=$BIN_SIZE
+build_type=$BUILD_TYPE
+bun_marker_hits=${BUN_HITS:-0}
+rust_marker_hits=${RUST_HITS:-0}
+strings_dump=$STRINGS_FILE
+created_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+EOF
+
+echo
+echo "Workspace ready: $WORKSPACE"
+echo "  binary:      $BIN"
+echo "  build type:  $BUILD_TYPE (bun markers: ${BUN_HITS:-0}, rust markers: ${RUST_HITS:-0})"
+echo "  strings:     $STRINGS_FILE"
+echo "  manifest:    $MANIFEST_FILE"
+if [[ "$BUILD_TYPE" == "unknown" ]]; then
+  echo
+  echo "No bun or rust markers found. Check 'file $BIN' and read references/source-clone.md" \
+       "-- this may be unbundled Node/readable source rather than something to spelunk."
+fi


### PR DESCRIPTION
## Summary

- Add scripts/spelunk-init.sh and scripts/extract-context.sh to the harness-binary-spelunking skill, replacing the freelanced strings-dump conventions (claude-strings.txt, then harness-strings.txt with no per-tool suffix, then no caching at all in rust.md) with one shared workspace under $TMPDIR/spelunk/<tool>/ that every recipe reads from.
- extract-context.sh fixes a real failure class: context-window extraction now runs through perl instead of grep's bounded-repetition engine, so it doesn't hit BSD grep's 255 cap or a ugrep shim's "exceeds complexity limits" error. Same root cause, different error text, depending on what's actually running as grep.
- Build classification (bun-js vs rust) is now scripted. Caught and fixed a real bug while verifying against the live claude binary: it embeds a native napi/tokio addon, so .cargo/registry hits alone don't mean "Rust build." Bun-specific markers now win over rust markers for exactly that reason.
- Updated SKILL.md, references/bun-js.md, and references/rust.md to point at the shared workspace instead of each inventing its own path.

## Test plan

- [x] scripts/spelunk-init.sh claude classified bun-js (7 bun markers, 118 rust markers from the embedded native addon)
- [x] scripts/spelunk-init.sh codex classified rust (0 bun markers, 3565 rust markers)
- [x] scripts/spelunk-init.sh opencode classified bun-js (4 bun markers, 185 rust markers)
- [x] Reproduced the ugrep "exceeds complexity limits" failure with a hand-rolled grep -aoE '.{0,400}...' on this machine, then confirmed extract-context.sh handles width 400 and 1500 without error
- [x] ./scripts/validate-plugin-versions.sh and hk run pre-commit both pass
- [x] grep -r for em-dash over the skill directory: zero hits