### PR TITLE
Improve taskwarrior UUID-safety: hooks + skill consolidation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
     {
       "name": "taskwarrior",
       "source": "./plugins/taskwarrior",
-      "version": "1.1.1"
+      "version": "1.2.0"
     },
     {
       "name": "github-actions",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "2.5.0"
+      "version": "2.5.1"
     },
     {
       "name": "buildkite",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "agent-meta",
       "source": "./plugins/agent-meta",
-      "version": "2.4.0"
+      "version": "2.4.1"
     },
     {
       "name": "buildkite",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
     {
       "name": "taskwarrior",
       "source": "./plugins/taskwarrior",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "github-actions",

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -35,8 +35,7 @@ Pick once and commit. Do not switch modes mid-write.
    - **Preferred:** Look for a `Session ID:` line in the PostToolUse hook context that this plugin injects when `agent-meta:park` is invoked. Use that value. A `Transcript:` line may also be present.
    - **Fallback:** Run [scripts/get-session-id.sh](scripts/get-session-id.sh) via Bash. If empty, use `unknown`.
 2. Gather git branch, worktree path, files touched.
-3. If the handoff cites a taskwarrior task, cite it by UUID and verify the UUID resolves to the intended task first (`task <uuid> info`) — a wrong-but-correctly-formatted UUID has landed in a handoff before. Never cite the bare integer ID; it can be reassigned to a different task by the time the handoff is resumed.
-4. Resolve output location, in order:
+3. Resolve output location, in order:
    1. Project `CLAUDE.md` → `## Handoffs` or `## Parking` → `Location:`
    2. User `~/.claude/CLAUDE.md` → same lookup
    3. Default: `.parkinglot/` in project root (verify it is gitignored)

--- a/plugins/agent-meta/skills/park/SKILL.md
+++ b/plugins/agent-meta/skills/park/SKILL.md
@@ -35,7 +35,8 @@ Pick once and commit. Do not switch modes mid-write.
    - **Preferred:** Look for a `Session ID:` line in the PostToolUse hook context that this plugin injects when `agent-meta:park` is invoked. Use that value. A `Transcript:` line may also be present.
    - **Fallback:** Run [scripts/get-session-id.sh](scripts/get-session-id.sh) via Bash. If empty, use `unknown`.
 2. Gather git branch, worktree path, files touched.
-3. Resolve output location, in order:
+3. If the handoff cites a taskwarrior task, cite it by UUID and verify the UUID resolves to the intended task first (`task <uuid> info`) — a wrong-but-correctly-formatted UUID has landed in a handoff before. Never cite the bare integer ID; it can be reassigned to a different task by the time the handoff is resumed.
+4. Resolve output location, in order:
    1. Project `CLAUDE.md` → `## Handoffs` or `## Parking` → `Location:`
    2. User `~/.claude/CLAUDE.md` → same lookup
    3. Default: `.parkinglot/` in project root (verify it is gitignored)

--- a/plugins/taskwarrior/README.md
+++ b/plugins/taskwarrior/README.md
@@ -12,6 +12,10 @@ Provides a skill that activates when you query or modify tasks. Captures dense r
 - **Full-text search:** `task export | jq -r '.[] | select(.annotations[]?.description | test("..."))'`
 - **Description-length convention:** ≤ 100 chars; long context goes in annotations.
 
+## Hooks
+
+A `PostToolUse:Skill` hook nudges taskwarrior UUID-safety whenever a skill that writes a durable, resumed-later artifact is invoked (currently: agent-meta's `park`). It injects a reminder to verify a cited UUID resolves before it goes into a handoff, and never cite the bare integer ID. See `hooks/nudge-uuid-on-handoff.py`.
+
 ## Companion config
 
 This skill assumes `~/.taskrc` has been configured with a named `dense` report. See the design doc at `docs/superpowers/specs/2026-05-08-taskwarrior-token-density-design.md` for the exact `.taskrc` block.

--- a/plugins/taskwarrior/hooks/hooks.json
+++ b/plugins/taskwarrior/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Nudge taskwarrior UUID-safety when a skill that writes durable, resumed-later artifacts is invoked",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/nudge-uuid-on-handoff.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/taskwarrior/hooks/nudge-uuid-on-handoff.py
+++ b/plugins/taskwarrior/hooks/nudge-uuid-on-handoff.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+PostToolUse:Skill hook that nudges taskwarrior UUID-safety when a skill
+that writes a durable, resumed-later artifact (currently: agent-meta's
+`park`) is invoked.
+
+Why here and not in the other skill: the taskwarrior UUID-drift problem
+belongs to this plugin, not to every skill that might happen to write a
+handoff. Putting the reminder in park's own instructions would couple a
+general-purpose skill to one specific tool it knows nothing else about,
+and the coupling would need to be repeated for every other skill that
+writes a durable artifact. A hook keyed off `tool_input.skill` lets this
+plugin own the reminder and attach it to whichever skills warrant it,
+without editing their instructions.
+
+This hook only fires for skills in TARGET_SKILLS. Other Skill calls are
+silently ignored (no context pollution).
+"""
+import json
+import sys
+
+# Skills that write durable, resumed-later artifacts where a taskwarrior
+# reference might get baked in stale. Add to this set as other such skills
+# come up; each addition should be a one-line change here, not an edit to
+# the target skill's own instructions.
+TARGET_SKILLS = {
+    "agent-meta:park",
+}
+
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    # Malformed stdin - fail silently so we never block a tool call.
+    sys.exit(0)
+
+tool_input = payload.get("tool_input") or {}
+skill_name = tool_input.get("skill", "")
+
+if skill_name not in TARGET_SKILLS:
+    sys.exit(0)
+
+output = {
+    "hookSpecificOutput": {
+        "hookEventName": "PostToolUse",
+        "additionalContext": (
+            "If this handoff cites a taskwarrior task, cite it by UUID and verify "
+            "the UUID resolves to the intended task first (`task <uuid> info`) -- "
+            "a wrong-but-correctly-formatted UUID has landed in a handoff before. "
+            "Never cite the bare integer ID; it can be reassigned to a different "
+            "task by the time the handoff is resumed. See the taskwarrior skill's "
+            "Durable references section."
+        ),
+    }
+}
+print(json.dumps(output))
+sys.exit(0)

--- a/plugins/taskwarrior/skills/taskwarrior/SKILL.md
+++ b/plugins/taskwarrior/skills/taskwarrior/SKILL.md
@@ -94,7 +94,12 @@ The `"i"` flag makes the test case-insensitive. Drop it for case-sensitive match
 
 ## Durable references: UUID, not numeric ID
 
-Numeric IDs are reused once a task completes — `task 197` today may be a completely different task next month. They're fine for same-session interactive use (`task 197 done`, or an `annotate` right after creating the task). They are **not** fine for anything that outlives the current shell: park/handoff files, commit messages, memory files, PR descriptions, beans. A numeric ID written into one of those will silently point at the wrong task later.
+Numeric IDs are reused once a task completes, or whenever the pending list otherwise reorders — `task 197` today may be a completely different task next month, or even a few tool calls from now if other tasks completed or unrelated background work touched taskwarrior in between. They're fine for same-session interactive use (`task 197 done`, or an `annotate` right after creating the task, with nothing in between). They are **not** fine for anything that outlives the current shell: park/handoff files, commit messages, memory files, PR descriptions, beans. A numeric ID written into one of those will silently point at the wrong task later.
+
+**Verify before you cite, and re-resolve before you act.** This has caused real, repeated damage — annotate/done calls landing on unrelated tasks in other projects, needing `task <uuid> denotate -- <text>` cleanup afterward:
+
+- Before writing a UUID into a durable artifact, confirm it actually resolves to the task you mean (`task <uuid> info`, read the description back). A UUID is only as trustworthy as the citation that produced it — hand-typed from memory, copied from an earlier message, or captured before the task was edited elsewhere can all silently point at the wrong task despite being correctly formatted.
+- Before acting on a cached integer ID (`done`, `annotate`, `modify`, `depends`), re-resolve it if it was captured more than a few commands ago in the same session. Don't trust that the number still means what it meant earlier.
 
 Capture the UUID at creation time and cite that instead:
 


### PR DESCRIPTION
## Summary
- Fold the taskwarrior UUID re-resolution guidance into the `taskwarrior` skill instead of duplicating it in an always-loaded dotfiles rule (skills only fully load on invocation, so it's the right place for the detail).
- Nudge taskwarrior UUID-safety whenever a skill that writes a durable, resumed-later artifact (currently: `agent-meta:park`) is invoked, via a `PostToolUse:Skill` hook in the `taskwarrior` plugin keyed off `tool_input.skill` — mirroring the pattern `agent-meta` already uses for its own session-context injection hook. This intentionally does *not* touch `park`'s own instructions: taskwarrior-specific knowledge stays inside the taskwarrior plugin, not leaked into a general-purpose skill it knows nothing else about. (An earlier version of this PR edited `park`'s SKILL.md directly to mention taskwarrior — reverted in favor of the hook once that coupling was spotted.)

Companion hooks (non-blocking, home-role-scoped) landed separately in `technicalpickles/dotfiles`, catching the same ID-drift pattern at write-time (`.parkinglot`/`.beans`/memory files) and act-time (`task <N> done/annotate/...` with a bare decimal ID) — this PR is the plugin-side half of that work.

## Context
Session review via `cq` found repeated real incidents of taskwarrior's integer-ID-reuse trap: cached numeric IDs drifting mid-session and landing annotate/done calls on unrelated tasks, requiring `task <uuid> denotate` cleanup. The existing rule said "use UUIDs" but had no verification step and no re-resolution guidance for mid-session drift.

## Test plan
- [x] Verified the taskwarrior skill's updated "Durable references" section reads correctly end to end
- [x] Pipe-tested `nudge-uuid-on-handoff.py` against a matching skill (`agent-meta:park`, nudges), a non-matching skill (silent), and malformed stdin (silent, exit 0)
- [x] Version bumps applied via `./scripts/bump-version.sh --auto` (taskwarrior 1.1.0→1.2.0, agent-meta 2.4.0→2.4.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)