### PR TITLE
feat(tailscale): document ACL tagOwners/grants and the silent-drop pattern

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -112,7 +112,7 @@
     {
       "name": "tailscale",
       "source": "./plugins/tailscale",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "description": "Tailscale CLI reference and safe patterns for exposing local services over a tailnet"
     },
     {

--- a/plugins/tailscale/skills/tailscale-cli/SKILL.md
+++ b/plugins/tailscale/skills/tailscale-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tailscale-cli
-description: Use when running `tailscale` commands to debug connectivity, inspect status, or manage `tailscale serve`/`funnel`/Services — especially when `tailscale serve status` looks wrong, `tailscale` isn't found in a shell, `tailscale ping` fails against a host that's clearly up, or you're working across a mix of macOS (GUI app) and Linux (VM/container) nodes in the same tailnet.
+description: Use when running `tailscale` commands to debug connectivity, inspect status, or manage `tailscale serve`/`funnel`/Services — especially when `tailscale serve status` looks wrong, `tailscale` isn't found in a shell, `tailscale ping` fails against a host that's clearly up, you're working across a mix of macOS (GUI app) and Linux (VM/container) nodes in the same tailnet, or a node/sidecar joins fine but something downstream (a grant, an app-level check) crash-loops or silently fails — that's often an ACL/tagOwners issue, not a code bug. Also use for authoring or reading tailnet ACLs (tagOwners, grants, the legacy `acls` array) or querying the live policy via the Tailscale API.
 ---
 
 # Tailscale CLI
@@ -36,6 +36,10 @@ Two different features that look similar but have separate config and status out
 `tailscale serve --https=443 off` (or the bare-port form) tears down **every** path mapping on that port, not just the one you added. Confirmed by running it on a node with two node-level mappings (`/` and `/readme-preview`) to remove only `/`: `serve status --json` came back completely empty afterward, both mappings gone. There's no scoped "remove just this path" for node-level serve — `tailscale serve --set-path=/some/path off` fails outright if that exact path isn't the one currently mapped, and even a successful narrower-looking command can still wipe the shared `:443` config underneath it.
 
 If a node has more than one node-level mapping, or you're not sure whether it does: `tailscale serve status --json` before you touch anything, and after, so you know exactly what existed and can rebuild it (`tailscale serve --bg --set-path=<path> <target>` per mapping) rather than assuming your teardown was scoped to what you added. This matters most on a shared host, or anywhere state might have been added since you last checked — never assume you're the only thing that's touched `serve` on that node.
+
+## ACLs: tagOwners, grants, and the silent-drop pattern
+
+There's no local `tailscale acl` command — the policy file only lives in the admin console or the API. A node can join the tailnet fine while silently losing a requested tag it wasn't authorized for (`tagOwners`), which then breaks something downstream (a grant, an app-level check) without any Tailscale-level error. Recognizing this pattern, tagOwners vs. grants, legacy `acls` vs. current `grants`, and reading the live policy via the API: [references/acls.md](references/acls.md).
 
 ## Setting up a brand-new Service
 

--- a/plugins/tailscale/skills/tailscale-cli/references/acls.md
+++ b/plugins/tailscale/skills/tailscale-cli/references/acls.md
@@ -1,0 +1,71 @@
+# ACLs: tagOwners, grants, and the silent-drop pattern
+
+Tailscale's tailnet-wide access policy (the ACL/policy file) is not visible to any local `tailscale` command — there is no `tailscale acl` subcommand. The only ways to see it are the admin console UI, or the API (see "Reading the live policy" below). `tailscale status`/`serve status` show *this node's* connectivity, not the policy that produced it.
+
+## Recognize this pattern first: the silent tag drop
+
+**Symptom:** a new node or sidecar container comes up, `tailscale status` shows it connected and healthy, but the application on top of it crash-loops on a backoff with a vague/generic error — not a clear `403` or "permission denied." The same setup steps worked for an existing, similar-looking node. The fix turns out to be an ACL change in the admin console, not a code or config bug.
+
+**Why this happens:** `tailscale up --advertise-tags=tag:foo` (or an authkey pre-loaded with tags) doesn't hard-fail when the requesting identity isn't authorized to apply `tag:foo`. The coordination server just **strips the unauthorized tag** and lets the node join anyway, untagged. `tailscale status` reports a perfectly healthy connection because, from Tailscale's point of view, nothing went wrong — the node joined the tailnet fine. But anything downstream that gated a capability, grant, or app-level check on that tag now sees a node without it, and that failure surfaces one layer up: in the *application*, not in Tailscale.
+
+This is why it looks like a networking bug (crash-loop, retries, backoff) when the actual cause is an authorization gap in `tagOwners` for that specific identity/authkey.
+
+**Fix:** in the admin console (or via a policy edit), add the requesting identity to `tagOwners` for that tag — see syntax below. Then re-issue the node's auth (re-run `tailscale up` with the tag, or mint a fresh authkey with the tag baked in); a node that joined untagged doesn't retroactively pick up the tag on its own.
+
+## Where tags and access are declared
+
+Two different sections in the policy file, easy to conflate:
+
+```json
+{
+  "tagOwners": {
+    "tag:sidecar": ["autogroup:admin"]
+  },
+  "grants": [
+    {"src": ["tag:bridge"], "dst": ["tag:sidecar:443"], "ip": ["tcp:443"]}
+  ]
+}
+```
+
+- **`tagOwners`** — who/what is allowed to *apply* a given tag to a device. This is the authorization the silent-drop pattern above trips over. If a key or user isn't listed here for `tag:foo`, they can request the tag but won't get it.
+- **`grants`** (or the older `acls` array — see next section) — once a device *has* a tag, what it's allowed to talk to. This is ordinary network-reachability policy, and failures here look different: an actual connection refusal/timeout at the network layer, not a silent no-op.
+
+Don't debug a connectivity symptom by only checking `grants`. If the destination side never got the tag it was supposed to have, the grant that references that tag is irrelevant — the real gap is one layer up, in `tagOwners`.
+
+## `acls` (legacy) and `grants` (current) can coexist
+
+Older policy files use an `acls` array (`{"action": "accept", "src": [...], "dst": [...]}`); newer ones use `grants`. **Both can be present in the same policy file at once** — Tailscale hasn't forced a migration. If you're reading a policy to understand what's allowed, check both arrays, not just whichever one you expected to find. A restriction enforced by a legacy `acls` rule is easy to miss if you only look at `grants`, and vice versa.
+
+Also watch for a default-allow wildcard grant sitting alongside more specific rules:
+
+```json
+{"src": ["*"], "dst": ["*"], "ip": ["*"]}
+```
+
+This is Tailscale's out-of-the-box default and is easy to leave in place indefinitely — it makes every other grant in the file effectively decorative for network reachability (everything can already reach everything). If a tailnet has this wildcard, don't reason about access from the specific grants alone; check whether the wildcard is still active first, since it silently supersedes them.
+
+## Reading the live policy
+
+There's no local CLI equivalent; querying the policy programmatically means the Tailscale API. Once an OAuth client with the **Policy File → Read** scope exists (client ID/secret from Settings → OAuth clients in the admin console):
+
+```bash
+# Exchange client credentials for a short-lived (1hr) access token
+TOKEN=$(curl -s -d "client_id=$TAILSCALE_OAUTH_CLIENT_ID" \
+  -d "client_secret=$TAILSCALE_OAUTH_CLIENT_SECRET" \
+  "https://api.tailscale.com/api/v2/oauth/token" | jq -r .access_token)
+
+# Fetch the policy file (HuJSON)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.tailscale.com/api/v2/tailnet/-/acl"
+```
+
+`tailnet/-/acl` uses `-` for "the tailnet this credential belongs to" — no need to look up the tailnet name separately.
+
+## Sidecar-container pattern
+
+The silent-drop failure above is especially common for sidecar containers (a helper container joining the same tailnet as a main service) because sidecars are often brought up with a shared or templated authkey that wasn't updated when a new tag was introduced. Checklist when a new sidecar crash-loops after joining its tailnet fine:
+
+1. `tailscale status --json` on the sidecar — does `.Self.Tags` actually include the tag you expect? If it's empty or missing the expected tag, that's the silent drop, not a bug in the sidecar itself.
+2. If the tag is missing: check `tagOwners` in the policy for that tag — is the authkey/identity the sidecar used actually listed as an owner?
+3. Fix `tagOwners`, then re-auth the sidecar (new authkey or re-run `tailscale up --advertise-tags=...`) — an already-joined, untagged node won't retroactively gain the tag.
+4. Only after confirming the tag is actually present: if it's still failing, that's now a `grants`/`acls` reachability problem, not a tagging problem — check both arrays per the section above.


### PR DESCRIPTION
## Summary

- Adds `references/acls.md` to the `tailscale-cli` skill, covering `tagOwners` vs `grants`, the legacy `acls` array coexisting with `grants`, and how to read the live policy via the Tailscale API.
- Documents the "silent tag drop" pattern: a node or sidecar joins the tailnet fine but loses an unauthorized tag silently, which then surfaces as a downstream app crash-loop instead of a Tailscale-level error. This is grounded in real incidents, not generic ACL docs.
- Broadens the skill's trigger description so ACL-shaped questions (a sidecar crash-looping after joining fine, authoring tagOwners/grants) actually surface this skill.

## Test plan

- Read through `references/acls.md` for accuracy against a real pulled ACL policy (via the Tailscale OAuth API) and against three real incidents that hit this exact failure mode.
