### PR TITLE
Resolve tailnet URLs before handing back localhost links

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -112,7 +112,7 @@
     {
       "name": "tailscale",
       "source": "./plugins/tailscale",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "Tailscale CLI reference and safe patterns for exposing local services over a tailnet"
     },
     {

--- a/plugins/tailscale/README.md
+++ b/plugins/tailscale/README.md
@@ -21,10 +21,15 @@ Use when deciding how to expose a locally-running server over a tailnet, working
 
 **Covers:**
 - Loopback bind + `tailscale serve` proxy (safe default) vs. binding directly to the tailnet interface (unauthenticated, exposure-widening)
+- Resolving a tailnet URL (via the bundled `scripts/resolve-tailnet-url.sh`) before handing back a `localhost`/bare-port link for anything served locally that the user might open from another device
 - The IPv4 (`127.0.0.1`) vs. IPv6 (`[::1]`) loopback trap
 - Empirically-verified behavior of Tailscale identity headers on Services (undocumented by Tailscale itself): Serve overwrites spoofed headers rather than stripping them, but a request straight to the loopback port arrives unverified — making loopback-only binding a security invariant, not just hygiene
 - Why tagged devices and Funnel traffic never carry identity headers, and why that fallback isn't optional
 - Why an automated "bind is loopback" check can pass while a Docker `-p` publish or reverse proxy still exposes the port
+
+## Hooks
+
+Before `crit:crit` launches (the interactive review skill from the `crit` plugin), a `PreToolUse` hook nudges toward `scripts/resolve-tailnet-url.sh` for resolving the review URL, instead of re-deriving Tailscale's status/DNS-name lookup by hand each time.
 
 ## Installation
 

--- a/plugins/tailscale/hooks/hooks.json
+++ b/plugins/tailscale/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Nudge toward the tailnet-URL helper script before crit launches a review server",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/nudge-tailscale-on-crit.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/tailscale/hooks/nudge-tailscale-on-crit.py
+++ b/plugins/tailscale/hooks/nudge-tailscale-on-crit.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: nudge toward the tailnet-URL helper before crit runs.
+
+crit's own skill (crit:crit) launches a local review server and, when
+reviewing over Tailscale, needs a tailnet URL to hand back. Several past
+sessions re-derived "find tailscale, read status --json, strip the
+trailing dot off DNSName" from scratch each time. This hook fires right
+before crit:crit runs and points at the shared helper script instead, so
+that logic lives in one place.
+
+Reads the PreToolUse JSON payload from stdin. If tool_name is "Skill" and
+tool_input.skill == "crit:crit", emits
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": ...}}
+so Claude sees the reminder before crit's own skill content loads. Any
+non-match (wrong tool, wrong skill, unparseable payload) exits 0 silently
+-- this hook only ever adds context, never blocks.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+TARGET_SKILL = "crit:crit"
+ADVICE = (
+    "Before launching crit with a Tailscale --public-url, resolve the URL with "
+    '"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-tailnet-url.sh" <port> (from the '
+    "tailscale plugin) instead of re-deriving it from `tailscale status --json` "
+    "by hand -- it already handles the GUI-app-not-on-PATH lookup, the "
+    "trailing dot on Self.DNSName, and checking BackendState before promising "
+    "a URL. Note: reading tailscaled's status requires the sandbox bypass "
+    "(dangerouslyDisableSandbox), same as any other tailscale command."
+)
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 0
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    if not isinstance(payload, dict):
+        return 0
+    if payload.get("tool_name") != "Skill":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+    if tool_input.get("skill") != TARGET_SKILL:
+        return 0
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": ADVICE,
+        }
+    }
+    print(json.dumps(output))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/tailscale/scripts/resolve-tailnet-url.sh
+++ b/plugins/tailscale/scripts/resolve-tailnet-url.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Resolve the tailnet URL for something running on a local port.
+#
+# Usage: resolve-tailnet-url.sh <port> [path]
+#
+# Prints a URL on stdout (http://<tailnet-hostname>:<port>/<path>, falling
+# back to the node's first Tailscale IP if the DNS name isn't usable) and
+# exits 0. If Tailscale isn't installed or isn't connected, prints nothing
+# to stdout, an explanation to stderr, and exits 1 -- callers should fall
+# back to a plain localhost URL in that case rather than guessing.
+set -euo pipefail
+
+port="${1:-}"
+path="${2:-}"
+
+if [[ -z "$port" ]]; then
+  echo "usage: $(basename "$0") <port> [path]" >&2
+  exit 2
+fi
+
+find_tailscale_binary() {
+  if command -v tailscale >/dev/null 2>&1; then
+    command -v tailscale
+    return 0
+  fi
+  # macOS GUI app (Tailscale.app) does not symlink onto $PATH by default.
+  local gui_binary="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+  if [[ -x "$gui_binary" ]]; then
+    echo "$gui_binary"
+    return 0
+  fi
+  return 1
+}
+
+if ! ts_bin="$(find_tailscale_binary)"; then
+  echo "tailscale binary not found (checked \$PATH and /Applications/Tailscale.app)" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to parse 'tailscale status --json' but isn't on \$PATH" >&2
+  exit 1
+fi
+
+status_json="$("$ts_bin" status --json 2>/dev/null)" || {
+  echo "'$ts_bin status --json' failed -- is tailscaled running?" >&2
+  exit 1
+}
+
+backend_state="$(jq -r '.BackendState // "Unknown"' <<<"$status_json")"
+if [[ "$backend_state" != "Running" ]]; then
+  echo "tailscale is not connected (BackendState=$backend_state)" >&2
+  exit 1
+fi
+
+# Self.DNSName carries a trailing dot (e.g. "host.tailnet.ts.net."); strip it.
+dns_name="$(jq -r '.Self.DNSName // ""' <<<"$status_json" | sed 's/\.$//')"
+fallback_ip="$(jq -r '.Self.TailscaleIPs[0] // ""' <<<"$status_json")"
+
+host=""
+if [[ -n "$dns_name" ]]; then
+  host="$dns_name"
+elif [[ -n "$fallback_ip" ]]; then
+  host="$fallback_ip"
+else
+  echo "could not determine this node's tailnet hostname or IP from 'tailscale status --json'" >&2
+  exit 1
+fi
+
+url="http://${host}:${port}/"
+if [[ -n "$path" ]]; then
+  url="${url}${path#/}"
+fi
+
+echo "$url"

--- a/plugins/tailscale/skills/tailscale-cli/SKILL.md
+++ b/plugins/tailscale/skills/tailscale-cli/SKILL.md
@@ -31,6 +31,12 @@ Symptom of getting this wrong: `sudo tailscale status --json` hangs asking for a
 
 Two different features that look similar but have separate config and status output — a Service's config is invisible to bare `tailscale serve status` (it prints `No serve config` even when fully configured), and a serve command against an undefined Service reports success but does nothing. Full explanation and the fix (`serve status --json`, `.Services`): [references/services.md](references/services.md).
 
+## `serve ... off` removes the whole port's config, not just your mapping
+
+`tailscale serve --https=443 off` (or the bare-port form) tears down **every** path mapping on that port, not just the one you added. Confirmed by running it on a node with two node-level mappings (`/` and `/readme-preview`) to remove only `/`: `serve status --json` came back completely empty afterward, both mappings gone. There's no scoped "remove just this path" for node-level serve — `tailscale serve --set-path=/some/path off` fails outright if that exact path isn't the one currently mapped, and even a successful narrower-looking command can still wipe the shared `:443` config underneath it.
+
+If a node has more than one node-level mapping, or you're not sure whether it does: `tailscale serve status --json` before you touch anything, and after, so you know exactly what existed and can rebuild it (`tailscale serve --bg --set-path=<path> <target>` per mapping) rather than assuming your teardown was scoped to what you added. This matters most on a shared host, or anywhere state might have been added since you last checked — never assume you're the only thing that's touched `serve` on that node.
+
 ## Setting up a brand-new Service
 
 Has a specific required order (define in admin console → `serve --service=` → restart `tailscaled` → approve → validate from a different node) that's easy to get wrong on a first deploy: [references/new-service-setup.md](references/new-service-setup.md).

--- a/plugins/tailscale/skills/tailscale-serve-patterns/SKILL.md
+++ b/plugins/tailscale/skills/tailscale-serve-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tailscale-serve-patterns
-description: Use when deciding how to expose a locally-running server over a tailnet (loopback bind + `tailscale serve` vs. binding directly to the tailnet interface), when a service is reachable at its Tailscale address but a request seems to bypass expected auth, when working with Tailscale identity headers (`Tailscale-User-Login` and friends) for browser auth, or when a "bind is loopback-only" security check doesn't seem to reflect what's actually reachable (Docker port publish, reverse proxy, container networking).
+description: Use when deciding how to expose a locally-running server over a tailnet (loopback bind + `tailscale serve` vs. binding directly to the tailnet interface), when a service is reachable at its Tailscale address but a request seems to bypass expected auth, when working with Tailscale identity headers (`Tailscale-User-Login` and friends) for browser auth, or when a "bind is loopback-only" security check doesn't seem to reflect what's actually reachable (Docker port publish, reverse proxy, container networking). Also use this BEFORE handing the user a `localhost`/`127.0.0.1` URL or a bare port number for anything you just started serving (a quick script, a dev server, a one-off demo, a review page) if there's any chance they'll open it from another device (phone, tablet, another machine) -- check whether Tailscale is available and give them a tailnet URL that actually works from there instead of a URL that only works on the machine you're running on.
 ---
 
 # Tailscale Serve Patterns
@@ -21,6 +21,22 @@ Two ways to make a local service reachable over a tailnet, with very different s
 **Default to loopback + `serve`.** It's the pattern used across this project's homelab services (bind `127.0.0.1:<port>`, expose via host `tailscaled` + Services) and what the `crit` review tool's own auto-mode classifier treats as the expected, low-friction path. Direct tailnet-interface binding is the exception, appropriate for short-lived single-user sessions (e.g. "review this on my phone for the next ten minutes, I'm the only one on this tailnet") — treat it as something that needs an explicit, conscious opt-in (a flag like `--allow-unauthenticated-network`), not a default.
 
 `serve` does not change what the process itself binds to — it's a separate proxy layer. If a server only binds `127.0.0.1`, requests straight to the tailnet hostname's port will fail; you must go through the URL/port `serve` publishes (usually 443), not the app's own port.
+
+## Before handing back a URL for anything you just served
+
+The default habit -- "it's running, here's `http://localhost:8080`" -- is wrong the moment the user wants to open it from their phone, their other laptop, or anywhere that isn't the exact machine the process is bound to. That's an easy thing to forget in the moment because the server *is* working, just only from one place. Before handing back a URL for something you just started serving locally, get in the habit of checking whether a tailnet URL would actually work for the person on the other end, rather than a URL that only resolves on your current machine.
+
+Use the bundled helper instead of re-deriving this by hand (it's easy to get the details wrong -- see the gotchas below):
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/resolve-tailnet-url.sh" <port> [path]
+```
+
+It finds the `tailscale` binary (PATH or the macOS GUI app), confirms Tailscale is actually connected (`BackendState == Running`, not just installed), and prints a ready-to-use `http://<tailnet-host>:<port>/<path>` -- using the node's tailnet IP if the DNS name isn't usable. If Tailscale isn't connected, it exits non-zero and prints nothing to stdout; treat that as your signal to fall back to a plain `localhost` URL and say so, rather than guessing at a tailnet name yourself.
+
+**Reading Tailscale's status needs the sandbox bypass.** `tailscale status --json` talks to `tailscaled` over a local socket that the sandbox blocks by default -- the command will hang or fail silently rather than error clearly. Run the helper (or any `tailscale` command) with `dangerouslyDisableSandbox: true`.
+
+This only tells you the *URL*, not whether the server is reachable there -- if you bound to loopback, you still need `tailscale serve` proxying in front of it (see above) for that URL to actually work from another device.
 
 ## The IPv4/IPv6 loopback trap
 
@@ -51,3 +67,5 @@ A security/doctor check that inspects `gateway.bind` (or equivalent app-level co
 | Assuming a `0.0.0.0`/tailnet-interface bind flag is fine because "only I'm on this tailnet" | True today, but it's an unauthenticated-by-default state with no expiry — treat it as an explicit, temporary opt-in, not a config to leave on |
 | Debugging a `[::1]`-vs-`127.0.0.1` connection failure as a Tailscale problem | Check the actual bound address first; it may have nothing to do with the tailnet at all |
 | Trusting a passing "bind is loopback" doctor/security check as proof of true exposure | It only sees the app's own config, not Docker publish or reverse-proxy layers in front of it |
+| Handing back `http://localhost:<port>` for something the user will open from another device | Only works on the machine the process is running on; resolve the tailnet URL first (see above) |
+| Tearing down your own `serve` mapping with `serve --https=443 off` on a host that might have others | Removes the *entire* port's config, not just yours — see the `tailscale-cli` skill's "`serve ... off` removes the whole port's config" section before cleaning up |


### PR DESCRIPTION
## Summary

- Adds `resolve-tailnet-url.sh`, a helper that resolves a tailnet-reachable URL for a locally served port (handles the GUI-app-not-on-PATH lookup, strips the trailing dot off `Self.DNSName`, checks `BackendState` before promising a URL)
- Broadens `tailscale-serve-patterns` to check for a tailnet URL before handing back a bare `localhost`/port link for anything just served locally
- Adds a `PreToolUse` hook that nudges toward the helper right before `crit:crit` launches, since that's the most common consumer today
- Documents a real gotcha found while testing: `tailscale serve --https=443 off` wipes the entire port's serve config, not just the mapping you meant to remove

## Test plan

- `resolve-tailnet-url.sh` verified live against a real Tailscale connection
- Hook script verified against matching, non-matching, and malformed `PreToolUse` payloads
- Ran a skill-creator eval comparing old vs. new `tailscale-serve-patterns` content on two realistic scenarios (explicit port handoff, subtler cross-device cue) — both versions correctly resolved tailnet URLs once consulted, confirming the fix here is about documentation/consistency and the deterministic crit hook, not a behavior gap in the original content
