### PR TITLE
Add SessionStart nudge for devlog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.12.1"
+      "version": "1.13.0"
     },
     {
       "name": "tool-routing",

--- a/plugins/second-brain/hooks/hooks.json
+++ b/plugins/second-brain/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-devlog-nudge.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/second-brain/hooks/session-start-devlog-nudge.sh
+++ b/plugins/second-brain/hooks/session-start-devlog-nudge.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SessionStart nudge: devlog's description-based triggering measured ~0
+# real invocations after launch (checked via cq over session transcripts).
+# Planting a standing instruction at session start is the same mechanism
+# stay-on-target uses for its "Focused Development Mode" banner - it only
+# fires once, but the instruction it plants governs the whole session.
+
+read -r -d '' CONTEXT <<'EOF'
+## Devlog
+
+This session has the `second-brain:devlog` skill available. Use it the
+moment one of these happens - don't ask, don't offer, just write it in the
+same turn:
+
+- You finish a feature or fix a notable bug
+- You wrap up a work session
+- You discover something non-obvious: a gotcha, undocumented behavior, a
+  workaround that took several tries, a constraint you only noticed after
+  hitting it
+
+Don't use it for routing/connecting/moving notes (`process-inbox`'s job) or
+for writing up an external source (`second-brain:capture`'s job).
+EOF
+
+ESCAPED_CONTEXT=$(printf '%s' "$CONTEXT" | jq -Rs .)
+
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": $ESCAPED_CONTEXT
+  }
+}
+EOF
+
+exit 0

--- a/plugins/second-brain/hooks/tests/session-start-devlog-nudge.bats
+++ b/plugins/second-brain/hooks/tests/session-start-devlog-nudge.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# Tests for the SessionStart hook that nudges devlog usage.
+
+HOOK="$BATS_TEST_DIRNAME/../session-start-devlog-nudge.sh"
+
+@test "emits valid SessionStart hookSpecificOutput JSON" {
+  run bash "$HOOK"
+
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"'
+}
+
+@test "additionalContext mentions the devlog skill and when to use it" {
+  run bash "$HOOK"
+
+  context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+
+  [[ "$context" == *"second-brain:devlog"* ]]
+  [[ "$context" == *"don't ask"* ]]
+}
+
+@test "additionalContext calls out what devlog is NOT for" {
+  run bash "$HOOK"
+
+  context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+
+  [[ "$context" == *"process-inbox"* ]]
+  [[ "$context" == *"second-brain:capture"* ]]
+}


### PR DESCRIPTION
## Summary

- devlog's description-based triggering alone got zero real invocations since it merged (checked via session transcript history)
- Add a SessionStart hook that plants a standing reminder for the whole session, the same mechanism `stay-on-target` uses for its own always-on banner

## Test plan

- `bats plugins/second-brain/hooks/tests/session-start-devlog-nudge.bats`
