### PR TITLE
fix(second-brain): drop capture's per-note routing offer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.12.0"
+      "version": "1.12.1"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/docs/plans/2026-08-27-capture-drop-route-offer-design.md
+++ b/plugins/second-brain/docs/plans/2026-08-27-capture-drop-route-offer-design.md
@@ -1,0 +1,127 @@
+# Capture: Drop the Per-Note Routing Offer
+
+Bean: gt-6zaa
+Date: 2026-08-27
+
+## Goal
+
+`second-brain:capture` Step 4 currently ends every single-note capture with a
+question — "Want me to route it to X?" — before leaving the note in the inbox.
+Remove that question. Routing is `process-inbox`'s job: it already auto-routes
+above a confidence threshold and only pauses on low-confidence notes. The
+per-note offer is a duplicated decision point on top of a batch path that
+already exists.
+
+## Background
+
+- A 2026-08-20 session (bean `1fxi` / PR #111) diagnosed capture as doing
+  three round-trips per note: route offer, connect offer, breadcrumb offer.
+  That work automated the breadcrumb (no longer a yes/no) but deliberately
+  left the route and connect offers unfiled — "a design call, not a bug fix."
+- Session history (checked via `cq` across ~1300 indexed transcripts,
+  2026-08-27) confirms capture asks to route on essentially every single-note
+  capture sampled from 2026-07-28 through 2026-08-20, while `process-inbox`
+  already auto-routes silently above threshold and only surfaces low-confidence
+  notes for a decision.
+- The newer, unmerged `devlog` skill (successor to `distill-conversation`,
+  currently only in the `bare.git.devlog-skill` worktree) already embodies the
+  target philosophy: never ask at write time, defer all processing decisions
+  to the batch pipeline.
+
+## Decision
+
+Capture stops asking about routing entirely. It doesn't route, and it doesn't
+mention that the note still needs routing — that status is `process-inbox`'s
+to surface, not capture's. The final report only covers what was captured and
+linked, the same way `devlog`'s report only covers what was logged.
+
+The one exception: if the user names a destination in the same conversation
+("put it in 66"), capture resolves it the way `route` would — via
+`sb vault structure`, matching against a real destination (JD `area`/`code` or
+PARA folder) — and moves the note there with `sb note move`. It never
+constructs a destination path from the user's words alone. This isn't an
+"offer"; it's honoring an explicit instruction, and it stays subject to the
+same "sb owns paths, no hand-rolling" rule the rest of the skill already
+follows.
+
+Out of scope: the Step 5 *connect* offer is untouched. Josh's 2026-08-27
+statement was specific to routing; no decision has been made on connect.
+
+## Changes
+
+### `skills/capture/SKILL.md`, Step 4
+
+Replace the current step:
+
+```
+## Step 4: Leave it in the inbox - routing is opt-in
+
+The note stays where sb put it. **Offer** to route it; do not route it.
+
+This overrides the vault's general "capture: file rough, move on / a wrong-but-close
+home beats the global inbox" guidance, which governs notes *the user* files by hand.
+Notes *the agent* writes on request stay in the inbox until the user says otherwise.
+Both rules coexist in the vault CLAUDE.md and the scope of the override has
+historically been read as ambiguous, which produced a roughly 50/50 split between
+inbox and direct-to-area filing. It is not ambiguous: **agent-written note on
+request → inbox, stop.**
+
+The exception is an explicit destination from the user ("put it in 66"). Then write it there.
+```
+
+with:
+
+```
+## Step 4: Leave it in the inbox for `process-inbox` to route
+
+The note stays where sb put it. Routing is `process-inbox`'s job, not capture's —
+don't ask, don't route it, and don't mention that it still needs routing.
+
+This overrides the vault's general "capture: file rough, move on / a wrong-but-close
+home beats the global inbox" guidance, which governs notes *the user* files by hand.
+Notes *the agent* writes on request stay in the inbox until `process-inbox` picks them
+up. Both rules coexist in the vault CLAUDE.md; the scope of the override has
+historically been read as ambiguous — first producing a roughly 50/50 split between
+inbox and direct-to-area filing, later a per-note routing question duplicating
+process-inbox's own batch routing. It is not ambiguous: **agent-written note on
+request → inbox, no offer, no mention.**
+
+The exception is an explicit destination named in the same conversation ("put it in
+66"). Resolve it the way `route` would rather than hand-rolling a path: run
+`sb vault structure`, match the user's phrase against a real destination (JD `area`/
+`code` or PARA folder), then `sb note move --from "{note-path}" --to "{destination}/"`.
+Never construct the destination path from the user's words alone.
+```
+
+### `skills/capture/SKILL.md`, Constraints section
+
+Replace:
+
+> - **Inbox by default.** Routing is offered, not performed.
+
+with:
+
+> - **Inbox by default.** Routing is `process-inbox`'s job — capture never asks or
+>   routes, except an explicit user-named destination, resolved via `sb vault
+>   structure` like `route` does, never hand-rolled.
+
+## Not changing
+
+- `description:` frontmatter — unchanged, so no eval re-run needed (evals only
+  test trigger-phrase discrimination, not this wording; confirmed by grepping
+  `evals/trigger-evals.json`, which has no assertions tied to Step 4).
+- Step 5 (connect offer, daily breadcrumb) — untouched.
+- `references/note-format.md` — already consistent with the new design ("a
+  capture that hasn't been routed isn't `filed` yet," pipeline states owned by
+  pipeline skills). No edit needed.
+- The vault's own `CLAUDE.md` (`~/Vaults/pickled-knowledge/CLAUDE.md`) — its
+  override language ("routing is a separate, opt-in step") remains accurate;
+  routing is still opt-in, just opt-in via running `process-inbox`, not via a
+  per-note question. Not part of this repo, not part of this PR.
+
+## Verification
+
+Textual change to a SKILL.md — no automated test surface. Verify by reading
+the diff for internal consistency (Step 4 and the Constraints bullet agree)
+and confirming no other file in `skills/capture/` still references the
+per-note routing offer (`grep -rn "route" skills/capture/`).

--- a/plugins/second-brain/docs/plans/2026-08-27-capture-drop-route-offer-plan.md
+++ b/plugins/second-brain/docs/plans/2026-08-27-capture-drop-route-offer-plan.md
@@ -1,0 +1,197 @@
+# Capture: Drop the Per-Note Routing Offer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the per-note "want me to route it?" question from `second-brain:capture`, since `process-inbox` already owns routing.
+
+**Architecture:** Single-file prose edit to `plugins/second-brain/skills/capture/SKILL.md` in the `pickled-claude-plugins` repo — no code, no tests, no `description:` change. Design is fully specified in `plugins/second-brain/docs/plans/2026-08-27-capture-drop-route-offer-design.md`; this plan just sequences the edit, verification, version bump, and PR.
+
+**Tech Stack:** Markdown (Claude Code skill file). Repo tooling: `scripts/bump-version.sh`, `scripts/check-commit-scope.sh` (conventional-commit CI gate), `gh` for the PR.
+
+---
+
+### Task 1: Edit `capture/SKILL.md` — Step 4 and the Constraints bullet
+
+**Files:**
+- Modify: `plugins/second-brain/skills/capture/SKILL.md:115-126` (Step 4)
+- Modify: `plugins/second-brain/skills/capture/SKILL.md:183` (Constraints bullet)
+
+- [ ] **Step 1: Replace Step 4**
+
+Find this exact block (lines 115-126):
+
+```markdown
+## Step 4: Leave it in the inbox - routing is opt-in
+
+The note stays where sb put it. **Offer** to route it; do not route it.
+
+This overrides the vault's general "capture: file rough, move on / a wrong-but-close
+home beats the global inbox" guidance, which governs notes *the user* files by hand. Notes *the agent* writes on
+request stay in the inbox until the user says otherwise. Both rules coexist in the vault CLAUDE.md
+and the scope of the override has historically been read as ambiguous, which produced a roughly
+50/50 split between inbox and direct-to-area filing. It is not ambiguous: **agent-written note on
+request → inbox, stop.**
+
+The exception is an explicit destination from the user ("put it in 66"). Then write it there.
+```
+
+Replace it with:
+
+```markdown
+## Step 4: Leave it in the inbox for `process-inbox` to route
+
+The note stays where sb put it. Routing is `process-inbox`'s job, not capture's —
+don't ask, don't route it, and don't mention that it still needs routing.
+
+This overrides the vault's general "capture: file rough, move on / a wrong-but-close
+home beats the global inbox" guidance, which governs notes *the user* files by hand.
+Notes *the agent* writes on request stay in the inbox until `process-inbox` picks them
+up. Both rules coexist in the vault CLAUDE.md; the scope of the override has
+historically been read as ambiguous — first producing a roughly 50/50 split between
+inbox and direct-to-area filing, later a per-note routing question duplicating
+process-inbox's own batch routing. It is not ambiguous: **agent-written note on
+request → inbox, no offer, no mention.**
+
+The exception is an explicit destination named in the same conversation ("put it in
+66"). Resolve it the way `route` would rather than hand-rolling a path: run
+`sb vault structure`, match the user's phrase against a real destination (JD `area`/
+`code` or PARA folder), then `sb note move --from "{note-path}" --to "{destination}/"`.
+Never construct the destination path from the user's words alone.
+```
+
+- [ ] **Step 2: Replace the Constraints bullet**
+
+Find this exact line:
+
+```markdown
+- **Inbox by default.** Routing is offered, not performed.
+```
+
+Replace it with:
+
+```markdown
+- **Inbox by default.** Routing is `process-inbox`'s job — capture never asks or
+  routes, except an explicit user-named destination, resolved via `sb vault
+  structure` like `route` does, never hand-rolled.
+```
+
+- [ ] **Step 3: Verify no leftover per-note routing-offer language**
+
+Run:
+
+```bash
+grep -n "route\|Route" plugins/second-brain/skills/capture/SKILL.md
+```
+
+Expected matches, and only these:
+- Line 3 (`description:`) — mentions `route` as the *other* skill capture defers to (unchanged, correct)
+- The new Step 4 block (mentions `route`, `sb vault structure`, `sb note move` — the resolution path, correct)
+- The new Constraints bullet (correct)
+- Line ~67 ("Notes get routed between folders constantly" in the search-fallback section) — unrelated, leave as is
+
+If any other line mentions offering to route, the edit is incomplete — fix before continuing.
+
+- [ ] **Step 4: Read the full file once for internal consistency**
+
+Read `plugins/second-brain/skills/capture/SKILL.md` top to bottom. Confirm:
+- Step 4's heading, body, and the Constraints bullet all agree (no offer, no mention, exception uses `sb vault structure` + `sb note move`)
+- Step 5 (connect offer, daily breadcrumb) is untouched
+- `references/note-format.md` is not touched (design doc confirmed it's already consistent)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/second-brain/skills/capture/SKILL.md
+git commit -m "$(cat <<'EOF'
+fix(second-brain): drop capture's per-note routing offer
+
+process-inbox already auto-routes above a confidence threshold and
+only surfaces low-confidence notes for a decision. capture's
+per-note "want me to route it?" question duplicated that decision
+instead of deferring to it. Capture now leaves the note in the
+inbox silently; the only exception is an explicit user-named
+destination, resolved via `sb vault structure` the way route
+resolves destinations, never hand-rolled.
+EOF
+)"
+```
+
+---
+
+### Task 2: Bump the plugin version
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json` (version bump)
+- Modify: `README.md` (plugin table, if `generate-plugin-table.sh` changes it — it won't here, since no plugin description changed, but the script still runs as part of `--auto`)
+
+- [ ] **Step 1: Run the auto-bump script**
+
+```bash
+./scripts/bump-version.sh --auto
+```
+
+Expected output: reports a version bump for `second-brain` (patch bump, since this is a `fix(second-brain)` commit — behavior fix, not a new feature).
+
+- [ ] **Step 2: Verify the diff**
+
+```bash
+git diff
+```
+
+Expected: `.claude-plugin/marketplace.json` shows `second-brain`'s version incremented by patch (e.g. `1.10.1` → `1.10.2` — check the actual current version in the file first, since it may have moved since this plan was written). No unrelated version bumps.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json README.md
+git commit -m "chore(second-brain): bump version to <version-from-step-1>"
+```
+
+(Fill in `<version-from-step-1>` with the actual number the script reported — don't guess it ahead of running the script.)
+
+---
+
+### Task 3: Open the PR
+
+**Files:** none (GitHub operation)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin capture-drop-route-offer
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "fix(second-brain): drop capture's per-note routing offer" --body "$(cat <<'EOF'
+## Summary
+- `second-brain:capture` no longer asks "want me to route it?" after writing a note — that's `process-inbox`'s job, which already auto-routes above a confidence threshold.
+- The one exception (an explicit destination named in the same conversation, e.g. "put it in 66") now resolves through `sb vault structure` the way `route` does, instead of writing a hand-rolled path.
+
+## Why
+Per-note capture already asks about the daily breadcrumb-adjacent connect offer and, until now, routing too — three round-trips per note. The breadcrumb one was fixed in #111. This closes the routing half: it was a duplicated decision point sitting on top of a batch routing path (`process-inbox`) that already exists and already handles low-confidence cases by asking.
+
+## Test plan
+- [ ] Read the diff: Step 4 and the Constraints bullet agree, Step 5 (connect offer, breadcrumb) untouched
+- [ ] `description:` frontmatter unchanged — no eval re-run needed
+- [ ] CI green (commit-scope check, version-bump check)
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm CI is green**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: both checks (commit-scope validation, version-bump check) pass. If either fails, read the failure output and fix before re-pushing — don't skip checks.
+
+---
+
+## Not in this plan
+
+- Merging the PR — that's a human call, done by Josh after review.
+- Updating bean `gt-6zaa` — mark it `completed` with the merge SHA once the PR actually merges (matches the `1fxi` precedent: don't mark done until the PR is in).
+- Any change to the Step 5 connect offer, `devlog`, or `route`/`process-inbox` skills — explicitly out of scope per the design doc.

--- a/plugins/second-brain/skills/capture/SKILL.md
+++ b/plugins/second-brain/skills/capture/SKILL.md
@@ -112,18 +112,25 @@ as of 2026-08-14 that had orphaned 46 notes, and untangling it took a single 211
 For a title, prefer the source's own framing over a topic label. `# Glide browser` beats
 `# Notes on a keyboard-driven browser`.
 
-## Step 4: Leave it in the inbox - routing is opt-in
+## Step 4: Leave it in the inbox for `process-inbox` to route
 
-The note stays where sb put it. **Offer** to route it; do not route it.
+The note stays where sb put it. Routing is `process-inbox`'s job, not capture's —
+don't ask, don't route it, and don't mention that it still needs routing.
 
-This overrides the vault's general "capture: file rough, move on / a wrong-but-close home beats the
-global inbox" guidance, which governs notes *the user* files by hand. Notes *the agent* writes on
-request stay in the inbox until the user says otherwise. Both rules coexist in the vault CLAUDE.md
-and the scope of the override has historically been read as ambiguous, which produced a roughly
-50/50 split between inbox and direct-to-area filing. It is not ambiguous: **agent-written note on
-request → inbox, stop.**
+This overrides the vault's general "capture: file rough, move on / a wrong-but-close
+home beats the global inbox" guidance, which governs notes *the user* files by hand.
+Notes *the agent* writes on request stay in the inbox until `process-inbox` picks them
+up. Both rules coexist in the vault CLAUDE.md; the scope of the override has
+historically been read as ambiguous — first producing a roughly 50/50 split between
+inbox and direct-to-area filing, later a per-note routing question duplicating
+process-inbox's own batch routing. It is not ambiguous: **agent-written note on
+request → inbox, no offer, no mention.**
 
-The exception is an explicit destination from the user ("put it in 66"). Then write it there.
+The exception is an explicit destination named in the same conversation ("put it in
+66"). Resolve it the way `route` would rather than hand-rolling a path: run
+`sb vault structure`, match the user's phrase against a real destination (JD `area`/
+`code` or PARA folder), then `sb note move --from "{note-path}" --to "{destination}/"`.
+Never construct the destination path from the user's words alone.
 
 ## Step 5: Offer connections, append the daily breadcrumb
 
@@ -180,7 +187,9 @@ yourself once all notes exist, since connections need the whole set in view.
 - **Never fabricate.** No invented URLs, no unverified `[[links]]`, no filled-in details. Stop and
   report the gap instead.
 - **sb owns paths.** No hand-rolled destinations.
-- **Inbox by default.** Routing is offered, not performed.
+- **Inbox by default.** Routing is `process-inbox`'s job — capture never asks or
+  routes, except an explicit user-named destination, resolved via `sb vault
+  structure` like `route` does, never hand-rolled.
 - **Connecting is offered; the breadcrumb is not.** Suggest related links and let the user decide,
   but the daily-note breadcrumb append happens automatically every time - it no longer waits for a
   yes.

--- a/plugins/second-brain/skills/capture/evals/README.md
+++ b/plugins/second-brain/skills/capture/evals/README.md
@@ -1,3 +1,32 @@
+# Evals for `capture`
+
+## Behavior eval: `no-route-offer`
+
+Permanent regression fixture for Step 4 ("leave it in the inbox for
+`process-inbox` to route" - capture must never ask about routing per note).
+Lives at `scenarios/no-route-offer/scenario.yaml`, run via the `skill-evals`
+harness (a separate tool, not `trigger_eval.py`):
+
+```bash
+cd /path/to/skill-evals
+uv run skill-evals \
+  --plugin-dir /path/to/pickled-claude-plugins/plugins/second-brain \
+  --config /path/to/pickled-claude-plugins/plugins/second-brain/skills/capture/evals/eval_config.yaml \
+  --scenarios-dir /path/to/pickled-claude-plugins/plugins/second-brain/skills/capture/evals/scenarios \
+  --project-root /path/to/pickled-claude-plugins/plugins/second-brain \
+  --scenario no-route-offer --trials 1
+```
+
+Confirmed 2026-08-28: passes 100% (behavior + tool_calls checks) against the
+current (fixed) `capture/SKILL.md` across 3 real runs. Read the "known quirk"
+comment at the top of `scenario.yaml` before trusting the transcript's own
+narrative of success/failure - the model sometimes reports Write/Edit as
+"denied" even when the harness's own results JSON shows the mock matched and
+returned success. That's a separate, filed `skill-evals` harness issue, not a
+`capture` bug, and doesn't affect this scenario's actual pass/fail (the checks
+are scoped to routing language and the absence of a `sb note move` call,
+neither of which the denial narrative touches either way).
+
 # Trigger evals for `capture`
 
 Measures whether the skill actually fires on real user phrasings. Queries in

--- a/plugins/second-brain/skills/capture/evals/eval_config.yaml
+++ b/plugins/second-brain/skills/capture/evals/eval_config.yaml
@@ -1,0 +1,28 @@
+judge_domain_context: |
+  The assistant is running the `second-brain:capture` Claude Code skill, which
+  writes a note into an Obsidian vault from a source the user hands it. We are
+  testing Step 4 of that skill: after creating the note, capture must leave it
+  in the inbox and never ask the user whether to route it anywhere. Routing is
+  a separate skill's job now (`process-inbox`, which auto-routes above a
+  confidence threshold on its own batch pass). A prior version of capture
+  asked "want me to route it?" on every single-note capture; this test guards
+  against regressing back to that.
+
+  Step-4-compliant behavior: the assistant reports the note was created and
+  left in the inbox (optionally also reporting the daily-note breadcrumb
+  and/or any connections offered, per the rest of the skill), without asking
+  the user any question about routing, moving, or filing the note, and
+  without itself moving the note via `sb note move` (no destination was
+  named in this scenario, so there is nothing to resolve).
+
+  Regressed behavior: the assistant asks something like "want me to route
+  it?", "should I move this to X?", "left it in the inbox, let me know if
+  you want it filed elsewhere" - any question or offer about the note's
+  destination - or silently moves the note without a user-named destination.
+
+# Run from the skill-evals repo (or wherever skill-evals is installed):
+#   uv run skill-evals \
+#     --plugin-dir plugins/second-brain \
+#     --config plugins/second-brain/skills/capture/evals/eval_config.yaml \
+#     --scenarios-dir plugins/second-brain/skills/capture/evals/scenarios \
+#     --project-root plugins/second-brain

--- a/plugins/second-brain/skills/capture/evals/scenarios/no-route-offer/scenario.yaml
+++ b/plugins/second-brain/skills/capture/evals/scenarios/no-route-offer/scenario.yaml
@@ -1,0 +1,162 @@
+# Known quirk (confirmed across 3 real runs, 2026-08-28): the model's final
+# report sometimes claims Write/Edit to the vault path were "denied," even
+# though this scenario's own results JSON shows those calls matched a mock
+# and returned success. This looks like a skill-evals limitation - Write/Edit
+# against a real absolute path apparently hit a permission layer the
+# closed-world PreToolUse mock doesn't fully override - not a capture-skill
+# bug. It does not affect this scenario's actual assertions: the behavior and
+# tool_calls checks below are scoped to routing language and `sb note move`
+# calls specifically, both of which are absent regardless of whether the
+# capture narrative reports full success or a self-reported block. Filed
+# separately against skill-evals as its own harness bug, tracked outside
+# this repo.
+scenarios:
+  - name: no-route-offer
+    prompt: |
+      Make a note for this article about the Roc pathfinding algorithm:
+      https://example.com/roc-pathfinding
+    # Closed-world: every tool call capture is expected to make, end to end,
+    # so the run reaches Step 4/5 without hitting a rejected-tool error.
+    mocks:
+      # Deliberately returns the ~/.claude/vaults/<name> symlink convention,
+      # not a real vault path - capture's allowed-tools frontmatter scopes
+      # Write/Edit to ~/.claude/vaults/**/*.md. In practice the model still
+      # ends up operating on the real vault path regardless (see the "known
+      # quirk" note at the top of this file), so this doesn't fully steer
+      # it, but it's the theoretically-correct value to return here and
+      # costs nothing to keep.
+      - tool: Bash
+        match:
+          command: "*sb vault info*"
+        response: |
+          {"vault": "test-vault", "path": "/Users/josh.nichols/.claude/vaults/test-vault", "inbox": "10-19 System & Capture/11 Inbox & triage"}
+      - tool: Bash
+        match:
+          command: "*sb config qmd-collection*"
+        response: "pickled-knowledge"
+      # Non-empty but obviously irrelevant, so the model doesn't treat this as
+      # "search came up empty" and go run the basename/both-inboxes fallback
+      # (raw `grep`/`find` over the vault) - those are real Bash commands the
+      # model phrases freely, which a static mock can't reliably intercept.
+      - tool: mcp__qmd__query
+        match:
+          intent: "*"
+        response: '{"results": [{"path": "50-59 Personal/54 Groceries/202601010000 grocery-list.md", "score": 0.12, "snippet": "milk, eggs, bread"}]}'
+      - tool: Read
+        match:
+          file_path: "*note-format.md"
+        response: |
+          # Capture Note Format
+
+          ## Frontmatter
+
+          ```yaml
+          ---
+          status: seedling
+          tags: [example]
+          created: 2026-08-28
+          source: https://example.com/roc-pathfinding
+          ---
+          ```
+
+          ## Filenames
+
+          sb generates these. Don't construct them by hand - use the exact
+          path returned by `sb note create`.
+      - tool: mcp__lightpanda__markdown
+        match:
+          url: "*roc-pathfinding*"
+        response: |
+          # Roc: a fast pathfinding algorithm
+
+          Roc trades a small amount of preprocessing time for large runtime
+          speedups on repeated pathfinding queries over the same map, using a
+          hierarchical decomposition of the search space.
+      - tool: WebFetch
+        match:
+          url: "*roc-pathfinding*"
+        response: |
+          # Roc: a fast pathfinding algorithm
+
+          Roc trades a small amount of preprocessing time for large runtime
+          speedups on repeated pathfinding queries over the same map, using a
+          hierarchical decomposition of the search space.
+      - tool: Bash
+        match:
+          command: "*sb note create*"
+        response: |
+          {"path": "10-19 System & Capture/11 Inbox & triage/202608281204 roc-pathfinding.md"}
+      # Broad match on the inbox directory, not a guessed filename - the
+      # model derives its own timestamp/slug for the note, which a mock
+      # can't predict in advance.
+      - tool: Read
+        match:
+          file_path: "*11 Inbox*.md"
+        response: |
+          ---
+          captured: 2026-08-28T12:15:00Z
+          source: manual
+          repo: none
+          branch: none
+          commit: none
+          ---
+
+          # Roc: a fast pathfinding algorithm
+      - tool: Write
+        match:
+          file_path: "*11 Inbox*.md"
+        response: "wrote note body"
+      - tool: Edit
+        match:
+          file_path: "*11 Inbox*.md"
+        response: "edited note body"
+      - tool: Bash
+        match:
+          command: "*sb daily path*"
+        response: "10-19 System & Capture/12 Daily notes/2026-08-28.md"
+      - tool: Glob
+        match:
+          pattern: "*2026-08-28.md"
+        response: "10-19 System & Capture/12 Daily notes/2026-08-28.md"
+      # Same fixture content on every read: pretends the append already
+      # landed, so both the pre-append existence check and the post-append
+      # placement-verification read see one consistent, already-correct
+      # state. Static mocks can't distinguish call order, and inventing a
+      # second variant risks the model hitting the "sb daily append
+      # --section bug" fallback path (an Edit call), which isn't mocked here
+      # and is out of scope for this scenario.
+      - tool: Read
+        match:
+          file_path: "*2026-08-28.md"
+        response: |
+          # 2026-08-28
+
+          ## Notes
+          - [[202608281204 roc-pathfinding]] - Roc's hierarchical pathfinding decomposition
+      - tool: Bash
+        match:
+          command: "*sb daily append*"
+        response: "appended"
+    budget: "1.00"
+    variants:
+      - name: with_skills
+        skills_enabled: true
+    evaluations:
+      - type: behavior
+        expectations:
+          - "Reports that the note was created and left in the inbox"
+          - "Does not ask the user any question about whether, where, or if they want the note routed, moved, or filed"
+        auto_fail:
+          - "Asks the user a question about routing, moving, or filing the note anywhere (e.g. 'want me to route it?', 'should I move this to X?', 'let me know if you want it filed elsewhere')"
+          - "Mentions, as a reminder or FYI, that the note still needs to be routed or filed, even without phrasing it as a question"
+      - type: tool_calls
+        expected:
+          - tool: Bash
+            match:
+              command: "*sb note create*"
+            label: "creates the note via sb"
+        not_expected:
+          - tool: Bash
+            match:
+              command: "*sb note move*"
+            label: "does not move/route the note (no destination was named in this scenario)"


### PR DESCRIPTION
## Summary
- `second-brain:capture` no longer asks "want me to route it?" after writing a note. That's `process-inbox`'s job, which already auto-routes above a confidence threshold.
- The one exception (an explicit destination named in the same conversation, e.g. "put it in 66") now resolves through `sb vault structure` the way `route` does, instead of writing a hand-rolled path.

## Why
Per-note capture already asks about the daily breadcrumb-adjacent connect offer, and until now, routing too: three round-trips per note. The breadcrumb one was fixed in #111. This closes the routing half: it was a duplicated decision point sitting on top of a batch routing path (`process-inbox`) that already exists and already handles low-confidence cases by asking.

## Test plan
- [ ] Read the diff: Step 4 and the Constraints bullet agree, Step 5 (connect offer, breadcrumb) untouched
- [ ] `description:` frontmatter unchanged, no eval re-run needed
- [ ] CI green (commit-scope check, version-bump check)