### PR TITLE
Add tailscale plugin: CLI reference and serve-pattern skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -108,6 +108,12 @@
       "source": "./plugins/gut-check",
       "version": "0.1.0",
       "description": "Ground before you act: catch decisions and factual claims made from a thin basis (memory, the handoff, an unexamined pick)"
+    },
+    {
+      "name": "tailscale",
+      "source": "./plugins/tailscale",
+      "version": "0.1.0",
+      "description": "Tailscale CLI reference and safe patterns for exposing local services over a tailnet"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ See individual plugin READMEs for details on what each plugin provides.
 | [sandbox-advisor](plugins/sandbox-advisor) | Turns Claude Code sandbox EPERMs into crisp re-run-unsandboxed guidance | – |
 | [second-brain](plugins/second-brain) | Knowledge management for Obsidian vaults and structured markdown repositories | capture, connect, devlog, distill-rules, enrich, ingest, link-daily, obsidian, process-inbox, route |
 | [stay-on-target](plugins/stay-on-target) | Focused development mode - clarify, plan, verify, detect drift | – |
+| [tailscale](plugins/tailscale) | Tailscale CLI reference and safe patterns for exposing local services over a tailnet | tailscale-cli, tailscale-serve-patterns |
 | [taskwarrior](plugins/taskwarrior) | Token-dense recipes for taskwarrior CLI: dense listings, single-field lookups, batched exports, full-text search | taskwarrior |
 | [tool-routing](plugins/tool-routing) | Route tool calls to better alternatives (e.g., gh CLI instead of WebFetch for GitHub PRs) | – |
 | [working-in-monorepos](plugins/working-in-monorepos) | Navigate and execute commands in monorepo subprojects | working-in-monorepos |

--- a/plugins/tailscale/.claude-plugin/plugin.json
+++ b/plugins/tailscale/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "tailscale",
+  "description": "Tailscale CLI reference and safe patterns for exposing local services over a tailnet",
+  "author": {
+    "name": "Josh Nichols",
+    "email": "josh@technicalpickles.com"
+  },
+  "repository": "https://github.com/technicalpickles/pickled-claude-plugins",
+  "license": "MIT"
+}

--- a/plugins/tailscale/README.md
+++ b/plugins/tailscale/README.md
@@ -1,0 +1,35 @@
+# tailscale Plugin
+
+Tailscale CLI reference and safe patterns for exposing local services over a tailnet.
+
+## Skills
+
+### tailscale-cli
+
+Use when running `tailscale` commands to debug connectivity, inspect status, or manage `tailscale serve`/`funnel`/Services.
+
+**Covers:**
+- Where the `tailscale` binary lives (macOS GUI app vs. Homebrew vs. Linux) and why `which tailscale` can come up empty even when Tailscale is running
+- `sudo`/operator gotchas — most `tailscale` commands don't need root
+- Node-level `serve` vs. named Services (`svc:`) — separate config, separate status output
+- The reliable order for standing up a brand-new Service (admin console → serve → `tailscaled` restart → approve → validate)
+- Why `tailscale ping` fails against Service virtual IPs, and why self-curling a Service from its own serving host can hang
+
+### tailscale-serve-patterns
+
+Use when deciding how to expose a locally-running server over a tailnet, working with Tailscale identity headers for browser auth, or when a "bind is loopback" check doesn't reflect real exposure.
+
+**Covers:**
+- Loopback bind + `tailscale serve` proxy (safe default) vs. binding directly to the tailnet interface (unauthenticated, exposure-widening)
+- The IPv4 (`127.0.0.1`) vs. IPv6 (`[::1]`) loopback trap
+- Empirically-verified behavior of Tailscale identity headers on Services (undocumented by Tailscale itself): Serve overwrites spoofed headers rather than stripping them, but a request straight to the loopback port arrives unverified — making loopback-only binding a security invariant, not just hygiene
+- Why tagged devices and Funnel traffic never carry identity headers, and why that fallback isn't optional
+- Why an automated "bind is loopback" check can pass while a Docker `-p` publish or reverse proxy still exposes the port
+
+## Installation
+
+Requires the [pickled-claude-plugins marketplace](../../README.md#installation). Then:
+
+```
+/plugin install tailscale@pickled-claude-plugins
+```

--- a/plugins/tailscale/skills/tailscale-cli/SKILL.md
+++ b/plugins/tailscale/skills/tailscale-cli/SKILL.md
@@ -27,46 +27,17 @@ For binding/exposure architecture (loopback vs. tailnet-interface binding, ident
 
 Symptom of getting this wrong: `sudo tailscale status --json` hangs asking for a password ("a terminal is required to read the password") on a host where plain `tailscale status` works fine and `sudo tailscale serve status` also works fine (because sudo is scoped to `serve *`, not `status`). Fix: drop the unneeded `sudo`, or check what the sudoers rule actually covers (`sudo -n -l`) before assuming Tailscale itself is broken.
 
-## Services (`svc:`) vs. node-level `serve`
+## Services vs. node-level serve
 
-Two different Tailscale features look similar but have separate config and separate status output:
+Two different features that look similar but have separate config and status output — a Service's config is invisible to bare `tailscale serve status` (it prints `No serve config` even when fully configured), and a serve command against an undefined Service reports success but does nothing. Full explanation and the fix (`serve status --json`, `.Services`): [references/services.md](references/services.md).
 
-- **Node-level serve**: `tailscale serve --https=443 http://127.0.0.1:8080` — attaches to *this node's* own identity (`<hostname>.<tailnet>.ts.net`).
-- **Services**: `tailscale serve --service=svc:myapp --https=443 http://127.0.0.1:8080` — proxies for a named **Service** with its own virtual IP/hostname (`myapp.<tailnet>.ts.net`), independent of which node is currently serving it (enables failover/migration later).
+## Setting up a brand-new Service
 
-**The gotcha that eats debugging time:** `tailscale serve status` **with no flags only shows node-level routes.** A Service's config is invisible to it — it prints `No serve config` even when the Service is fully configured and traffic is flowing. This looks exactly like "the serve command silently failed" and will send you down a rabbit hole of restarting `tailscaled`, running `tailscale down`/`up`, and re-issuing the serve command, all for nothing.
+Has a specific required order (define in admin console → `serve --service=` → restart `tailscaled` → approve → validate from a different node) that's easy to get wrong on a first deploy: [references/new-service-setup.md](references/new-service-setup.md).
 
-**Fix:** always check `tailscale serve status --json` and look under `.Services["svc:<name>"]`. That's the real source of truth for Service-based proxies.
+## `ping` and self-curl gotchas
 
-```bash
-tailscale serve status --json | jq '.Services'
-```
-
-**Prerequisite gotcha:** `tailscale serve --service=svc:X ...` does **not** create the Service. A Service must already be defined in the tailnet admin console (Services page, name + port) before the CLI has anything to attach a pending-host-approval to. Running the serve command against an undefined Service reports success ("Serve started and running in the background") but nothing ever shows up as pending, and the hostname never resolves to anything real. Define the Service first, then run `serve --service=`.
-
-## Setting up a brand-new Service (the reliable order)
-
-Getting the order wrong is the single most common source of "why won't this approve" on a first deploy. Follow it in this order, not the order a deploy script's automated steps happen to run in:
-
-1. **Define the Service in the admin console first**, before running anything else: `https://login.tailscale.com/admin/services` → "Define Service" → name + port. A `tailscale serve --service=` call against an undefined Service can report success with nothing to actually show for it.
-2. **Run `tailscale serve --service=svc:X --https=443 <target>`** on the host that will proxy it.
-3. **Restart `tailscaled` on that host**: `sudo systemctl restart tailscaled` (Linux). Confirmed required, not optional — until the daemon restarts, the pending-proxy registration from step 2 does not get pushed up to Tailscale's Services backend, and nothing shows up as approvable in step 4. Just re-toggling `serve ... off` / `serve ... on` is **not** a substitute for this restart.
-4. **Approve the pending host** in the admin console (Services page, next to the Service you defined in step 1).
-5. **Validate** from a different node: `curl -fsS https://<name>.<tailnet>.ts.net/<health-path>` (never from the serving host itself — see below).
-
-This restart is a deliberate, expected part of standing up a new Service — it's a different situation from the "don't restart tailscaled reflexively" troubleshooting advice further below, which is about an *already-working* Service whose `serve status` output merely looks wrong.
-
-## `tailscale ping` doesn't work on Service virtual IPs
-
-`tailscale ping <service-hostname-or-vip>` returns `no matching peer` even when the Service is healthy — a Service's virtual IP isn't a real WireGuard peer, so ping has nothing to reach. This is expected, not a failure signal. To test a Service, `curl` the HTTPS hostname instead:
-
-```bash
-curl -fsS --max-time 8 https://myapp.<tailnet>.ts.net/healthz -o /dev/null -w 'HTTP %{http_code}\n'
-```
-
-## Self-curl from the serving host can hang
-
-Curling a Service's own hostname *from the same host that's proxying it* can time out or hang (hairpin/self-connect issue) even when the Service works fine for every other node. Don't conclude a Service is broken from a failed self-test on the host — verify from a different tailnet node (e.g. your Mac, or another peer) before troubleshooting further.
+`tailscale ping` doesn't work against Service virtual IPs (`no matching peer` is expected, not a failure), and curling a Service's own hostname from the host that's proxying it can hang even when the Service is healthy for everyone else: [references/ping-and-curl-gotchas.md](references/ping-and-curl-gotchas.md).
 
 ## Quick troubleshooting checklist: "serve status looks wrong"
 
@@ -77,7 +48,7 @@ Curling a Service's own hostname *from the same host that's proxying it* can tim
 5. Are you testing from the same host that's serving the proxy? Test from a different node.
 6. Only after 1-5 are ruled out: check `tailscaled` itself (`systemctl status tailscaled`, `tailscale status`, node's `BackendState`).
 
-**Restarting `tailscaled` on a shared host is a real action, not a diagnostic one** — it affects connectivity for every service that host proxies. Don't do it reflexively while chasing a status-display confusion on an *already-working* Service; confirm with whoever owns the host first, and reach for it only after ruling out the display gotchas above. (This is different from standing up a brand-new Service, where the restart is an expected, required step — see above.)
+**Restarting `tailscaled` on a shared host is a real action, not a diagnostic one** — it affects connectivity for every service that host proxies. Don't do it reflexively while chasing a status-display confusion on an *already-working* Service; confirm with whoever owns the host first, and reach for it only after ruling out the gotchas above. (Standing up a *new* Service is different — there the restart is an expected, required step: [references/new-service-setup.md](references/new-service-setup.md).)
 
 ## Useful commands
 
@@ -85,7 +56,7 @@ Curling a Service's own hostname *from the same host that's proxying it* can tim
 |---|---|
 | `tailscale status` | Peer list + this node's connection state (no sudo needed normally) |
 | `tailscale status --json` | Same, machine-readable — `.Self`, `.Peer[]`, `.CurrentTailnet`, `.Health` |
-| `tailscale serve status --json` | Real Services + node-serve config — see Services section above |
+| `tailscale serve status --json` | Real Services + node-serve config — see [references/services.md](references/services.md) |
 | `tailscale ping <peer>` | WireGuard-level reachability to a real node (not Services) |
 | `tailscale version` | Compare versions across nodes when behavior differs between hosts |
 | `tailscale serve --service=svc:X ... off` | Disable a Service's proxy config (keeps the Service definition) |

--- a/plugins/tailscale/skills/tailscale-cli/SKILL.md
+++ b/plugins/tailscale/skills/tailscale-cli/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: tailscale-cli
+description: Use when running `tailscale` commands to debug connectivity, inspect status, or manage `tailscale serve`/`funnel`/Services — especially when `tailscale serve status` looks wrong, `tailscale` isn't found in a shell, `tailscale ping` fails against a host that's clearly up, or you're working across a mix of macOS (GUI app) and Linux (VM/container) nodes in the same tailnet.
+---
+
+# Tailscale CLI
+
+## Overview
+
+The `tailscale` CLI behaves differently depending on install shape (macOS GUI app vs. Linux package) and config model (plain node-level `serve` vs. `--service=svc:X` Services). Most "tailscale is broken" moments are actually one of these known gotchas, not a real outage.
+
+For binding/exposure architecture (loopback vs. tailnet-interface binding, identity headers, auth implications) rather than CLI mechanics, see the `tailscale-serve-patterns` skill instead.
+
+## Where the binary lives
+
+| Environment | Binary | Notes |
+|---|---|---|
+| macOS, Tailscale.app (GUI) | `/Applications/Tailscale.app/Contents/MacOS/Tailscale` | **Not on `$PATH`** — the App Store/direct-download GUI app does not symlink a `tailscale` command by default. `which tailscale` returning nothing does not mean Tailscale isn't running; check the menu-bar icon or `/Applications/Tailscale.app/Contents/MacOS/Tailscale status` directly. Alias it if you use it often: `alias tailscale=/Applications/Tailscale.app/Contents/MacOS/Tailscale`. |
+| macOS, Homebrew (`brew install tailscale`) | `tailscale` on `$PATH` | Different install path than the GUI app; if both are present they can diverge in version. |
+| Linux (systemd package, VM/container) | `tailscale` on `$PATH`, daemon is `tailscaled` | Standard install. Talks to `tailscaled` over a local socket. |
+
+**Diagnostic tell:** if a `... | jq ...` pipeline throws `jq: parse error: Invalid numeric literal at line 1, column N`, don't debug jq — the upstream command almost certainly failed (e.g. `command not found: tailscale`) and its error text got merged into stdout via `2>&1`, and jq is choking on that text, not real JSON. Re-run the upstream command alone first.
+
+## Root/sudo: don't reach for it by default
+
+`tailscale status` and `tailscale ping` are normally readable by any local user — no `sudo` needed. Mutating commands (`serve`, `funnel`, `up`/`down` in some configs) may need root, *or* may work passwordless if the local user is set as the tailscale operator (`tailscale set --operator=<user>`) or granted a scoped `NOPASSWD` sudo rule for `tailscale serve *`.
+
+Symptom of getting this wrong: `sudo tailscale status --json` hangs asking for a password ("a terminal is required to read the password") on a host where plain `tailscale status` works fine and `sudo tailscale serve status` also works fine (because sudo is scoped to `serve *`, not `status`). Fix: drop the unneeded `sudo`, or check what the sudoers rule actually covers (`sudo -n -l`) before assuming Tailscale itself is broken.
+
+## Services (`svc:`) vs. node-level `serve`
+
+Two different Tailscale features look similar but have separate config and separate status output:
+
+- **Node-level serve**: `tailscale serve --https=443 http://127.0.0.1:8080` — attaches to *this node's* own identity (`<hostname>.<tailnet>.ts.net`).
+- **Services**: `tailscale serve --service=svc:myapp --https=443 http://127.0.0.1:8080` — proxies for a named **Service** with its own virtual IP/hostname (`myapp.<tailnet>.ts.net`), independent of which node is currently serving it (enables failover/migration later).
+
+**The gotcha that eats debugging time:** `tailscale serve status` **with no flags only shows node-level routes.** A Service's config is invisible to it — it prints `No serve config` even when the Service is fully configured and traffic is flowing. This looks exactly like "the serve command silently failed" and will send you down a rabbit hole of restarting `tailscaled`, running `tailscale down`/`up`, and re-issuing the serve command, all for nothing.
+
+**Fix:** always check `tailscale serve status --json` and look under `.Services["svc:<name>"]`. That's the real source of truth for Service-based proxies.
+
+```bash
+tailscale serve status --json | jq '.Services'
+```
+
+**Prerequisite gotcha:** `tailscale serve --service=svc:X ...` does **not** create the Service. A Service must already be defined in the tailnet admin console (Services page, name + port) before the CLI has anything to attach a pending-host-approval to. Running the serve command against an undefined Service reports success ("Serve started and running in the background") but nothing ever shows up as pending, and the hostname never resolves to anything real. Define the Service first, then run `serve --service=`.
+
+## Setting up a brand-new Service (the reliable order)
+
+Getting the order wrong is the single most common source of "why won't this approve" on a first deploy. Follow it in this order, not the order a deploy script's automated steps happen to run in:
+
+1. **Define the Service in the admin console first**, before running anything else: `https://login.tailscale.com/admin/services` → "Define Service" → name + port. A `tailscale serve --service=` call against an undefined Service can report success with nothing to actually show for it.
+2. **Run `tailscale serve --service=svc:X --https=443 <target>`** on the host that will proxy it.
+3. **Restart `tailscaled` on that host**: `sudo systemctl restart tailscaled` (Linux). Confirmed required, not optional — until the daemon restarts, the pending-proxy registration from step 2 does not get pushed up to Tailscale's Services backend, and nothing shows up as approvable in step 4. Just re-toggling `serve ... off` / `serve ... on` is **not** a substitute for this restart.
+4. **Approve the pending host** in the admin console (Services page, next to the Service you defined in step 1).
+5. **Validate** from a different node: `curl -fsS https://<name>.<tailnet>.ts.net/<health-path>` (never from the serving host itself — see below).
+
+This restart is a deliberate, expected part of standing up a new Service — it's a different situation from the "don't restart tailscaled reflexively" troubleshooting advice further below, which is about an *already-working* Service whose `serve status` output merely looks wrong.
+
+## `tailscale ping` doesn't work on Service virtual IPs
+
+`tailscale ping <service-hostname-or-vip>` returns `no matching peer` even when the Service is healthy — a Service's virtual IP isn't a real WireGuard peer, so ping has nothing to reach. This is expected, not a failure signal. To test a Service, `curl` the HTTPS hostname instead:
+
+```bash
+curl -fsS --max-time 8 https://myapp.<tailnet>.ts.net/healthz -o /dev/null -w 'HTTP %{http_code}\n'
+```
+
+## Self-curl from the serving host can hang
+
+Curling a Service's own hostname *from the same host that's proxying it* can time out or hang (hairpin/self-connect issue) even when the Service works fine for every other node. Don't conclude a Service is broken from a failed self-test on the host — verify from a different tailnet node (e.g. your Mac, or another peer) before troubleshooting further.
+
+## Quick troubleshooting checklist: "serve status looks wrong"
+
+1. Are you checking `serve status` bare, or `--json`? Bare misses Services — always add `--json` for Services.
+2. Did you `sudo` a command that doesn't need it (or that isn't covered by a scoped sudoers rule)? Try without `sudo` first.
+3. Is the target a Service (`svc:`) and does it actually exist in the admin console yet? A serve command against an undefined Service "succeeds" but does nothing.
+4. Are you testing with `ping` against a Service VIP? Use `curl` against the hostname instead.
+5. Are you testing from the same host that's serving the proxy? Test from a different node.
+6. Only after 1-5 are ruled out: check `tailscaled` itself (`systemctl status tailscaled`, `tailscale status`, node's `BackendState`).
+
+**Restarting `tailscaled` on a shared host is a real action, not a diagnostic one** — it affects connectivity for every service that host proxies. Don't do it reflexively while chasing a status-display confusion on an *already-working* Service; confirm with whoever owns the host first, and reach for it only after ruling out the display gotchas above. (This is different from standing up a brand-new Service, where the restart is an expected, required step — see above.)
+
+## Useful commands
+
+| Command | Purpose |
+|---|---|
+| `tailscale status` | Peer list + this node's connection state (no sudo needed normally) |
+| `tailscale status --json` | Same, machine-readable — `.Self`, `.Peer[]`, `.CurrentTailnet`, `.Health` |
+| `tailscale serve status --json` | Real Services + node-serve config — see Services section above |
+| `tailscale ping <peer>` | WireGuard-level reachability to a real node (not Services) |
+| `tailscale version` | Compare versions across nodes when behavior differs between hosts |
+| `tailscale serve --service=svc:X ... off` | Disable a Service's proxy config (keeps the Service definition) |
+| `tailscale serve clear svc:X` | Remove all serve config for a Service |

--- a/plugins/tailscale/skills/tailscale-cli/references/new-service-setup.md
+++ b/plugins/tailscale/skills/tailscale-cli/references/new-service-setup.md
@@ -1,0 +1,13 @@
+# Setting up a brand-new Service (the reliable order)
+
+Getting the order wrong is the single most common source of "why won't this approve" on a first deploy. Follow it in this order, not the order a deploy script's automated steps happen to run in:
+
+1. **Define the Service in the admin console first**, before running anything else: `https://login.tailscale.com/admin/services` → "Define Service" → name + port. A `tailscale serve --service=` call against an undefined Service can report success with nothing to actually show for it.
+2. **Run `tailscale serve --service=svc:X --https=443 <target>`** on the host that will proxy it.
+3. **Restart `tailscaled` on that host**: `sudo systemctl restart tailscaled` (Linux). Confirmed required, not optional — until the daemon restarts, the pending-proxy registration from step 2 does not get pushed up to Tailscale's Services backend, and nothing shows up as approvable in step 4. Just re-toggling `serve ... off` / `serve ... on` is **not** a substitute for this restart.
+4. **Approve the pending host** in the admin console (Services page, next to the Service you defined in step 1).
+5. **Validate** from a different node: `curl -fsS https://<name>.<tailnet>.ts.net/<health-path>` (never from the serving host itself — self-curl from the serving host can hang, see the troubleshooting checklist in SKILL.md).
+
+This restart is a deliberate, expected part of standing up a new Service — it's a different situation from the "don't restart tailscaled reflexively" troubleshooting advice in SKILL.md, which is about an *already-working* Service whose `serve status` output merely looks wrong.
+
+**Restarting `tailscaled` on a shared host is a real action, not a diagnostic one** — it affects connectivity for every service that host proxies. Don't do it reflexively while chasing a status-display confusion on an *already-working* Service; confirm with whoever owns the host first, and reach for it only after ruling out the display gotchas in SKILL.md. (This is different from standing up a brand-new Service, where the restart is an expected, required step — see above.)

--- a/plugins/tailscale/skills/tailscale-cli/references/ping-and-curl-gotchas.md
+++ b/plugins/tailscale/skills/tailscale-cli/references/ping-and-curl-gotchas.md
@@ -1,0 +1,13 @@
+# `tailscale ping` and self-curl gotchas
+
+## `tailscale ping` doesn't work on Service virtual IPs
+
+`tailscale ping <service-hostname-or-vip>` returns `no matching peer` even when the Service is healthy — a Service's virtual IP isn't a real WireGuard peer, so ping has nothing to reach. This is expected, not a failure signal. To test a Service, `curl` the HTTPS hostname instead:
+
+```bash
+curl -fsS --max-time 8 https://myapp.<tailnet>.ts.net/healthz -o /dev/null -w 'HTTP %{http_code}\n'
+```
+
+## Self-curl from the serving host can hang
+
+Curling a Service's own hostname *from the same host that's proxying it* can time out or hang (hairpin/self-connect issue) even when the Service works fine for every other node. Don't conclude a Service is broken from a failed self-test on the host — verify from a different tailnet node (e.g. your Mac, or another peer) before troubleshooting further.

--- a/plugins/tailscale/skills/tailscale-cli/references/services.md
+++ b/plugins/tailscale/skills/tailscale-cli/references/services.md
@@ -1,0 +1,20 @@
+# Services (`svc:`) vs. node-level `serve`
+
+Two different Tailscale features look similar but have separate config and separate status output:
+
+- **Node-level serve**: `tailscale serve --https=443 http://127.0.0.1:8080` — attaches to *this node's* own identity (`<hostname>.<tailnet>.ts.net`).
+- **Services**: `tailscale serve --service=svc:myapp --https=443 http://127.0.0.1:8080` — proxies for a named **Service** with its own virtual IP/hostname (`myapp.<tailnet>.ts.net`), independent of which node is currently serving it (enables failover/migration later).
+
+## The gotcha that eats debugging time
+
+`tailscale serve status` **with no flags only shows node-level routes.** A Service's config is invisible to it — it prints `No serve config` even when the Service is fully configured and traffic is flowing. This looks exactly like "the serve command silently failed" and will send you down a rabbit hole of restarting `tailscaled`, running `tailscale down`/`up`, and re-issuing the serve command, all for nothing.
+
+**Fix:** always check `tailscale serve status --json` and look under `.Services["svc:<name>"]`. That's the real source of truth for Service-based proxies.
+
+```bash
+tailscale serve status --json | jq '.Services'
+```
+
+## Prerequisite gotcha
+
+`tailscale serve --service=svc:X ...` does **not** create the Service. A Service must already be defined in the tailnet admin console (Services page, name + port) before the CLI has anything to attach a pending-host-approval to. Running the serve command against an undefined Service reports success ("Serve started and running in the background") but nothing ever shows up as pending, and the hostname never resolves to anything real. Define the Service first, then run `serve --service=`.

--- a/plugins/tailscale/skills/tailscale-serve-patterns/SKILL.md
+++ b/plugins/tailscale/skills/tailscale-serve-patterns/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: tailscale-serve-patterns
+description: Use when deciding how to expose a locally-running server over a tailnet (loopback bind + `tailscale serve` vs. binding directly to the tailnet interface), when a service is reachable at its Tailscale address but a request seems to bypass expected auth, when working with Tailscale identity headers (`Tailscale-User-Login` and friends) for browser auth, or when a "bind is loopback-only" security check doesn't seem to reflect what's actually reachable (Docker port publish, reverse proxy, container networking).
+---
+
+# Tailscale Serve Patterns
+
+## Overview
+
+Two ways to make a local service reachable over a tailnet, with very different security properties: bind loopback-only and let `tailscale serve` proxy HTTPS in front of it, or bind the process directly to the tailnet interface address. For CLI mechanics (commands, Services vs. node-serve, troubleshooting `serve status`), see the `tailscale-cli` skill instead — this skill is about which exposure shape to choose and what it implies for auth.
+
+## The two binding patterns
+
+| | Loopback bind + `tailscale serve` | Direct bind to tailnet interface |
+|---|---|---|
+| What's exposed | `127.0.0.1:<port>` only; `serve` proxies HTTPS at `<host>.<tailnet>.ts.net` | Plain HTTP directly at the tailnet IP (e.g. `100.x.y.z:<port>`) |
+| Auth | Tailscale itself is the gate — only tailnet members can reach the hostname at all; TLS terminated by `tailscaled` | None unless the app adds its own — anyone on the tailnet who knows the IP:port can hit it over unencrypted HTTP |
+| Setup cost | One extra `tailscale serve` mapping to create/tear down | Zero extra config — just bind a different address |
+| Failure mode if misconfigured | Hitting `<tailnet-hostname>:<port>` directly (skipping the proxy) fails, because the app only bound loopback — this is *expected*, not a bug | A stray bind flag or default (`0.0.0.0` instead of `127.0.0.1`) silently widens exposure to the whole tailnet with no signal |
+
+**Default to loopback + `serve`.** It's the pattern used across this project's homelab services (bind `127.0.0.1:<port>`, expose via host `tailscaled` + Services) and what the `crit` review tool's own auto-mode classifier treats as the expected, low-friction path. Direct tailnet-interface binding is the exception, appropriate for short-lived single-user sessions (e.g. "review this on my phone for the next ten minutes, I'm the only one on this tailnet") — treat it as something that needs an explicit, conscious opt-in (a flag like `--allow-unauthenticated-network`), not a default.
+
+`serve` does not change what the process itself binds to — it's a separate proxy layer. If a server only binds `127.0.0.1`, requests straight to the tailnet hostname's port will fail; you must go through the URL/port `serve` publishes (usually 443), not the app's own port.
+
+## The IPv4/IPv6 loopback trap
+
+`127.0.0.1` and `[::1]` are both "loopback" but not interchangeable. A listener bound to `[::1]` only (IPv6 loopback) is unreachable from `127.0.0.1` (IPv4) — and unreachable from Tailscale either way, since Tailscale doesn't change this. If a browser's `localhost` resolves to IPv4 first and the server only listens on `[::1]`, you'll see a connection failure that looks tailnet-related but has nothing to do with Tailscale at all. Check `lsof -i` for the actual bound address before assuming a tailnet/proxy problem.
+
+## Identity headers: what's actually verified, not assumed
+
+Tailscale Serve/Services can stamp identity headers (`Tailscale-User-Login`, `Tailscale-User-Name`, `Tailscale-User-Profile-Pic`) onto proxied requests, which is tempting to use as a browser auth signal instead of a shared secret. **Tailscale's own docs describe this for node-level `serve` but say nothing about `--service=svc:` Services** — if your deployment uses Services (see `tailscale-cli`), don't assume the docs cover your case. Verify empirically instead of trusting the docs or your assumptions:
+
+- **Services do stamp the headers** (confirmed by temporarily adding a test path handler to a live service and reading what arrived).
+- **A spoofed header sent *through* Serve is overwritten, not merely stripped** — Serve replaces `Tailscale-User-Login` with the real caller's identity even if the client tried to set its own value.
+- **The same spoofed header sent straight to the loopback port arrives verbatim.** This is the load-bearing fact: identity-header trust is only safe if the loopback bind is the *only* path to the backend. Anything that can reach the port directly (a misconfigured `0.0.0.0` bind, a container publishing the port beyond loopback) can forge any identity. The loopback-only bind stops being just network hygiene and becomes a security invariant the moment you trust these headers.
+- **Tagged devices (servers, CI runners, agents) get zero identity headers**, even through Services. A machine-to-machine caller has no identity path, ever — it needs its own credential (API key), and that requirement doesn't go away just because identity headers exist for humans.
+- **Funnel traffic carries no identity headers either.** If a route can also be reached via Funnel, header-based auth silently degrades to no-auth-signal on that path — the request needs a fallback (e.g. an API key check) rather than assuming the header will be present.
+
+If you're building header-based auth: default the trust flag off, fail closed (empty allow-list = reject, don't accept-any-identity), and fail fast at startup if the flag is on with no allow-list configured — a silently-useless config (flag on, empty allow-list) just re-prompts users with no explanation of why.
+
+## Automated "is this bound to loopback" checks can lie
+
+A security/doctor check that inspects `gateway.bind` (or equivalent app-level config) and calls it safe because it says `127.0.0.1` has no visibility into what's *actually* reachable: Docker's `-p` publish flag can expose a container's "loopback" port to the whole host or network regardless of what the app thinks it bound to, and a reverse proxy or `tailscale serve` mapping sits entirely outside the app's own config. A green check here means "the app's own bind setting is loopback," not "this is only reachable from this machine." Verify actual reachability from a different tailnet node (`curl` the tailnet hostname, or attempt the raw port) rather than trusting a config-level check alone.
+
+## Common mistakes
+
+| Mistake | Why it's wrong |
+|---|---|
+| Trusting `Tailscale-User-*` headers without confirming Services (not just node-serve) actually stamp them for your setup | Undocumented by Tailscale for Services; verify empirically first |
+| Building identity-header auth without a fallback for tagged devices or Funnel traffic | Both produce zero identity headers by design — the fallback path isn't optional |
+| Assuming a `0.0.0.0`/tailnet-interface bind flag is fine because "only I'm on this tailnet" | True today, but it's an unauthenticated-by-default state with no expiry — treat it as an explicit, temporary opt-in, not a config to leave on |
+| Debugging a `[::1]`-vs-`127.0.0.1` connection failure as a Tailscale problem | Check the actual bound address first; it may have nothing to do with the tailnet at all |
+| Trusting a passing "bind is loopback" doctor/security check as proof of true exposure | It only sees the app's own config, not Docker publish or reverse-proxy layers in front of it |


### PR DESCRIPTION
## Summary

- Adds a `tailscale` plugin with two skills: `tailscale-cli` (command mechanics — binary location, sudo/operator gotchas, Services vs. node-serve, `serve status` troubleshooting) and `tailscale-serve-patterns` (exposure architecture — loopback bind + `serve` vs. direct tailnet-interface bind, identity-header trust model, IPv4/IPv6 loopback trap)
- `tailscale-cli` generalizes a skill that already existed in `picklehome`; `tailscale-serve-patterns` is new, synthesized from an empirically-verified spike in brineworks' identity-auth ADR plus recurring crit remote-review sessions
- Registered in the marketplace at `0.1.0`, README plugin table regenerated

## Test plan

- Ran a retrieval check with a fresh agent against 6 realistic trigger scenarios (serve status looks wrong, direct-bind question, identity-header auth safety, binary not found, etc.) using only the two `description:` fields — all 6 routed to the correct skill with no overlap
