### PR TITLE
fix(buildkite): document bktide build create/rebuild as the bk build substitute

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "buildkite",
       "source": "./plugins/buildkite",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "cq",

--- a/plugins/buildkite/skills/investigating-builds/SKILL.md
+++ b/plugins/buildkite/skills/investigating-builds/SKILL.md
@@ -23,6 +23,7 @@ Use this skill when:
 - Waiting for builds to complete
 - Checking build status across multiple repos/PRs
 - Understanding what "broken" or other Buildkite states mean
+- Triggering a fresh build or retriggering an existing one (e.g. an event like undrafting a PR doesn't start a new build — you need to trigger one directly)
 
 ## Tool Hierarchy and Selection
 
@@ -81,7 +82,11 @@ npx bktide@latest pipelines <org>                    # List pipelines
 npx bktide@latest builds <org>/<pipeline>            # List builds
 npx bktide@latest build <org>/<pipeline>#<build>     # Get build details
 npx bktide@latest annotations <org>/<pipeline>#<build>  # Show annotations
+npx bktide@latest build create [<org>/<pipeline>]    # Trigger a new build (auto-detects from git if omitted)
+npx bktide@latest build rebuild <build-ref>          # Re-run an existing build with its original params
 ```
+
+`build create` and `build rebuild` are bktide's one write capability — use `--watch` to poll until the build reaches a terminal state instead of a separate `wait_for_build` call.
 
 ### Tertiary: MCP Tools (Fallback)
 
@@ -110,6 +115,7 @@ Available MCP tools:
 | Save to files     | ✅              | ❌         | ❌        |
 | Wait for build    | ❌              | ❌         | ✅        |
 | Unblock jobs      | ❌              | ❌         | ✅        |
+| **Create/rebuild a build** | ❌    | **✅**     | ❌        |
 
 > This tool preference order can be overridden via `~/.config/pickled-claude-plugins/buildkite.yml`. A PreToolUse hook enforces your preference by intercepting `bk` CLI commands that overlap with bktide capabilities.
 
@@ -593,6 +599,24 @@ Look for:
 **Alternative 3: Analyze the failure in place**
 
 Sometimes reproduction isn't needed - the logs plus artifacts contain enough information to understand and fix the issue without running it locally.
+
+### 8. Triggering or Rebuilding a Build
+
+Some events that feel like they should start a new build don't. GitHub's "ready for review" event, for example, does not trigger a new Buildkite build — only pushes do. If you need a build for the current state without a new commit, don't push an empty commit as a workaround; trigger one directly:
+
+```bash
+# Start a new build (auto-detects org/pipeline/commit/branch from the current git checkout)
+npx bktide@latest build create
+
+# Watch it through to completion
+npx bktide@latest build create --watch
+
+# Re-run an existing build with its original commit/branch/message
+npx bktide@latest build rebuild <org>/<pipeline>/<build-number>
+npx bktide@latest build rebuild <buildkite-build-url>
+```
+
+Flags (`--commit`, `--branch`, `--message`, `--env`) override git auto-detection; run `bktide build create --help` for the full list. This is the one write operation bktide supports — it's the direct replacement for `bk build create`/`bk build retry`, which the buildkite tool-preference hook blocks in favor of this command.
 
 ## Understanding Buildkite States
 

--- a/plugins/buildkite/skills/investigating-builds/references/tool-capabilities.md
+++ b/plugins/buildkite/skills/investigating-builds/references/tool-capabilities.md
@@ -24,6 +24,8 @@ Three tool categories exist with different strengths and limitations:
 | List artifacts        | ❌                  | ❌                  | ✅ `buildkite:list_artifacts`   |                                |
 | Wait for build        | ❌                  | ❌                  | ✅ `buildkite:wait_for_build`   |                                |
 | Unblock jobs          | ❌                  | ❌                  | ✅ `buildkite:unblock_job`      |                                |
+| **Create a build**    | ❌                  | **✅** `build create` | ❌                            | Auto-detects pipeline/commit/branch from git |
+| **Rebuild a build**   | ❌                  | **✅** `build rebuild` | ❌                           | Re-runs with original params   |
 | Human-readable output | ✅                  | ✅                  | ❌ (JSON)                       |                                |
 
 ## Detailed Tool Information
@@ -119,7 +121,11 @@ npx bktide@latest pipelines <org>                    # List pipelines
 npx bktide@latest builds <org>/<pipeline>            # List recent builds
 npx bktide@latest build <org>/<pipeline>#<number>    # Build details
 npx bktide@latest annotations <org>/<pipeline>#<number>    # Show annotations
+npx bktide@latest build create [<org>/<pipeline>]    # Trigger a new build (auto-detects from git if omitted)
+npx bktide@latest build rebuild <build-ref>          # Re-run an existing build with its original params
 ```
+
+Both `build create` and `build rebuild` accept `--watch` to poll the new build until it reaches a terminal state, same as `wait_for_build`.
 
 ### Bundled Scripts (Tertiary)
 
@@ -206,6 +212,7 @@ Features:
 - Listing pipelines or builds
 - Getting quick status overview
 - Interactive terminal work
+- Triggering a new build or retriggering an existing one (`build create` / `build rebuild`) — this is the one write capability bktide has; don't fall back to `bk build create`/`bk build retry` or a throwaway empty-commit push
 
 ### Use MCP Tools When:
 

--- a/plugins/buildkite/src/buildkite_hooks/check.py
+++ b/plugins/buildkite/src/buildkite_hooks/check.py
@@ -47,6 +47,7 @@ def build_message(command, config):
         f"\n"
         f"The command `{command}` was intercepted. Your preferred tool is {preferred}.\n"
         f"Use `npx bktide@latest snapshot <buildkite-url>` for build investigation,\n"
+        f"`npx bktide@latest build create` / `build rebuild` to trigger or retrigger a build,\n"
         f"or `npx bktide@latest --help` for other commands.\n"
         f"\n"
         f"To allow bk commands, set `strict: false` in "


### PR DESCRIPTION
## Summary
- bktide gained `build create` / `build rebuild` (write capability, [bktide#29](https://github.com/technicalpickles/bktide/pull/29)) after this plugin's hook message and skill docs were written, so both still only pointed at `snapshot` for investigation.
- The `^bk build\b` intercept in `check.py` blocks `bk build create`/`bk build retry` with no mention of the real substitute, so sessions hitting the block fell back to pushing an empty commit to trigger a build.
- Updates the hook's block message, `tool-capabilities.md`, and `investigating-builds/SKILL.md` (new workflow 8) to point at `bktide build create`/`build rebuild`.

## Related
- gt-a7t5 / gt-bgog (internal beans tracking this)

## Test plan
- [x] `python3 -m py_compile` / `ast.parse` on `check.py` (syntax only, no behavior change beyond the message string)
- [x] Confirmed `npx bktide@latest build --help` shows `show`/`create`/`rebuild` subcommands
- [x] `scripts/bump-version.sh --auto` applied the patch bump for `buildkite` (1.1.0 → 1.1.1)