### PR TITLE
feat(agent-meta): add configurable destination command for park

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "2.4.0"
+      "version": "2.5.0"
     },
     {
       "name": "buildkite",

--- a/plugins/agent-meta/README.md
+++ b/plugins/agent-meta/README.md
@@ -60,6 +60,19 @@ Location: ~/Vaults/my-vault/handoffs/
 
 Default location: `.parkinglot/` in project root (gitignored).
 
+Optionally, also send the parked file to an external destination (e.g. filing it into a second-brain vault) via env vars:
+
+```bash
+# Literal destination command template
+export AGENT_PARK_DESTINATION='npx @techpickles/sb note create --source auto --title "{title}" --content-file {file}'
+
+# Or: a no-arg command whose stdout produces the template dynamically. Wins over
+# AGENT_PARK_DESTINATION if both are set.
+export AGENT_PARK_DESTINATION_HELPER='~/.claude/bin/pick-park-destination.sh'
+```
+
+Both accept `{file}`, `{title}`, and `{mode}` (`continuation` or `close-out`) placeholders. Neither var set means park behaves exactly as it does without one — this is purely additive, never a replacement for the local file.
+
 ## Installation
 
 Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:

--- a/plugins/agent-meta/hooks/inject-session-context.py
+++ b/plugins/agent-meta/hooks/inject-session-context.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
-PostToolUse:Skill hook that injects the current session ID and transcript
-path into context when an agent-meta skill that needs them is invoked.
+PostToolUse:Skill hook that injects the current session ID, transcript
+path, and (for park) a configured destination command into context when
+an agent-meta skill that needs them is invoked.
 
 Why: the `park` skill needs the Claude Code session ID to write a durable
 record of where this session lived. Previously it ran a Bash script that
@@ -16,8 +17,31 @@ skill's steps.
 
 This hook only injects context for skills that actually need it. Other
 Skill calls are silently ignored (no context pollution).
+
+Destination command: park can optionally hand its output to an external
+command (e.g. filing it into a second-brain vault) instead of only
+writing a local file. This is configured via env vars, resolved here
+rather than hardcoded into the skill, so the plugin stays agnostic about
+where a "destination" actually is:
+
+- AGENT_PARK_DESTINATION_HELPER: a no-arg command, run once by this hook;
+  its trimmed stdout is used as the destination command template. Lets
+  the destination be computed at park-time (e.g. by inspecting the
+  project) rather than being a fixed string. Wins over the literal var
+  below if both are set.
+- AGENT_PARK_DESTINATION: a literal destination command template, used
+  as-is when no helper is set (or the helper produces nothing usable).
+
+Either way the result is a single-line command template containing
+{file}/{title}/{mode} placeholders, injected as a `Park destination:`
+line. The skill body - not this hook - is responsible for substituting
+the placeholders and actually running the command, visibly, via Bash.
+This hook never executes the destination command itself, only (when a
+helper is configured) the helper that produces its template.
 """
 import json
+import os
+import subprocess
 import sys
 
 # Skills in the agent-meta plugin that benefit from knowing the session ID.
@@ -26,6 +50,51 @@ import sys
 TARGET_SKILLS = {
     "agent-meta:park",
 }
+
+# Guardrails against a misbehaving helper: a destination template is a
+# single command line, not a blob. Reject anything that doesn't look like
+# one rather than silently forwarding garbage into context.
+MAX_TEMPLATE_LENGTH = 2000
+
+
+def resolve_destination_template():
+    """Return a validated destination command template, or None."""
+    helper = os.environ.get("AGENT_PARK_DESTINATION_HELPER", "").strip()
+    if helper:
+        try:
+            result = subprocess.run(
+                helper,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except Exception:
+            result = None
+
+        if result is not None and result.returncode == 0:
+            candidate = result.stdout.strip()
+            if _is_valid_template(candidate):
+                return candidate
+        # Helper failed, timed out, or produced something unusable - fall
+        # through to the literal env var rather than erroring out.
+
+    literal = os.environ.get("AGENT_PARK_DESTINATION", "").strip()
+    if _is_valid_template(literal):
+        return literal
+
+    return None
+
+
+def _is_valid_template(candidate):
+    if not candidate:
+        return False
+    if len(candidate) > MAX_TEMPLATE_LENGTH:
+        return False
+    if "\n" in candidate or "\r" in candidate:
+        return False
+    return True
+
 
 try:
     payload = json.load(sys.stdin)
@@ -42,13 +111,19 @@ if skill_name not in TARGET_SKILLS:
 session_id = payload.get("session_id", "")
 transcript_path = payload.get("transcript_path", "")
 
-if not session_id:
+lines = []
+if session_id:
+    lines.append(f"Session ID: {session_id}")
+    if transcript_path:
+        lines.append(f"Transcript: {transcript_path}")
+
+destination_template = resolve_destination_template()
+if destination_template:
+    lines.append(f"Park destination: {destination_template}")
+
+if not lines:
     # Nothing useful to inject; let park fall back to its script.
     sys.exit(0)
-
-lines = [f"Session ID: {session_id}"]
-if transcript_path:
-    lines.append(f"Transcript: {transcript_path}")
 
 output = {
     "hookSpecificOutput": {

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -39,6 +39,7 @@ Pick once and commit. Do not switch modes mid-write.
    1. Project `CLAUDE.md` → `## Handoffs` or `## Parking` → `Location:`
    2. User `~/.claude/CLAUDE.md` → same lookup
    3. Default: `.parkinglot/` in project root (verify it is gitignored)
+4. Check the injected context for a `Park destination:` line. This is separate from the CLAUDE.md location above and always optional — it names a command to also send the file to once it's written, e.g. filing it into a second brain vault. Not present unless the user configured `AGENT_PARK_DESTINATION` or `AGENT_PARK_DESTINATION_HELPER`. Note the template if present; it's used in "After Parking" below.
 
 ## Continuation Template
 
@@ -112,6 +113,16 @@ Filename: `[topic-slug]-wrapped.md`
 
 Close-out has no Resume Prompt and no Next Steps. If you find yourself wanting to write either, the work is probably a continuation: re-check the mode.
 
+## Sending to a Destination
+
+If step 4 above found a `Park destination:` template, run it now, after the file is written:
+
+1. Substitute placeholders in the template: `{file}` → the full path just written, `{title}` → the topic slug/heading, `{mode}` → `continuation` or `close-out`.
+2. Run the substituted command via Bash. This happens as a normal, visible tool call — never assume it succeeded without checking the result.
+3. Report the outcome to the user alongside the local path (see "After Parking" below). If the command fails, say so plainly and still report the local file as parked — the local write is the source of truth; the destination is a best-effort extra.
+
+If no `Park destination:` line was present, skip this section entirely — park behaves exactly as it does without one.
+
 ## After Parking
 
 For continuation:
@@ -130,3 +141,5 @@ Wrapped to `[path]`.
 
 This is a close-out record. To start fresh work that builds on it, reference the file in your next session.
 ```
+
+If a destination command ran, append one line noting the result either way, e.g. `Also sent to [destination]` or `Destination command failed: [short reason]`.


### PR DESCRIPTION
## Summary

- Lets `park` hand its output to an external command (e.g. filing it into a second-brain vault) instead of only writing a local file, configured via `AGENT_PARK_DESTINATION` (literal command template) or `AGENT_PARK_DESTINATION_HELPER` (a command whose stdout produces the template dynamically, wins if both are set)
- Resolution and validation (non-empty, single-line, length-capped, helper exit code checked) happen in the existing `PostToolUse:Skill` hook rather than being hardcoded into the skill, so nothing vault-specific lives in the plugin
- Purely additive: with neither var set, park behaves exactly as before; the local file write is always the source of truth, the destination command is best-effort

## Test plan

- Ran the hook directly against sample `PostToolUse` payloads covering: no destination configured, literal template, helper winning over literal, helper failing and falling back to literal, helper producing invalid multi-line output and falling back, and an unrelated skill being ignored
