### PR TITLE
Add claude.ai Skills under per-plugin directories

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
     {
       "name": "second-brain",
       "source": "./plugins/second-brain",
-      "version": "1.13.1"
+      "version": "1.14.0"
     },
     {
       "name": "tool-routing",

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 # Temporary/generated test artifacts
 tmp/
 __pycache__
+
+# claude.ai Skill build output (see docs/claude-ai-skill-porting.md)
+plugins/*/claude-ai-skills/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,20 @@ plugins/{name}/
 - **Skill names are globally unique across all installed plugins** (Claude Code surfaces skills by their bare `name:` slug, not `plugin:name`). Two plugins shipping a skill called `doctor` collide. Prefix the directory and `name:` field with the plugin name: `plugins/actually-lsp/skills/actually-lsp-doctor/SKILL.md` with `name: actually-lsp-doctor`, not `skills/doctor/SKILL.md` with `name: doctor`. Some existing plugins (agent-meta, sandbox-first) ship generic-named skills and got away with it only because the names happened to be unique; don't rely on that for new plugins.
 - **Don't ship a `commands/{name}.md` with the same name as a `skills/{name}/SKILL.md`.** Beyond commands simply not being surfaced (see above), a same-name collision specifically suppresses the SKILL.md content injection that normally follows a Skill tool invocation, forcing the model to grep/read the file manually or hallucinate its contents. If a skill already exists at `skills/{name}/`, either give any slash-command wrapper a different name or drop it entirely: direct Skill invocation via keyword match or `/plugin:skill-name` is sufficient. Slash-command wrappers pointing at skills are a legacy pattern from before skills were directly slash-callable.
 
+## claude.ai Skills
+
+Some Claude Code skills are also worth porting to **claude.ai Skills** (the chat
+product's own skill format — Settings → Capabilities → Skills, no filesystem/CLI/MCP
+access, uploaded as a zip by hand). These ports live at
+`plugins/{name}/claude-ai-skills/{skill}/`, colocated with the Claude Code plugin they
+mirror, but they are **not** plugin skills — no `plugin.json` entry, no marketplace
+entry, not part of the generated README table, and none of the versioning/commit-scope
+mechanics below apply to their *content*. A commit touching one still uses that
+plugin's name as its conventional-commit scope, same as any other change to the plugin.
+
+→ Full details, the shared build script, and the straight-vs-adapted-port checklist:
+[`docs/claude-ai-skill-porting.md`](docs/claude-ai-skill-porting.md)
+
 ## Versioning
 
 Versions live in `.claude-plugin/marketplace.json` only (not in plugin.json files).
@@ -167,6 +181,7 @@ The `plugin-list-check.yml` workflow blocks merge until the committed table matc
 ## Documentation
 
 - [`docs/versioning.md`](docs/versioning.md) - How plugin versions are managed
+- [`docs/claude-ai-skill-porting.md`](docs/claude-ai-skill-porting.md) - How claude.ai Skills (a separate product from Claude Code plugins) are structured and built
 - `plugins/tool-routing/docs/route-discovery.md` - How routes are found and merged
 - `plugins/tool-routing/docs/tests/` - Test scenarios and baseline results
 - `plugins/tool-routing/docs/retrospectives/` - Investigation notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,9 @@ mirror, but they are **not** plugin skills — no `plugin.json` entry, no market
 entry, not part of the generated README table, and none of the versioning/commit-scope
 mechanics below apply to their *content*. A commit touching one still uses that
 plugin's name as its conventional-commit scope, same as any other change to the plugin.
+This does mean a commit that touches only a claude-ai-skills port still bumps that
+plugin's published version in `marketplace.json` — expected, not a bug, and
+`./scripts/bump-version.sh --auto` handles it the same as any other plugin change.
 
 → Full details, the shared build script, and the straight-vs-adapted-port checklist:
 [`docs/claude-ai-skill-porting.md`](docs/claude-ai-skill-porting.md)

--- a/docs/claude-ai-skill-porting.md
+++ b/docs/claude-ai-skill-porting.md
@@ -27,6 +27,12 @@ mirrors, and a commit touching it naturally scopes to that plugin
 existing commit-scope rule (see root `CLAUDE.md`'s Versioning section) with no
 special-casing.
 
+One consequence worth knowing: since version bumps are driven by
+conventional-commit scope, not by which files changed, a commit that touches only
+a claude-ai-skills port still bumps the host plugin's published version. That's
+intended — treat it like any other plugin change and run
+`./scripts/bump-version.sh --auto` as usual.
+
 A plugin's `claude-ai-skills/` directory can hold more than one skill.
 
 ## Building

--- a/docs/claude-ai-skill-porting.md
+++ b/docs/claude-ai-skill-porting.md
@@ -1,0 +1,78 @@
+# claude.ai Skill Porting Guide
+
+claude.ai Skills (Settings → Capabilities → Skills in the Claude chat app) are a
+different product from this repo's Claude Code plugins. They're chat-only: no
+filesystem, CLI, or MCP access, uploaded as a zip by hand instead of installed via
+`/plugin install`. Some of this repo's Claude Code skills are worth porting there —
+this doc covers where they live, how to build them, and what to watch for when
+adapting one.
+
+## Where they live
+
+Each port lives inside the Claude Code plugin it's derived from, as a sibling to that
+plugin's `skills/` and `hooks/` directories:
+
+```
+plugins/{plugin-name}/claude-ai-skills/{skill-name}/
+  SKILL.md
+  references/        # optional, same shape as Claude Code skills
+```
+
+A claude-ai-skills port is **not** a Claude Code plugin skill: it has no
+`.claude-plugin/plugin.json` entry, isn't listed in `.claude-plugin/marketplace.json`,
+and doesn't appear in the generated README plugin table. The only reason it's nested
+inside `plugins/{name}/` is organizational — it sits next to the conventions it
+mirrors, and a commit touching it naturally scopes to that plugin
+(`feat(second-brain): add vault-capture claude.ai skill`), satisfying this repo's
+existing commit-scope rule (see root `CLAUDE.md`'s Versioning section) with no
+special-casing.
+
+A plugin's `claude-ai-skills/` directory can hold more than one skill.
+
+## Building
+
+One shared script handles every plugin:
+
+```bash
+./scripts/build-claude-ai-skill.sh <plugin>                # build every skill under that plugin
+./scripts/build-claude-ai-skill.sh <plugin> <skill-name>   # build just one
+```
+
+Output lands at `plugins/<plugin>/claude-ai-skills/dist/<skill-name>.zip`, gitignored.
+`SKILL.md` sits at the zip root — that's the shape claude.ai's uploader expects.
+
+## Uploading
+
+claude.ai → Settings → Capabilities → Skills → upload the zip. Re-uploading the same
+skill name replaces the previous version. There's no CLI for this; it's a manual step
+after building.
+
+## Porting checklist
+
+When adapting a Claude Code skill into a claude.ai skill, start here:
+
+**Does the source skill invoke tools, a CLI, MCP, or the filesystem?**
+
+- **No** → straight port. The instructions carry over close to as-is. Review is
+  lightweight — check the description still triggers correctly in a chat-only context,
+  and that nothing in the body assumes Claude Code-specific mechanics (skill file
+  paths, other installed plugins, etc.).
+- **Yes** → adapted port. Do a capability-gap pass:
+  1. Enumerate every capability the source skill relies on that claude.ai chat doesn't
+     have (filesystem search, a CLI's dedup/validation logic, MCP calls, other
+     installed skills it composes with).
+  2. For each one, decide: disclose the gap plainly (tell the user this step can't be
+     done and why), or find a chat-safe equivalent. Never fake it — don't have the
+     skill claim to have deduplicated, searched, or validated something it structurally
+     cannot.
+  3. Check whether any reference data needs to be baked into `references/` because the
+     source skill previously read it live from somewhere claude.ai can't reach (a
+     vault's own `CLAUDE.md`, a database, another plugin's config). `vault-capture`'s
+     `references/jd-map.md` is an example: it condenses the `pickled-knowledge` vault's
+     Johnny Decimal layout, which the source `second-brain:capture` skill reads live
+     from the vault's `CLAUDE.md` but a claude.ai skill can't.
+
+**Either way**, the port goes through the full `superpowers:writing-skills` TDD process
+(baseline subagent runs, rationalization tables) before being considered done. The
+checklist above changes *what* needs adapting — it doesn't change whether the result
+gets tested like any other skill.

--- a/docs/superpowers/plans/2026-09-11-claude-ai-skills-structure.md
+++ b/docs/superpowers/plans/2026-09-11-claude-ai-skills-structure.md
@@ -1,0 +1,377 @@
+# claude.ai Skills Structure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the existing `vault-capture` claude.ai-skill work out of a bare top-level `claude-ai-skills/` directory and into a repeatable, per-plugin convention (`plugins/{name}/claude-ai-skills/{skill}/`), backed by one shared build script and a porting guide.
+
+**Architecture:** claude.ai-skill ports live inside the Claude Code plugin they're derived from, as a sibling to that plugin's `skills/`/`hooks/` directories. They are not Claude Code plugin skills themselves (no `plugin.json` entry, not installable via `/plugin`). One shared script at the repo root builds any plugin's port into an uploadable zip, replacing per-directory `build.sh` copies. A new doc explains the convention and gives a checklist for distinguishing a straight port (no tool/CLI/MCP/filesystem dependency in the source skill) from an adapted port (needs a capability-gap pass).
+
+**Tech Stack:** Bash (`scripts/*.sh`, existing repo convention), Markdown (`SKILL.md`, docs), `zip`.
+
+**Spec:** [`docs/superpowers/specs/2026-09-11-claude-ai-skills-structure-design.md`](../specs/2026-09-11-claude-ai-skills-structure-design.md)
+
+## Global Constraints
+
+- claude-ai-skill ports live at `plugins/{plugin-name}/claude-ai-skills/{skill-name}/`, never at a bare top-level `claude-ai-skills/`.
+- They are never given a `.claude-plugin/plugin.json`, never added to `.claude-plugin/marketplace.json`, and never listed in the generated README plugin table.
+- Build tooling is one shared script (`scripts/build-claude-ai-skill.sh`), not a script per plugin.
+- Every zip must have `SKILL.md` at its root (not nested in a subfolder) — this is what claude.ai's uploader expects.
+- Commits touching a plugin's claude-ai-skills work use that plugin's name as the conventional-commit scope (e.g. `feat(second-brain): ...`), same as any other change to that plugin.
+
+---
+
+### Task 1: Shared build script
+
+**Files:**
+- Create: `scripts/build-claude-ai-skill.sh`
+
+**Interfaces:**
+- Consumes: nothing (no earlier tasks)
+- Produces: an executable `scripts/build-claude-ai-skill.sh <plugin> [skill-name ...]` that later tasks (Task 2) invoke directly as a shell command — no importable functions, just a CLI.
+
+This replaces the old `claude-ai-skills/build.sh` (which zipped everything relative to itself) with a version that takes a plugin name and zips from `plugins/<plugin>/claude-ai-skills/<skill>/` into `plugins/<plugin>/claude-ai-skills/dist/<skill>.zip`. There's no existing automated test harness for the repo's `scripts/*.sh` utilities (`bump-version.sh`, `check-commit-scope.sh`, etc. are verified by direct invocation, not a test suite) — follow that same convention: verify by running the script against real fixture data in Task 2, once `vault-capture` exists at its new path.
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+#
+# Packages a claude.ai Skill (a plugin's claude-ai-skills/{name}/ directory) into an
+# uploadable zip. claude.ai Skills are a separate product from this repo's Claude Code
+# plugins - see plugins/{plugin}/claude-ai-skills/ and docs/claude-ai-skill-porting.md.
+#
+# Usage:
+#   ./scripts/build-claude-ai-skill.sh <plugin> [skill-name ...]
+#   ./scripts/build-claude-ai-skill.sh second-brain                # build every skill under second-brain
+#   ./scripts/build-claude-ai-skill.sh second-brain vault-capture  # build just one
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <plugin> [skill-name ...]" >&2
+  exit 1
+fi
+
+plugin="$1"
+shift
+skills_root="$REPO_ROOT/plugins/$plugin/claude-ai-skills"
+
+if [ ! -d "$skills_root" ]; then
+  echo "error: no claude-ai-skills directory at plugins/$plugin/claude-ai-skills" >&2
+  exit 1
+fi
+
+dist_dir="$skills_root/dist"
+mkdir -p "$dist_dir"
+
+skills=("$@")
+if [ "${#skills[@]}" -eq 0 ]; then
+  for dir in "$skills_root"/*/; do
+    name="$(basename "$dir")"
+    [ "$name" = "dist" ] && continue
+    [ -f "$dir/SKILL.md" ] && skills+=("$name")
+  done
+fi
+
+if [ "${#skills[@]}" -eq 0 ]; then
+  echo "error: no skill directories with SKILL.md found under $skills_root" >&2
+  exit 1
+fi
+
+for name in "${skills[@]}"; do
+  skill_dir="$skills_root/$name"
+  if [ ! -f "$skill_dir/SKILL.md" ]; then
+    echo "skip: $name has no SKILL.md" >&2
+    continue
+  fi
+  out="$dist_dir/$name.zip"
+  rm -f "$out"
+  (cd "$skill_dir" && zip -X -r "$out" . -x '.*')
+  echo "built plugins/$plugin/claude-ai-skills/dist/$name.zip"
+done
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x scripts/build-claude-ai-skill.sh`
+
+- [ ] **Step 3: Verify usage/error output before real fixtures exist**
+
+Run: `./scripts/build-claude-ai-skill.sh`
+Expected: prints `Usage: ./scripts/build-claude-ai-skill.sh <plugin> [skill-name ...]` to stderr and exits non-zero (no `plugins/` directory arg given).
+
+Run: `./scripts/build-claude-ai-skill.sh does-not-exist`
+Expected: prints `error: no claude-ai-skills directory at plugins/does-not-exist/claude-ai-skills` to stderr and exits non-zero.
+
+- [ ] **Step 4: Run shellcheck**
+
+Run: `shellcheck scripts/build-claude-ai-skill.sh`
+Expected: no warnings. (If `shellcheck` isn't installed in the execution environment, skip this step — it's not part of this repo's CI today.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/build-claude-ai-skill.sh
+git commit -m "feat(repo): add shared claude.ai-skill build script"
+```
+
+---
+
+### Task 2: Migrate vault-capture into plugins/second-brain
+
+**Files:**
+- Create: `plugins/second-brain/claude-ai-skills/vault-capture/SKILL.md` (moved from `claude-ai-skills/vault-capture/SKILL.md`)
+- Create: `plugins/second-brain/claude-ai-skills/vault-capture/references/jd-map.md` (moved from `claude-ai-skills/vault-capture/references/jd-map.md`)
+- Delete: `claude-ai-skills/README.md`
+- Delete: `claude-ai-skills/build.sh`
+- Delete: `claude-ai-skills/dist/vault-capture.zip`
+- Delete: `claude-ai-skills/vault-capture/SKILL.md`, `claude-ai-skills/vault-capture/references/jd-map.md` (via directory move)
+- Modify: `.gitignore` (ignore build output)
+
+**Interfaces:**
+- Consumes: `scripts/build-claude-ai-skill.sh <plugin> [skill-name ...]` from Task 1
+- Produces: `plugins/second-brain/claude-ai-skills/vault-capture/dist/vault-capture.zip` (gitignored build artifact) — nothing later depends on this programmatically, it's the deliverable a human uploads to claude.ai by hand
+
+Both `claude-ai-skills/` (old, top-level, untracked) and `plugins/second-brain/` (existing, tracked) already exist in the working tree — this task only moves files and does not need to create the `plugins/second-brain/` directory itself.
+
+- [ ] **Step 1: Move the skill directory**
+
+```bash
+mkdir -p plugins/second-brain/claude-ai-skills
+git mv claude-ai-skills/vault-capture plugins/second-brain/claude-ai-skills/vault-capture 2>/dev/null || \
+  mv claude-ai-skills/vault-capture plugins/second-brain/claude-ai-skills/vault-capture
+```
+
+(`claude-ai-skills/` was untracked before this plan, so plain `git status` after this step should show the new path as untracked, not staged as a rename — that's expected; `git mv` on untracked files falls back to a plain filesystem move, hence the `||` fallback.)
+
+- [ ] **Step 2: Remove the old top-level directory's leftovers**
+
+```bash
+rm -f claude-ai-skills/README.md claude-ai-skills/build.sh
+rm -rf claude-ai-skills/dist
+rmdir claude-ai-skills/vault-capture 2>/dev/null || true
+rmdir claude-ai-skills 2>/dev/null || true
+```
+
+- [ ] **Step 3: Verify the old directory is gone and the new one is in place**
+
+Run: `test ! -e claude-ai-skills && echo "old dir gone"`
+Expected: prints `old dir gone`
+
+Run: `find plugins/second-brain/claude-ai-skills -type f | sort`
+Expected:
+```
+plugins/second-brain/claude-ai-skills/vault-capture/SKILL.md
+plugins/second-brain/claude-ai-skills/vault-capture/references/jd-map.md
+```
+
+- [ ] **Step 4: Ignore build output**
+
+Add to `.gitignore` (append, keep existing entries above intact):
+
+```gitignore
+
+# claude.ai Skill build output (see docs/claude-ai-skill-porting.md)
+plugins/*/claude-ai-skills/dist/
+```
+
+- [ ] **Step 5: Rebuild the zip via the shared script**
+
+Run: `./scripts/build-claude-ai-skill.sh second-brain vault-capture`
+Expected: prints `built plugins/second-brain/claude-ai-skills/dist/vault-capture.zip`
+
+- [ ] **Step 6: Verify the zip shape**
+
+Run: `unzip -l plugins/second-brain/claude-ai-skills/dist/vault-capture.zip`
+Expected output includes, with `SKILL.md` at the zip root (not nested under `vault-capture/`):
+```
+SKILL.md
+references/jd-map.md
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugins/second-brain/claude-ai-skills .gitignore
+git status  # confirm claude-ai-skills/ (old top-level path) no longer appears at all
+git commit -m "feat(second-brain): move vault-capture claude.ai skill into plugin directory"
+```
+
+---
+
+### Task 3: Porting guide doc
+
+**Files:**
+- Create: `docs/claude-ai-skill-porting.md`
+
+**Interfaces:**
+- Consumes: nothing programmatically (references the script from Task 1 and the directory from Task 2 in prose/examples only)
+- Produces: a doc that Task 4's `CLAUDE.md` pointer links to
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# claude.ai Skill Porting Guide
+
+claude.ai Skills (Settings → Capabilities → Skills in the Claude chat app) are a
+different product from this repo's Claude Code plugins. They're chat-only: no
+filesystem, CLI, or MCP access, uploaded as a zip by hand instead of installed via
+`/plugin install`. Some of this repo's Claude Code skills are worth porting there —
+this doc covers where they live, how to build them, and what to watch for when
+adapting one.
+
+## Where they live
+
+Each port lives inside the Claude Code plugin it's derived from, as a sibling to that
+plugin's `skills/` and `hooks/` directories:
+
+```
+plugins/{plugin-name}/claude-ai-skills/{skill-name}/
+  SKILL.md
+  references/        # optional, same shape as Claude Code skills
+```
+
+A claude-ai-skills port is **not** a Claude Code plugin skill: it has no
+`.claude-plugin/plugin.json` entry, isn't listed in `.claude-plugin/marketplace.json`,
+and doesn't appear in the generated README plugin table. The only reason it's nested
+inside `plugins/{name}/` is organizational — it sits next to the conventions it
+mirrors, and a commit touching it naturally scopes to that plugin
+(`feat(second-brain): add vault-capture claude.ai skill`), satisfying this repo's
+existing commit-scope rule (see root `CLAUDE.md`'s Versioning section) with no
+special-casing.
+
+A plugin's `claude-ai-skills/` directory can hold more than one skill.
+
+## Building
+
+One shared script handles every plugin:
+
+```bash
+./scripts/build-claude-ai-skill.sh <plugin>                # build every skill under that plugin
+./scripts/build-claude-ai-skill.sh <plugin> <skill-name>   # build just one
+```
+
+Output lands at `plugins/<plugin>/claude-ai-skills/dist/<skill-name>.zip`, gitignored.
+`SKILL.md` sits at the zip root — that's the shape claude.ai's uploader expects.
+
+## Uploading
+
+claude.ai → Settings → Capabilities → Skills → upload the zip. Re-uploading the same
+skill name replaces the previous version. There's no CLI for this; it's a manual step
+after building.
+
+## Porting checklist
+
+When adapting a Claude Code skill into a claude.ai skill, start here:
+
+**Does the source skill invoke tools, a CLI, MCP, or the filesystem?**
+
+- **No** → straight port. The instructions carry over close to as-is. Review is
+  lightweight — check the description still triggers correctly in a chat-only context,
+  and that nothing in the body assumes Claude Code-specific mechanics (skill file
+  paths, other installed plugins, etc.).
+- **Yes** → adapted port. Do a capability-gap pass:
+  1. Enumerate every capability the source skill relies on that claude.ai chat doesn't
+     have (filesystem search, a CLI's dedup/validation logic, MCP calls, other
+     installed skills it composes with).
+  2. For each one, decide: disclose the gap plainly (tell the user this step can't be
+     done and why), or find a chat-safe equivalent. Never fake it — don't have the
+     skill claim to have deduplicated, searched, or validated something it structurally
+     cannot.
+  3. Check whether any reference data needs to be baked into `references/` because the
+     source skill previously read it live from somewhere claude.ai can't reach (a
+     vault's own `CLAUDE.md`, a database, another plugin's config). `vault-capture`'s
+     `references/jd-map.md` is an example: it condenses the `pickled-knowledge` vault's
+     Johnny Decimal layout, which the source `second-brain:capture` skill reads live
+     from the vault's `CLAUDE.md` but a claude.ai skill can't.
+
+**Either way**, the port goes through the full `superpowers:writing-skills` TDD process
+(baseline subagent runs, rationalization tables) before being considered done. The
+checklist above changes *what* needs adapting — it doesn't change whether the result
+gets tested like any other skill.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/claude-ai-skill-porting.md
+git commit -m "docs(repo): add claude.ai skill porting guide"
+```
+
+---
+
+### Task 4: Root CLAUDE.md pointer
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: `docs/claude-ai-skill-porting.md` (Task 3), `plugins/second-brain/claude-ai-skills/` (Task 2) as a concrete example
+- Produces: nothing consumed by later tasks (this is the last task)
+
+- [ ] **Step 1: Add a new section after "Plugin Internal Structure"**
+
+In `CLAUDE.md`, insert a new section immediately after the "### Naming Gotchas" subsection ends and before `## Versioning` (i.e. right after the line containing `Slash-command wrappers pointing at skills are a legacy pattern from before skills were directly slash-callable.` and its trailing blank line):
+
+```markdown
+## claude.ai Skills
+
+Some Claude Code skills are also worth porting to **claude.ai Skills** (the chat
+product's own skill format — Settings → Capabilities → Skills, no filesystem/CLI/MCP
+access, uploaded as a zip by hand). These ports live at
+`plugins/{name}/claude-ai-skills/{skill}/`, colocated with the Claude Code plugin they
+mirror, but they are **not** plugin skills — no `plugin.json` entry, no marketplace
+entry, not part of the generated README table, and none of the versioning/commit-scope
+mechanics below apply to their *content*. A commit touching one still uses that
+plugin's name as its conventional-commit scope, same as any other change to the plugin.
+
+→ Full details, the shared build script, and the straight-vs-adapted-port checklist:
+[`docs/claude-ai-skill-porting.md`](docs/claude-ai-skill-porting.md)
+```
+
+- [ ] **Step 2: Add it to the Documentation list**
+
+In the `## Documentation` section, add a bullet after the existing `docs/versioning.md` line:
+
+```markdown
+- [`docs/claude-ai-skill-porting.md`](docs/claude-ai-skill-porting.md) - How claude.ai Skills (a separate product from Claude Code plugins) are structured and built
+```
+
+- [ ] **Step 3: Verify the doc renders sensibly**
+
+Run: `grep -n "claude-ai-skill-porting" CLAUDE.md`
+Expected: two matches (the new section's link, and the Documentation list bullet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(repo): point CLAUDE.md at the claude.ai skill porting guide"
+```
+
+---
+
+### Task 5: Final verification
+
+**Files:** none (verification only)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4
+- Produces: nothing (terminal task)
+
+- [ ] **Step 1: Confirm the old top-level directory is fully gone**
+
+Run: `git status --porcelain | grep -c '^?? claude-ai-skills' || true`
+Expected: `0`
+
+- [ ] **Step 2: Confirm the new structure builds cleanly from a fresh clone's perspective**
+
+Run: `git clean -ndx plugins/second-brain/claude-ai-skills` (dry run — lists what would be removed, does not delete)
+Expected: only lists `plugins/second-brain/claude-ai-skills/dist/` (the gitignored build output), nothing else — confirms `SKILL.md` and `references/` are tracked, not accidentally gitignored.
+
+- [ ] **Step 3: Confirm all commits from this plan are present**
+
+Run: `git log --oneline -4`
+Expected: four commits in this order (most recent first): the `CLAUDE.md` pointer commit, the porting-guide commit, the vault-capture migration commit, the build-script commit — on top of whatever was `HEAD` before this plan started.

--- a/docs/superpowers/specs/2026-09-11-claude-ai-skills-structure-design.md
+++ b/docs/superpowers/specs/2026-09-11-claude-ai-skills-structure-design.md
@@ -1,0 +1,116 @@
+# claude.ai Skills Structure — Design
+
+**Date:** 2026-09-11
+**Status:** Draft, pending user approval
+**Author:** brainstorm with Claude
+
+## Problem
+
+This repo hosts Claude Code plugins under `plugins/{name}/`, with everything — commit
+scopes, `bump-version.sh`, the generated README plugin table, marketplace entries — built
+around that convention. Separately, there's a need for **claude.ai Skills**: the chat
+product's own skill format (Settings → Capabilities → Skills), uploaded as a zip, usable
+in general chat with no filesystem/CLI/MCP access.
+
+A first one, `vault-capture`, was built this session as a chat-only rewrite of the
+`second-brain:capture` Claude Code skill. It went through two location guesses (dotfiles,
+then a bare top-level `claude-ai-skills/` dir in this repo) before being parked: the
+top-level dir didn't fit a repo whose every convention assumes `plugins/{name}/`, and
+being a lone top-level artifact hid the fact that `vault-capture` is tightly coupled to
+`second-brain`'s conventions (`note-format.md`, the vault's own `CLAUDE.md`) — a coupling
+that was invisible from the directory structure.
+
+During brainstorming it became clear this isn't a one-off: a second candidate
+(`writing-tools`'s scannability/undisclosed-context skills) surfaced immediately, so this
+needs to be a repeatable pattern across multiple source plugins, not a single ad hoc
+export.
+
+## Goals
+
+1. Give claude.ai-skill ports a home that reflects their coupling to a specific source
+   plugin, so the relationship isn't lost.
+2. Make commits touching a port fit the repo's existing commit-scope convention
+   (`feat(second-brain): ...`) without a carve-out.
+3. Share build/packaging logic across ports instead of duplicating a `build.sh` per port.
+4. Distinguish, in process (not just informally), between a **straight port** (source
+   skill has no tool/CLI/MCP/filesystem dependency — closer to copy-paste) and an
+   **adapted port** (source skill assumes capabilities claude.ai chat doesn't have, and
+   needs an explicit capability-gap pass).
+5. Migrate the existing `vault-capture` work into the new structure.
+
+## Non-goals
+
+- Not building the `writing-tools` port in this pass — it's the second, confirming
+  example of the pattern, but its own port is future work.
+- Not making claude.ai-skill ports real Claude Code plugins (no `plugin.json`, no
+  marketplace entry, no `/plugin install`). They stay a separate, manually-uploaded
+  product, per the original `vault-capture` scoping decision.
+- Not retroactively applying full `superpowers:writing-skills` TDD rigor to
+  `vault-capture` itself — that decision (lightweight pass) was made and executed before
+  this structural rethink; the new rigor requirement applies going forward.
+
+## Approach
+
+### 1. Directory convention — colocated inside the source plugin
+
+```
+plugins/{plugin-name}/claude-ai-skills/{skill-name}/
+  SKILL.md
+  references/        # optional, same shape as Claude Code skills
+```
+
+Sibling to that plugin's `skills/`, `hooks/`, etc. Not a Claude Code plugin skill itself —
+doesn't appear in `/plugin install`, has no `plugin.json` entry, isn't part of the
+generated README table. The only reason it's nested here is organizational: it sits next
+to the conventions it mirrors, and a commit touching it naturally scopes to that plugin
+(`feat(second-brain): add vault-capture claude.ai skill`), satisfying the existing
+commit-scope rule with no special-casing.
+
+A plugin's `claude-ai-skills/` directory can hold more than one skill (a family), same as
+`skills/` can.
+
+### 2. Shared build tooling
+
+One script, `scripts/build-claude-ai-skill.sh <plugin> <skill-name>`, replacing the
+per-directory `build.sh` from the original design. It zips
+`plugins/<plugin>/claude-ai-skills/<skill-name>/` into
+`plugins/<plugin>/claude-ai-skills/dist/<skill-name>.zip`, with `SKILL.md` at the zip
+root (the shape claude.ai's uploader expects). No per-plugin copies to keep in sync.
+
+### 3. Docs — porting guide
+
+Root `CLAUDE.md` gets a short pointer section, following the existing pattern used for
+`docs/versioning.md`, linking to a new `docs/claude-ai-skill-porting.md`. That doc covers:
+
+- The directory/build convention from sections 1-2 above.
+- **A porting checklist**, applied when adapting a Claude Code skill into a claude.ai
+  skill:
+  - Does the source skill invoke tools, a CLI, MCP, or the filesystem?
+    - **No** → straight port. The instructions carry over close to as-is; review is
+      lightweight.
+    - **Yes** → adapted port. Do a capability-gap pass: enumerate what's lost without
+      filesystem/CLI/MCP access, decide per capability whether to disclose the gap
+      plainly or find a chat-safe equivalent (never fake it), and check whether any
+      reference data needs to be baked into `references/` because it previously lived
+      only in an external config the source skill could read live (as `jd-map.md` had to
+      be, standing in for the vault's own `CLAUDE.md`).
+  - Either way, the port goes through the full `superpowers:writing-skills` TDD process
+    (baseline subagent runs, rationalization tables) before being considered done — the
+    checklist changes *what* gets adapted, not whether it gets tested.
+
+### 4. Migration
+
+- Move `claude-ai-skills/vault-capture/` (currently untracked, top-level) to
+  `plugins/second-brain/claude-ai-skills/vault-capture/`.
+- Drop the top-level `claude-ai-skills/README.md` and `claude-ai-skills/build.sh` —
+  superseded by `docs/claude-ai-skill-porting.md` and the shared script.
+- Rebuild `dist/vault-capture.zip` via the new shared script at its new location.
+
+## Testing / Verification
+
+- `scripts/build-claude-ai-skill.sh second-brain vault-capture` produces a zip with
+  `SKILL.md` at its root and the expected `references/jd-map.md` alongside it.
+- `git status` shows the migrated files as untracked in their new location, and the old
+  top-level `claude-ai-skills/` dir is gone.
+- Root `CLAUDE.md` and `docs/claude-ai-skill-porting.md` cross-reference each other, same
+  as the existing `docs/versioning.md` link.

--- a/plugins/second-brain/claude-ai-skills/vault-capture/SKILL.md
+++ b/plugins/second-brain/claude-ai-skills/vault-capture/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: vault-capture
+description: Use when Josh asks to write a note, make a note, or capture something for his "pickled-knowledge" Obsidian vault - triggers on "write a note about X", "make a note for this", "capture this", "note this up", "put together a note on X", or a bare URL/article/tweet handed over with intent to write it up. Do NOT use for generic writing help, drafting prose that isn't a vault note, or when Josh is just asking a question and not asking for a note.
+---
+
+# Vault Capture
+
+Turn a source (or a raw idea) into one Obsidian note file, already shaped for Josh's
+`pickled-knowledge` vault - correct filename, correct frontmatter, correct body shape, and a
+best-guess at where it'll eventually live. He should be able to save the file straight into his
+vault with no renaming, no reformatting, no hunting down the source URL after the fact.
+
+This is a chat-only rewrite of a more capable version that runs inside Claude Code (searches
+the vault first, checks for duplicates, auto-links related notes, appends a daily-note
+breadcrumb, actually files the note). None of that is reachable from here - no filesystem, no
+vault search index. Say so plainly once, up front, rather than quietly skipping it:
+
+> "Heads up: I can't search your vault from here, so I'm not checking for an existing note or
+> suggesting related links - worth a quick check yourself before you file this."
+
+## Step 1: Get the real source - never invent one
+
+- **A URL was given:** fetch and read it for real (browse it). Never write the note from the
+  URL text alone, a guess at what the page probably says, or general knowledge about the
+  topic. If the page can't be reached, say so and stop - don't write a plausible-sounding note
+  anyway.
+- **A tweet/thread:** read the actual tweet content if it can be fetched. If not reachable,
+  say so rather than reconstructing it from context.
+- **No URL, just an idea or topic:** there is no source to fetch. Don't backfill one from
+  training knowledge and present it as researched. Write the note from what Josh actually said,
+  and leave `source` off the frontmatter entirely.
+- **Several sources at once** ("make notes for each of these"): handle them one at a time, in
+  order, and produce one file per source. There's no subagent fan-out available here.
+
+## Step 2: Write the frontmatter
+
+```yaml
+---
+status: seedling
+tags: [lowercase, hyphenated, no-leading-hash]
+created: 2026-09-11
+source: https://example.com/the-actual-page
+---
+```
+
+- **`status: seedling`** always, for a fresh capture. This is the note's maturity, not a
+  workflow state - don't write `filed`, `active`, `incubating`, etc. Those belong to notes
+  that have already been routed inside the vault, which this one hasn't.
+- **`tags`**: a short list, lowercase, hyphenated, **no `#` prefix** (a bare `#` at the start
+  of a YAML flow-sequence item is a comment and silently corrupts the frontmatter). Pick 2-4
+  topic tags from what the note is actually about. [references/jd-map.md](references/jd-map.md)
+  is useful here too - a tag that matches how the vault already splits a topic (e.g. `ruby` vs
+  a generic `programming`) ages better.
+- **`created`**: today's date, `YYYY-MM-DD`.
+- **`source`**: the real URL/origin actually fetched in Step 1. Omit the field entirely for a
+  sourceless idea capture - don't write `source: none` or similar.
+
+## Step 3: Write the body
+
+```markdown
+# Glide browser
+
+A [Firefox fork](https://glide-browser.app/firefox) that is keyboard-focused, with a
+Vim-style modal interface and a TypeScript config surface.
+```
+
+- **`# Title`** in sentence case, matching the source's own framing rather than a generic
+  topic label - `# Glide browser`, not `# Notes on a keyboard-driven browser`.
+- **Prose, not an outline.** One to three paragraphs. Only reach for `##` subheadings once
+  there's enough content to need them - a three-paragraph note doesn't need five headings.
+- **Link out inline** to the primary source so the reader can get to the real thing.
+- **No `## Related` section.** The real vault workflow only links to notes a live search
+  confirmed exist; nothing here can confirm that, so don't fabricate `[[wiki-links]]` to
+  notes that may or may not exist. Leave that entirely to Josh.
+- **One note, one idea.** If the source clearly carries several distinct, separable ideas,
+  say so and offer to split it into multiple notes rather than writing one sprawling one.
+
+## Step 4: Name the file
+
+```
+202609111420 glide-browser.md
+└──┬───────┘ └──────┬──────┘
+   │                └─ hyphenated slug, from the title
+   └─ YYYYMMDDHHMM, then a single SPACE (not a hyphen)
+```
+
+Use the current date and time (down to the minute, best effort). The space between the
+timestamp and the slug is exactly one space - a hyphen there (`202608071430-glide-browser.md`)
+is the wrong shape.
+
+## Step 5: Guess a likely destination
+
+Read [references/jd-map.md](references/jd-map.md) - the vault's Johnny Decimal area map - and
+name the area/category the note will probably land in once routed (e.g. "probably `66 AI &
+agentic development`"). This is Josh's own filing step to do, not something happening here -
+frame it as a guess he can accept or override, never as a decision already made. Say so plainly
+when two areas are plausible, or when nothing fits well.
+
+## Step 6: Hand over the file
+
+Create the actual `.md` file (frontmatter + body from Steps 2-3) named exactly as in Step 4,
+and give it to Josh as a download. Don't just print the content and ask him to save it himself.
+
+Then, in a few short lines, tell him:
+- the filename
+- that it's built to drop straight into `10-19 System & Capture/11 Inbox & triage/` in the
+  vault (that's where fresh captures land before routing) - he still has to move it there
+  himself, nothing here can write into the vault directly
+- the likely-destination guess from Step 5
+- the one-line duplicate/related-notes caveat from Step 1, if it wasn't already said
+
+No further ceremony - a few short lines are enough, not a summary of every step taken.
+
+## Constraints
+
+- **Never fabricate.** No invented URLs, no filled-in details from memory, no `[[links]]` to
+  notes that might not exist. If the source can't be reached, say that and stop.
+- **No workflow-state values.** Fresh captures are always `status: seedling`. Leave lifecycle
+  status (`filed`, `active`, `incubating`, ...) to whatever actually routes the note later.
+- **No pretending to search the vault, and no pretending the destination guess is final.**
+  State both limitations plainly and move on.
+- **Filename and frontmatter exactly as specified above.** This is the whole point of the
+  skill - if Josh still has to rename the file or fix the frontmatter afterward, it failed at
+  its one job.

--- a/plugins/second-brain/claude-ai-skills/vault-capture/references/jd-map.md
+++ b/plugins/second-brain/claude-ai-skills/vault-capture/references/jd-map.md
@@ -1,0 +1,48 @@
+# pickled-knowledge: Johnny Decimal map
+
+Condensed from the vault's own `CLAUDE.md`. This is for guessing a **likely destination area**
+to save Josh a step, and for picking tags that match how the vault already carves things up.
+It is a guess, not a fact - nothing here can be confirmed without actually opening the vault, so
+always present it as "probably `NN`", never as a done deal, and never as something already filed.
+
+## Structural rules (the short version)
+
+- **Status lives in frontmatter, never in a folder name.** No "Active"/"Done"/"Archive" folders.
+- **Areas are record-heavy or thought-heavy.** Record-heavy areas (Family, Home, Work-projects,
+  People) use numbered ID-folders per discrete thing. Thought-heavy areas (Software, Thinking)
+  stay flat - loose timestamped notes plus tags. A fresh chat capture is almost always a *thought*
+  (an idea, a concept, a tool note), so flat-area placement is the common case.
+- **Tags carry overlapping axes**, not new folders. If a note could plausibly sit in two areas,
+  say so and suggest a tag for the secondary one rather than picking a folder to force it into.
+
+## The 9 areas
+
+| Code | Area | What lives here | Notable sub-categories |
+|------|------|------------------|-------------------------|
+| `10-19` | System & Capture | Meta: inbox, vault config, PKM practice itself | `11` Inbox & triage (fresh captures land here) · `13` System config · `14` Knowledge management practice |
+| `20-29` | Work | Employer-specific (Gusto) | `21` role/team/org/culture · `22` projects (ID-folders) · `23` cross-employer career dev · `24` eng tooling/infra/CI · `25` work-relationship process (interviews, 1:1s - **not** person notes, those go `86`) · `28` past employers (ID-folders) |
+| `30-39` | Family | People you're responsible for | `31` Tracy · `32` Alex · `33` pets (one ID-folder per pet) · `36` family finances/estate · `39` other family (ID-folders) |
+| `40-49` | Home & Property | Physical spaces, maintenance | `41` current house (system ID-folders: HVAC, plumbing, electrical, appliances...) · `42` rental property · `43` smart home · `44` home lab/network · `45` vehicles (ID-folder per car) · `49` sold/past properties |
+| `50-59` | Self & Body | Yours specifically - body, health, mind, appearance | `51` physical/medical · `52` ADHD/autism/therapy/psych · `53` fitness · `56` clothes/grooming |
+| `60-69` | Software & Engineering | The general discipline, not job-specific | `61` SE concepts/architecture/patterns · `62` Ruby/Rails · `63` JS/Node/frontend · `65` DevOps/infra/CI/datastores · `66` AI & agentic development · `67` tools & dev experience (dense ID-folders: `67.01` git, `67.02` github, `67.03` macos, `67.04` ssh, `67.05` neovim, `67.06` tmux, `67.07` fish, `67.08` ghostty, `67.09` pickles.dev, `67.10` obsidian) · `69` other/low-volume languages |
+| `70-79` | Interests & Hobbies | Non-software | `71` shows/movies/anime · `72` books/comics/scifi · `73` video games · `74` RPGs & board games (general knowledge only - active campaigns live in a separate RPG vault) · `75` legos/making · `76` cooking/cocktails · `79` podcasts/misc |
+| `80-89` | Community & People | Activity groups, social ties, PRM | `84` social groups/clubs (own ties, e.g. a pool membership) · `85` online communities · `86` People (flat name-notes, e.g. `Carl Hoover.md` - **any** person note, including coworkers, goes here) · `89` other community |
+| `90-99` | Thinking & Concepts | Mental models, frameworks | `91` cognitive biases/mental models/named laws · `92` productivity/GTD/planning · `93` leadership/management · `94` social/cultural · `95` writing craft |
+
+## Quick disambiguation
+
+- **A tool config for *your own machine*** (dotfiles, tmux/fish/neovim setup, personal CLI habits)
+  → `67`. **A tool/language *as it's used in projects*** (Ruby idioms, JS build tooling, Docker
+  patterns) → `61`-`65` by ecosystem.
+- **A person, even a coworker** → `86`, never `25` (`25` is the work-relationship *process*, not
+  the person record).
+- **A management/leadership/mentoring note** that surfaced while working → `93`, not `20-29`,
+  unless it's specifically about *this* job's culture (`21`).
+- **An X9 "Other" category** (`69`, `89`, `49`, `39`, `79`) is the catch-all for its area - suggest
+  it only when nothing more specific fits, never invent a new mid-area "Other X" category.
+
+## When you genuinely can't tell
+
+Say so - "could go either `66` (AI concepts) or `92` (productivity) - your call" beats guessing
+with false confidence. This map is a hint to save Josh a step, not a routing decision he doesn't
+get to see.

--- a/scripts/build-claude-ai-skill.sh
+++ b/scripts/build-claude-ai-skill.sh
@@ -31,6 +31,8 @@ dist_dir="$skills_root/dist"
 mkdir -p "$dist_dir"
 
 skills=("$@")
+explicit=0
+[ "${#skills[@]}" -gt 0 ] && explicit=1
 if [ "${#skills[@]}" -eq 0 ]; then
   for dir in "$skills_root"/*/; do
     name="$(basename "$dir")"
@@ -47,11 +49,15 @@ fi
 for name in "${skills[@]}"; do
   skill_dir="$skills_root/$name"
   if [ ! -f "$skill_dir/SKILL.md" ]; then
+    if [ "$explicit" -eq 1 ]; then
+      echo "error: $name has no SKILL.md" >&2
+      exit 1
+    fi
     echo "skip: $name has no SKILL.md" >&2
     continue
   fi
   out="$dist_dir/$name.zip"
   rm -f "$out"
-  (cd "$skill_dir" && zip -X -r "$out" . -x '.*')
+  (cd "$skill_dir" && zip -X -r "$out" . -x '.*' -x '*/.*')
   echo "built plugins/$plugin/claude-ai-skills/dist/$name.zip"
 done

--- a/scripts/build-claude-ai-skill.sh
+++ b/scripts/build-claude-ai-skill.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Packages a claude.ai Skill (a plugin's claude-ai-skills/{name}/ directory) into an
+# uploadable zip. claude.ai Skills are a separate product from this repo's Claude Code
+# plugins - see plugins/{plugin}/claude-ai-skills/ and docs/claude-ai-skill-porting.md.
+#
+# Usage:
+#   ./scripts/build-claude-ai-skill.sh <plugin> [skill-name ...]
+#   ./scripts/build-claude-ai-skill.sh second-brain                # build every skill under second-brain
+#   ./scripts/build-claude-ai-skill.sh second-brain vault-capture  # build just one
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <plugin> [skill-name ...]" >&2
+  exit 1
+fi
+
+plugin="$1"
+shift
+skills_root="$REPO_ROOT/plugins/$plugin/claude-ai-skills"
+
+if [ ! -d "$skills_root" ]; then
+  echo "error: no claude-ai-skills directory at plugins/$plugin/claude-ai-skills" >&2
+  exit 1
+fi
+
+dist_dir="$skills_root/dist"
+mkdir -p "$dist_dir"
+
+skills=("$@")
+if [ "${#skills[@]}" -eq 0 ]; then
+  for dir in "$skills_root"/*/; do
+    name="$(basename "$dir")"
+    [ "$name" = "dist" ] && continue
+    [ -f "$dir/SKILL.md" ] && skills+=("$name")
+  done
+fi
+
+if [ "${#skills[@]}" -eq 0 ]; then
+  echo "error: no skill directories with SKILL.md found under $skills_root" >&2
+  exit 1
+fi
+
+for name in "${skills[@]}"; do
+  skill_dir="$skills_root/$name"
+  if [ ! -f "$skill_dir/SKILL.md" ]; then
+    echo "skip: $name has no SKILL.md" >&2
+    continue
+  fi
+  out="$dist_dir/$name.zip"
+  rm -f "$out"
+  (cd "$skill_dir" && zip -X -r "$out" . -x '.*')
+  echo "built plugins/$plugin/claude-ai-skills/dist/$name.zip"
+done


### PR DESCRIPTION
## Summary

- Add a convention for **claude.ai Skills**: the chat-only product (Settings → Capabilities → Skills), separate from this repo's Claude Code plugins. They live at `plugins/{plugin}/claude-ai-skills/{skill}/`, colocated with the Claude Code plugin they're derived from
- Add one shared build script, `scripts/build-claude-ai-skill.sh`, that zips any plugin's port for upload
- Add `docs/claude-ai-skill-porting.md` with a checklist for telling a straight port (no tool/CLI/MCP dependency) from an adapted one that needs a capability-gap pass
- Add the first skill under this convention, `vault-capture`, to `plugins/second-brain/` (a chat-only rewrite of the existing `second-brain:capture` Claude Code skill)

## Test plan

- `./scripts/build-claude-ai-skill.sh second-brain vault-capture` builds a zip with `SKILL.md` at its root
- `./scripts/analyze-version-bumps.sh` and `./scripts/check-commit-scope.sh` both pass clean on this branch
